### PR TITLE
feat: output with short syntax if package name starts with `<repository full name>/"

### DIFF
--- a/pkg/controller/generate.go
+++ b/pkg/controller/generate.go
@@ -180,7 +180,7 @@ func (ctrl *Controller) getOutputtedGitHubPkg(ctx context.Context, outputPkg *Pa
 		}).Warn("get the latest release")
 		return
 	}
-	if pkgName == repoOwner+"/"+repoName {
+	if pkgName == repoOwner+"/"+repoName || strings.HasPrefix(pkgName, repoOwner+"/"+repoName+"/") {
 		outputPkg.Name += "@" + release.GetTagName()
 		outputPkg.Version = ""
 	} else {


### PR DESCRIPTION
https://github.com/aquaproj/aqua-renovate-config/releases/tag/0.1.3

AS IS

```console
$ aqua g istio/istio/istioctl
- name: istio/istio/istioctl
  version: 1.12.1
```

TO BE

```console
$ aqua g istio/istio/istioctl
- name: istio/istio/istioctl@1.12.1
```