### PR TITLE
feat: output the detail error log about the detection of unarciver and decompressor

### DIFF
--- a/pkg/controller/unarchive.go
+++ b/pkg/controller/unarchive.go
@@ -35,6 +35,11 @@ func unarchive(body io.Reader, filename, typ, dest string) error { //nolint:cycl
 	}
 	arc, err := getUnarchiver(filename, typ)
 	if err != nil {
+		logrus.WithFields(logrus.Fields{
+			"archive_type":           typ,
+			"filename":               filename,
+			"filepath.Ext(filename)": filepath.Ext(filename),
+		}).Error("get the unarchiver or decompressor")
 		return fmt.Errorf("get the unarchiver or decompressor by the file extension: %w", err)
 	}
 


### PR DESCRIPTION
e.g.

```
ERRO[0001] get the unarchiver or decompressor            archive_type= filename=shfmt_v3.3.1_darwin_amd64 filepath.Ext(filename)=.1_darwin_amd64
```