### PR TITLE
fix: allow to install same pair of the registry name and package name

### DIFF
--- a/pkg/controller/error.go
+++ b/pkg/controller/error.go
@@ -4,7 +4,6 @@ import "errors"
 
 var (
 	errPkgNameMustBeUniqueInRegistry      = errors.New("the package name must be unique in the same registry")
-	errPairPkgNameAndRegistryMustBeUnique = errors.New("the pair of package name and registry must be unique")
 	errInvalidType                        = errors.New("type is invalid")
 	errConfigFileNotFound                 = errors.New("configuration file isn't found")
 	errUnknownPkg                         = errors.New("unknown package")

--- a/pkg/controller/validate.go
+++ b/pkg/controller/validate.go
@@ -47,17 +47,6 @@ func validateConfig(cfg *Config) error {
 }
 
 func validatePackages(pkgs []*Package) error {
-	names := map[string]struct{}{}
-	for _, pkg := range pkgs {
-		key := pkg.Registry + " " + pkg.Name
-		if _, ok := names[key]; ok {
-			return logerr.WithFields(errPairPkgNameAndRegistryMustBeUnique, logrus.Fields{ //nolint:wrapcheck
-				"package_name":  pkg.Name,
-				"retistry_name": pkg.Registry,
-			})
-		}
-		names[key] = struct{}{}
-	}
 	return nil
 }
 

--- a/pkg/controller/validate_internal_test.go
+++ b/pkg/controller/validate_internal_test.go
@@ -138,7 +138,7 @@ func Test_validatePackages(t *testing.T) {
 					Registry: "standard",
 				},
 			},
-			isErr: true,
+			isErr: false,
 		},
 	}
 	for _, d := range data {
@@ -147,9 +147,7 @@ func Test_validatePackages(t *testing.T) {
 			t.Parallel()
 			err := validatePackages(d.pkgs)
 			if d.isErr {
-				if !errors.Is(err, errPairPkgNameAndRegistryMustBeUnique) {
-					t.Fatal(err)
-				}
+				t.Fatal(err)
 				return
 			}
 			if err != nil {


### PR DESCRIPTION
## Problem to solve

In aqua.yaml, when the pair of the registry and package is duplicated, aqua fails to read the configuration.

```yaml
registries:
- type: standard
  ref: v0.12.2 # renovate: depName=aquaproj/aqua-registry

packages:
- name: suzuki-shunsuke/tfcmt@v3.0.0
- name: suzuki-shunsuke/tfcmt@v2.0.0
```

```
$ aqua i
FATA[0000] aqua failed                                   aqua_version=0.8.8 error="configuration is invalid: the pair of package name and registry must be unique" package_name=suzuki-shunsuke/tfcmt program=aqua retistry_name=standard
```