### PR TITLE
feat: add lazy install option to package config

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -16,10 +16,11 @@ import (
 )
 
 type Package struct {
-	Name     string `validate:"required"`
-	Registry string `validate:"required" yaml:",omitempty"`
-	Version  string `validate:"required" yaml:",omitempty"`
-	Import   string `yaml:",omitempty"`
+	Name        string `validate:"required"`
+	Registry    string `validate:"required" yaml:",omitempty"`
+	Version     string `validate:"required" yaml:",omitempty"`
+	Import      string `yaml:",omitempty"`
+	LazyInstall bool   `yaml:"lazy,omitempty"`
 }
 
 func (pkg *Package) UnmarshalYAML(unmarshal func(interface{}) error) error {


### PR DESCRIPTION
If we want to install some applications normally and the others applications lazily, we must manage two configurations and run a shell script like the following:

````
$ aqua --config=/path/to/aqua.yaml install
$ aqua --config=/path/to/aqua-lazy.yaml install -l
````

And we need to export AQUA_GLOBAL_CONFIG to refer two config files.

```
export AQUA_GLOBAL_CONFIG=/path/to/aqua.yaml:/path/to/aqua-lazy.yaml
````

This configuration and script is a bit ugly. In order to be able to manage the installation all together in one configuration, I would like to add the following lazy install option.

```
packages:
- name: golang/go
  version: "1.16
  lazy: true
``` 

If `lazy: true` is set in a package as above, `aqua install` only creates links and doesn't download, even if no `-l` option.