### PR TITLE
feat: add the field `rosetta2` to support Rosetta 2 easily

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -111,13 +111,21 @@ type File struct {
 	Src  *Template
 }
 
+func getArch(rosetta2 bool, replacements map[string]string) string {
+	if rosetta2 && runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
+		// Rosetta 2
+		return replace("amd64", replacements)
+	}
+	return replace(runtime.GOARCH, replacements)
+}
+
 func (file *File) RenderSrc(pkg *Package, pkgInfo *MergedPackageInfo) (string, error) {
 	return file.Src.Execute(map[string]interface{}{
 		"Version":  pkg.Version,
 		"GOOS":     runtime.GOOS,
 		"GOARCH":   runtime.GOARCH,
 		"OS":       replace(runtime.GOOS, pkgInfo.GetReplacements()),
-		"Arch":     replace(runtime.GOARCH, pkgInfo.GetReplacements()),
+		"Arch":     getArch(pkgInfo.Rosetta2, pkgInfo.GetReplacements()),
 		"Format":   pkgInfo.GetFormat(),
 		"FileName": file.Name,
 	})

--- a/pkg/controller/package_info.go
+++ b/pkg/controller/package_info.go
@@ -24,6 +24,7 @@ type MergedPackageInfo struct {
 	VersionConstraints *VersionConstraints  `yaml:"version_constraint"`
 	VersionOverrides   []*MergedPackageInfo `yaml:"version_overrides"`
 	SupportedIf        *PackageCondition    `yaml:"supported_if"`
+	Rosetta2           bool
 }
 
 func (pkgInfo *MergedPackageInfo) HasRepo() bool {
@@ -172,7 +173,7 @@ func (pkgInfo *MergedPackageInfo) GetPkgPath(rootDir string, pkg *Package) (stri
 			"GOOS":    runtime.GOOS,
 			"GOARCH":  runtime.GOARCH,
 			"OS":      replace(runtime.GOOS, pkgInfo.GetReplacements()),
-			"Arch":    replace(runtime.GOARCH, pkgInfo.GetReplacements()),
+			"Arch":    getArch(pkgInfo.Rosetta2, pkgInfo.GetReplacements()),
 			"Format":  pkgInfo.GetFormat(),
 		})
 		if err != nil {
@@ -197,7 +198,7 @@ func (pkgInfo *MergedPackageInfo) RenderAsset(pkg *Package) (string, error) {
 			"GOOS":    runtime.GOOS,
 			"GOARCH":  runtime.GOARCH,
 			"OS":      replace(runtime.GOOS, pkgInfo.GetReplacements()),
-			"Arch":    replace(runtime.GOARCH, pkgInfo.GetReplacements()),
+			"Arch":    getArch(pkgInfo.Rosetta2, pkgInfo.GetReplacements()),
 			"Format":  pkgInfo.GetFormat(),
 		})
 	case pkgInfoTypeGitHubRelease:
@@ -206,7 +207,7 @@ func (pkgInfo *MergedPackageInfo) RenderAsset(pkg *Package) (string, error) {
 			"GOOS":    runtime.GOOS,
 			"GOARCH":  runtime.GOARCH,
 			"OS":      replace(runtime.GOOS, pkgInfo.GetReplacements()),
-			"Arch":    replace(runtime.GOARCH, pkgInfo.GetReplacements()),
+			"Arch":    getArch(pkgInfo.Rosetta2, pkgInfo.GetReplacements()),
 			"Format":  pkgInfo.GetFormat(),
 		})
 	case pkgInfoTypeHTTP:
@@ -229,7 +230,7 @@ func (pkgInfo *MergedPackageInfo) renderURL(pkg *Package) (string, error) {
 		"GOOS":    runtime.GOOS,
 		"GOARCH":  runtime.GOARCH,
 		"OS":      replace(runtime.GOOS, pkgInfo.GetReplacements()),
-		"Arch":    replace(runtime.GOARCH, pkgInfo.GetReplacements()),
+		"Arch":    getArch(pkgInfo.Rosetta2, pkgInfo.GetReplacements()),
 		"Format":  pkgInfo.GetFormat(),
 	})
 	if err != nil {


### PR DESCRIPTION
Close #442