### PR TITLE
feat: add command names in the result of `aqua g`

### DIFF
--- a/pkg/controller/generate.go
+++ b/pkg/controller/generate.go
@@ -20,7 +20,7 @@ type FindingPackage struct {
 	RegistryName string
 }
 
-func (ctrl *Controller) Generate(ctx context.Context, param *Param) error { //nolint:cyclop
+func (ctrl *Controller) Generate(ctx context.Context, param *Param) error { //nolint:cyclop,funlen
 	wd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("get the current directory: %w", err)
@@ -56,7 +56,17 @@ func (ctrl *Controller) Generate(ctx context.Context, param *Param) error { //no
 	}
 	idx, err := fuzzyfinder.Find(pkgs, func(i int) string {
 		pkg := pkgs[i]
-		return fmt.Sprintf("%s (%s)", pkg.PackageInfo.GetName(), pkg.RegistryName)
+		files := pkg.PackageInfo.GetFiles()
+		fileNames := make([]string, len(files))
+		for i, file := range files {
+			fileNames[i] = file.Name
+		}
+		fileNamesStr := strings.Join(fileNames, ", ")
+		pkgName := pkg.PackageInfo.GetName()
+		if strings.HasSuffix(pkgName, "/"+fileNamesStr) || pkgName == fileNamesStr {
+			return fmt.Sprintf("%s (%s)", pkgName, pkg.RegistryName)
+		}
+		return fmt.Sprintf("%s (%s) (%s)", pkgName, pkg.RegistryName, fileNamesStr)
 	},
 		fuzzyfinder.WithPreviewWindow(func(i, w, h int) string {
 			if i < 0 {


### PR DESCRIPTION
## Problem to solve

Sometimes installed command names aren't included in the package name, so you can't search package with the command name.
And you can't know what commands are installed by the package.

## How to solve

Add command names in the result of `aqua g`.

e.g.

```
  aquasecurity/starboard (standard) (starboard, kubectl-starboard)           ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
  int128/kauthproxy (standard) (kauthproxy, kubectl-auth_proxy)              │  kubernetes/kubectl
  aquasecurity/kubectl-who-can (standard) (kubectl-who_can)                  │
  argoproj/argo-rollouts (standard) (kubectl-argo-rollouts)                  │  https://kubernetes.io/docs/reference/kubectl/overview/
  corneliusweig/ketall (standard) (ketall, kubectl-get_all)                  │  The kubectl command line tool lets you control Kubernetes clusters
  kvaps/kubectl-node-shell (standard) (kubectl-node_shell)                   │
  oam-dev/kubevela/kubectl-plugin (standard) (kubectl-vela)                  │
  crossplane/crossplane (standard) (kubectl-crossplane)                      │
  replicatedhq/outdated (standard) (kubectl-outdated)                        │
  int128/kubelogin (standard) (kubectl-oidc_login)                           │
  kudobuilder/kuttl (standard) (kubectl-kuttl)                               │
  kubemq-io/kubemqctl (standard)                                             │
  postfinance/kubectl-sudo (standard)                                        │
  emirozer/kubectl-doctor (standard)                                         │
  Ladicle/kubectl-rolesum (standard)                                         │
  ernoaapa/kubectl-warp (standard)                                           │
  iovisor/kubectl-trace (standard)                                           │
  ahmetb/kubectl-tree (standard)                                             │
> kubernetes/kubectl (standard)                                              │
  24/344                                                                     │
> kubectl                                                                    └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
```