### PR TITLE
feat: support getting the version of `http` package in `aqua g`

### DIFF
--- a/pkg/controller/package_info.go
+++ b/pkg/controller/package_info.go
@@ -32,11 +32,7 @@ func (pkgInfo *MergedPackageInfo) GetRosetta2() bool {
 }
 
 func (pkgInfo *MergedPackageInfo) HasRepo() bool {
-	switch pkgInfo.Type {
-	case pkgInfoTypeGitHubRelease, pkgInfoTypeGitHubArchive, pkgInfoTypeGitHubContent:
-		return true
-	}
-	return false
+	return pkgInfo.RepoOwner != "" && pkgInfo.RepoName != ""
 }
 
 func (pkgInfo *MergedPackageInfo) GetName() string {

--- a/pkg/controller/package_info_test.go
+++ b/pkg/controller/package_info_test.go
@@ -240,8 +240,9 @@ func TestMergedPackageInfo_GetFiles(t *testing.T) {
 				},
 			},
 			pkgInfo: &controller.MergedPackageInfo{
-				Type:     "github_release",
-				RepoName: "ci-info",
+				Type:      "github_release",
+				RepoOwner: "suzuki-shunsuke",
+				RepoName:  "ci-info",
 			},
 		},
 	}


### PR DESCRIPTION
## AS IS

```console
$ aqua g hashicorp/terraform
- name: hashicorp/terraform
  version: '[SET PACKAGE VERSION]'
```

## TO BE

```console
$ aqua g hashicorp/terraform
- name: hashicorp/terraform@v1.1.2
```