### PR TITLE
feat: support XDG Base Directory by default

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -19,7 +19,7 @@ jobs:
         go-version: '1.17.5'
 
     - run: go build -o /usr/local/bin/aqua ./cmd/aqua
-    - run: echo "$HOME/.aqua/bin" >> "$GITHUB_PATH"
+    - run: echo "${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua/bin" >> "$GITHUB_PATH"
     - run: echo "AQUA_GLOBAL_CONFIG=$PWD/tests/aqua-global.yaml:$PWD/tests/aqua-global-2.yaml" >> "$GITHUB_ENV"
     - run: echo "standard,kubernetes-sigs/kind" | aqua g -f -
     - run: echo "x-motemen/ghq" | aqua g -f -

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
         go-version: '1.17.5'
 
     - run: go build -o /usr/local/bin/aqua ./cmd/aqua
-    - run: echo "$HOME/.aqua/bin" >> "$GITHUB_PATH"
+    - run: echo "${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua/bin" >> "$GITHUB_PATH"
     - run: aqua i
 
     - uses: suzuki-shunsuke/github-action-golangci-lint@v0.1.1

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -209,7 +209,7 @@ func (finder *configFinder) Finds(wd string) []string {
 
 func (finder *configFinder) FindGlobal(rootDir string) string {
 	for _, file := range []string{"aqua.yaml", "aqua.yml", ".aqua.yaml", ".aqua.yml"} {
-		cfgFilePath := filepath.Join(rootDir, "global", file)
+		cfgFilePath := filepath.Join(rootDir, file)
 		if _, err := os.Stat(cfgFilePath); err == nil {
 			return cfgFilePath
 		}

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -194,7 +194,6 @@ func (ctrl *Controller) readConfig(configFilePath string, cfg *Config) error {
 type ConfigFinder interface {
 	Find(wd string) string
 	Finds(wd string) []string
-	FindGlobal(rootDir string) string
 }
 
 type configFinder struct{}
@@ -205,16 +204,6 @@ func (finder *configFinder) Find(wd string) string {
 
 func (finder *configFinder) Finds(wd string) []string {
 	return findconfig.Finds(wd, findconfig.Exist, "aqua.yaml", "aqua.yml", ".aqua.yaml", ".aqua.yml")
-}
-
-func (finder *configFinder) FindGlobal(rootDir string) string {
-	for _, file := range []string{"aqua.yaml", "aqua.yml", ".aqua.yaml", ".aqua.yml"} {
-		cfgFilePath := filepath.Join(rootDir, file)
-		if _, err := os.Stat(cfgFilePath); err == nil {
-			return cfgFilePath
-		}
-	}
-	return ""
 }
 
 type ConfigReader interface {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -22,6 +22,7 @@ type Controller struct {
 	GitHubRepositoryService GitHubRepositoryService
 	PackageDownloader       PackageDownloader
 	RootDir                 string
+	GlobalConfingDir        string
 	Version                 string
 }
 
@@ -75,8 +76,18 @@ func New(ctx context.Context, param *Param) (*Controller, error) {
 		Version:      param.AQUAVersion,
 	}
 	if ctrl.RootDir == "" {
-		ctrl.RootDir = filepath.Join(os.Getenv("HOME"), ".aqua")
+		xdgDataHome := os.Getenv("XDG_DATA_HOME")
+		if xdgDataHome == "" {
+			xdgDataHome = filepath.Join(os.Getenv("HOME"), ".local", "share")
+		}
+		ctrl.RootDir = filepath.Join(xdgDataHome, "aquaproj-aqua")
 	}
+	xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
+	if xdgConfigHome == "" {
+		xdgConfigHome = filepath.Join(os.Getenv("HOME"), ".config")
+	}
+	ctrl.GlobalConfingDir = filepath.Join(xdgConfigHome, "aquaproj-aqua")
+
 	ctrl.GitHubRepositoryService = github.NewClient(getHTTPClientForGitHub(ctx, getGitHubToken())).Repositories
 	ctrl.PackageDownloader = &pkgDownloader{
 		GitHubRepositoryService: ctrl.GitHubRepositoryService,

--- a/pkg/controller/install.go
+++ b/pkg/controller/install.go
@@ -49,13 +49,6 @@ func (ctrl *Controller) installAll(ctx context.Context, rootBin string, param *P
 			return err
 		}
 	}
-	cfgFilePath := ctrl.ConfigFinder.FindGlobal(ctrl.GlobalConfingDir)
-	if _, err := os.Stat(cfgFilePath); err != nil {
-		return nil //nolint:nilerr
-	}
-	if err := ctrl.install(ctx, rootBin, cfgFilePath, param); err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/pkg/controller/install.go
+++ b/pkg/controller/install.go
@@ -49,7 +49,7 @@ func (ctrl *Controller) installAll(ctx context.Context, rootBin string, param *P
 			return err
 		}
 	}
-	cfgFilePath := ctrl.ConfigFinder.FindGlobal(ctrl.RootDir)
+	cfgFilePath := ctrl.ConfigFinder.FindGlobal(ctrl.GlobalConfingDir)
 	if _, err := os.Stat(cfgFilePath); err != nil {
 		return nil //nolint:nilerr
 	}

--- a/pkg/controller/which.go
+++ b/pkg/controller/which.go
@@ -59,7 +59,7 @@ func (ctrl *Controller) which(ctx context.Context, param *Param, exeName string)
 		}
 	}
 
-	cfgFilePath := ctrl.ConfigFinder.FindGlobal(ctrl.RootDir)
+	cfgFilePath := ctrl.ConfigFinder.FindGlobal(ctrl.GlobalConfingDir)
 	if _, err := os.Stat(cfgFilePath); err != nil {
 		exePath := lookPath(exeName)
 		if exePath == "" {

--- a/pkg/controller/which.go
+++ b/pkg/controller/which.go
@@ -26,7 +26,7 @@ type Which struct {
 	ExePath string
 }
 
-func (ctrl *Controller) which(ctx context.Context, param *Param, exeName string) (*Which, error) { //nolint:cyclop,funlen
+func (ctrl *Controller) which(ctx context.Context, param *Param, exeName string) (*Which, error) {
 	fields := logrus.Fields{
 		"exe_name": exeName,
 	}
@@ -59,36 +59,15 @@ func (ctrl *Controller) which(ctx context.Context, param *Param, exeName string)
 		}
 	}
 
-	cfgFilePath := ctrl.ConfigFinder.FindGlobal(ctrl.GlobalConfingDir)
-	if _, err := os.Stat(cfgFilePath); err != nil {
-		exePath := lookPath(exeName)
-		if exePath == "" {
-			return nil, logerr.WithFields(errCommandIsNotFound, logrus.Fields{ //nolint:wrapcheck
-				"exe_name": exeName,
-			})
-		}
-		return &Which{
-			ExePath: exePath,
-		}, nil
+	exePath := lookPath(exeName)
+	if exePath == "" {
+		return nil, logerr.WithFields(errCommandIsNotFound, logrus.Fields{ //nolint:wrapcheck
+			"exe_name": exeName,
+		})
 	}
-
-	pkg, pkgInfo, file, err := ctrl.findExecFile(ctx, cfgFilePath, exeName)
-	if err != nil {
-		return nil, err
-	}
-	if pkg == nil {
-		exePath := lookPath(exeName)
-		if exePath == "" {
-			return nil, logerr.WithFields(errCommandIsNotFound, logrus.Fields{ //nolint:wrapcheck
-				"exe_name": exeName,
-			})
-		}
-		return &Which{
-			ExePath: exePath,
-		}, nil
-	}
-
-	return ctrl.whichFile(pkg, pkgInfo, file)
+	return &Which{
+		ExePath: exePath,
+	}, nil
 }
 
 func (ctrl *Controller) whichFile(pkg *Package, pkgInfo *PackageInfo, file *File) (*Which, error) {


### PR DESCRIPTION
## ⚠️ Breaking Changes

* File paths are changed
* Default Global Configuration `$AQUA_ROOT_DIR/global` is removed. If you use Global Configuration, please set `$AQUA_GLOBAL_CONFIG`.

### File paths are changed

Note that Global Configuration file is optional.

#### AS IS

* aqua installs tools in `$AQUA_ROOT_DIR`
* You have to add `${AQUA_ROOT_DIR}/bin` to `$PATH`
* Global Configuration file is located at `${AQUA_ROOT_DIR}/global`
* Default value of `$AQUA_ROOT_DIR` is `$HOME/.aqua`

#### TO BE

* aqua installs tools in `$AQUA_ROOT_DIR`: No change
* You have to add `${AQUA_ROOT_DIR}/bin` to `$PATH`: No change
* Default Global Configuration file is removed
* Default value of `$AQUA_ROOT_DIR` is `${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua`