### PR TITLE
feat: support passing packages with `aqua g`'s arguments

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -24,6 +24,8 @@ jobs:
     - run: echo "standard,kubernetes-sigs/kind" | aqua g -f -
     - run: echo "x-motemen/ghq" | aqua g -f -
     - run: echo "inline,aquaproj/aqua-installer" | aqua -c tests/aqua-global.yaml g -f -
+    - run: aqua g x-motemen/ghq aquaproj/aqua-installer
+    - run: echo cli/cli | aqua g -f - x-motemen/ghq aquaproj/aqua-installer
 
     - run: aqua list
     - run: aqua i -l -a

--- a/pkg/cli/generate.go
+++ b/pkg/cli/generate.go
@@ -18,5 +18,5 @@ func (runner *Runner) generateAction(c *cli.Context) error {
 		return fmt.Errorf("initialize a controller: %w", err)
 	}
 
-	return ctrl.Generate(c.Context, param) //nolint:wrapcheck
+	return ctrl.Generate(c.Context, param, c.Args().Slice()...) //nolint:wrapcheck
 }

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -143,11 +143,13 @@ FATA[0000] aqua failed                                   aqua_version=0.8.6 erro
 				Action: runner.whichAction,
 			},
 			{
-				Name:    "generate",
-				Aliases: []string{"g"},
-				Usage:   "Search packages in registries and output the configuration interactively",
+				Name:      "generate",
+				Aliases:   []string{"g"},
+				Usage:     "Search packages in registries and output the configuration interactively",
+				ArgsUsage: `[<registry name>,<package name> ...]`,
 				Description: `Search packages in registries and output the configuration interactively.
-Interactive fuzzy finder is launched.
+
+If no argument is passed, interactive fuzzy finder is launched.
 
 $ aqua g
 
@@ -183,7 +185,20 @@ You can update the configuration file directly by "aqua g >> <configuration file
 
 $ aqua g >> aqua.yaml
 
-With "-f" option, you can pass packages without interactive UI.
+You can pass packages with positional arguments.
+
+$ aqua g [<registry name>,<package name> ...]
+
+$ aqua g standard,cli/cli standard,junegunn/fzf
+- name: cli/cli@v2.2.0
+- name: junegunn/fzf@0.28.0
+
+You can omit the registry name if it is "standard".
+
+$ aqua g cli/cli
+- name: cli/cli@v2.2.0
+
+With "-f" option, you can pass packages.
 
 $ aqua g -f packages.txt # list of <registry name>,<package name>
 - name: cli/cli@v2.2.0
@@ -195,11 +210,12 @@ $ cat packages.txt | aqua g -f -
 - name: junegunn/fzf@0.28.0
 - name: tfmigrator/cli@v0.2.1
 
+$ aqua list | aqua g -f - # Generate configuration to install all packages
+
 You can omit the registry name if it is "standard".
 
 echo "cli/cli" | aqua g -f -
-
-$ aqua list | aqua g -f - # Generate configuration to install all packages`,
+- name: cli/cli@v2.2.0`,
 				Action: runner.generateAction,
 				Flags: []cli.Flag{
 					&cli.StringFlag{


### PR DESCRIPTION
Close #484

You can pass packages with positional arguments.

```console
$ aqua g [<registry name>,<package name> ...]
```

```console
$ aqua g standard,cli/cli standard,junegunn/fzf
- name: cli/cli@v2.2.0
- name: junegunn/fzf@0.28.0
```

You can omit the registry name if it is "standard".

```console
$ aqua g cli/cli
- name: cli/cli@v2.2.0
```