### PR TITLE
feat: support omitting the registry name

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -22,7 +22,7 @@ jobs:
     - run: echo "$HOME/.aqua/bin" >> $GITHUB_PATH
     - run: echo "AQUA_GLOBAL_CONFIG=$PWD/tests/aqua-global.yaml:$PWD/tests/aqua-global-2.yaml" >> $GITHUB_ENV
     - run: echo "standard,kubernetes-sigs/kind" | aqua g -f -
-    - run: echo "standard,x-motemen/ghq" | aqua g -f -
+    - run: echo "x-motemen/ghq" | aqua g -f -
     - run: echo "inline,aquaproj/aqua-installer" | aqua -c tests/aqua-global.yaml g -f -
 
     - run: aqua list

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -195,6 +195,10 @@ $ cat packages.txt | aqua g -f -
 - name: junegunn/fzf@0.28.0
 - name: tfmigrator/cli@v0.2.1
 
+You can omit the registry name if it is "standard".
+
+echo "cli/cli" | aqua g -f -
+
 $ aqua list | aqua g -f - # Generate configuration to install all packages`,
 				Action: runner.generateAction,
 				Flags: []cli.Flag{

--- a/pkg/controller/generate.go
+++ b/pkg/controller/generate.go
@@ -137,6 +137,9 @@ func (ctrl *Controller) outputListedPkgs(ctx context.Context, param *Param, regi
 	outputPkgs := []*Package{}
 	for scanner.Scan() {
 		txt := scanner.Text()
+		if !strings.Contains(txt, ",") {
+			txt = "standard," + txt
+		}
 		findingPkg, ok := m[txt]
 		if !ok {
 			return logerr.WithFields(errUnknownPkg, logrus.Fields{"package_name": txt}) //nolint:wrapcheck


### PR DESCRIPTION
When you pass the list of packages to `aqua g`, you can omit the registry name if the registry name is `standard`.

## AS IS

```console
$ echo "suzuki-shunsuke/tfcmt" | aqua g -f -
FATA[0000] aqua failed                                   aqua_version=0.8.7 error="unknown package" package_name=suzuki-shunsuke/tfcmt program=aqua

$ echo "standard,suzuki-shunsuke/tfcmt" | aqua g -f -
- name: suzuki-shunsuke/tfcmt@v3.0.0
```

## TO BE

```console
$ echo "suzuki-shunsuke/tfcmt" | aqua g -f -
- name: suzuki-shunsuke/tfcmt@v3.0.0

$ echo "standard,suzuki-shunsuke/tfcmt" | aqua g -f -
- name: suzuki-shunsuke/tfcmt@v3.0.0
```
