### PR TITLE
fix: fix `aqua g -i`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,3 +16,4 @@ linters:
   - exhaustivestruct # https://github.com/mbilski/exhaustivestruct
   - ireturn
   - varnamelen
+  - exhaustive

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -4,7 +4,6 @@
 registries:
 - type: standard
   ref: v1.4.0 # renovate: depName=aquaproj/aqua-registry
-
 packages:
 - name: suzuki-shunsuke/cmdx@v1.6.1
 - name: golangci/golangci-lint@v1.43.0

--- a/pkg/controller/generate_insert.go
+++ b/pkg/controller/generate_insert.go
@@ -1,11 +1,14 @@
 package controller
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
 	"github.com/goccy/go-yaml"
+	"github.com/goccy/go-yaml/ast"
 	"github.com/goccy/go-yaml/parser"
+	"github.com/goccy/go-yaml/printer"
 )
 
 func (ctrl *Controller) generateInsert(cfgFilePath string, pkgs interface{}) error {
@@ -13,6 +16,23 @@ func (ctrl *Controller) generateInsert(cfgFilePath string, pkgs interface{}) err
 	if err != nil {
 		return fmt.Errorf("parse configuration file as YAML: %w", err)
 	}
+
+	if err := ctrl.updateASTFile(file, pkgs); err != nil {
+		return err
+	}
+
+	stat, err := os.Stat(cfgFilePath)
+	if err != nil {
+		return fmt.Errorf("get configuration file stat: %w", err)
+	}
+	var p printer.Printer
+	if err := os.WriteFile(cfgFilePath, p.PrintNode(file.Docs[0]), stat.Mode()); err != nil {
+		return fmt.Errorf("write the configuration file: %w", err)
+	}
+	return nil
+}
+
+func (ctrl *Controller) updateASTFile(file *ast.File, pkgs interface{}) error {
 	node, err := yaml.ValueToNode(pkgs)
 	if err != nil {
 		return fmt.Errorf("convert packages to node: %w", err)
@@ -21,16 +41,25 @@ func (ctrl *Controller) generateInsert(cfgFilePath string, pkgs interface{}) err
 	if err != nil {
 		return fmt.Errorf("build a YAML Path: %w", err)
 	}
-	if err := path.MergeFromNode(file, node); err != nil {
-		return fmt.Errorf("add packages to AST: %w", err)
-	}
-
-	stat, err := os.Stat(cfgFilePath)
+	base, err := path.FilterFile(file)
 	if err != nil {
-		return fmt.Errorf("get configuration file stat: %w", err)
+		if errors.Is(err, yaml.ErrNotFoundNode) {
+			if err := path.ReplaceWithNode(file, node); err != nil {
+				return fmt.Errorf("replace node: %w", err)
+			}
+			return nil
+		}
+		return fmt.Errorf("get packages with YAML Path: %w", err)
 	}
-	if err := os.WriteFile(cfgFilePath, []byte(file.String()+"\n"), stat.Mode()); err != nil {
-		return fmt.Errorf("write the configuration file: %w", err)
+	if base.Type() == ast.NullType {
+		ctrl.logE().Info("replace null node")
+		if err := path.ReplaceWithNode(file, node); err != nil {
+			return fmt.Errorf("replace node: %w", err)
+		}
+		return nil
+	}
+	if err := ast.Merge(base, node); err != nil {
+		return fmt.Errorf("add packages to AST: %w", err)
 	}
 	return nil
 }

--- a/pkg/controller/generate_insert.go
+++ b/pkg/controller/generate_insert.go
@@ -8,7 +8,6 @@ import (
 	"github.com/goccy/go-yaml"
 	"github.com/goccy/go-yaml/ast"
 	"github.com/goccy/go-yaml/parser"
-	"github.com/goccy/go-yaml/printer"
 )
 
 func (ctrl *Controller) generateInsert(cfgFilePath string, pkgs interface{}) error {
@@ -25,8 +24,7 @@ func (ctrl *Controller) generateInsert(cfgFilePath string, pkgs interface{}) err
 	if err != nil {
 		return fmt.Errorf("get configuration file stat: %w", err)
 	}
-	var p printer.Printer
-	if err := os.WriteFile(cfgFilePath, p.PrintNode(file.Docs[0]), stat.Mode()); err != nil {
+	if err := os.WriteFile(cfgFilePath, []byte(file.String()+"\n"), stat.Mode()); err != nil {
 		return fmt.Errorf("write the configuration file: %w", err)
 	}
 	return nil
@@ -37,29 +35,28 @@ func (ctrl *Controller) updateASTFile(file *ast.File, pkgs interface{}) error {
 	if err != nil {
 		return fmt.Errorf("convert packages to node: %w", err)
 	}
-	path, err := yaml.PathString("$.packages")
-	if err != nil {
-		return fmt.Errorf("build a YAML Path: %w", err)
-	}
-	base, err := path.FilterFile(file)
-	if err != nil {
-		if errors.Is(err, yaml.ErrNotFoundNode) {
-			if err := path.ReplaceWithNode(file, node); err != nil {
-				return fmt.Errorf("replace node: %w", err)
+
+	for _, doc := range file.Docs {
+		body, ok := doc.Body.(*ast.MappingNode)
+		if !ok {
+			continue
+		}
+		for _, mapValue := range body.Values {
+			if mapValue.Key.String() != "packages" {
+				continue
 			}
-			return nil
+			switch mapValue.Value.Type() {
+			case ast.NullType:
+				mapValue.Value = node
+			case ast.SequenceType:
+				if err := ast.Merge(mapValue.Value, node); err != nil {
+					return fmt.Errorf("merge packages: %w", err)
+				}
+			default:
+				return errors.New("packages must be null or array")
+			}
+			break
 		}
-		return fmt.Errorf("get packages with YAML Path: %w", err)
-	}
-	if base.Type() == ast.NullType {
-		ctrl.logE().Info("replace null node")
-		if err := path.ReplaceWithNode(file, node); err != nil {
-			return fmt.Errorf("replace node: %w", err)
-		}
-		return nil
-	}
-	if err := ast.Merge(base, node); err != nil {
-		return fmt.Errorf("add packages to AST: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
# ⚠️ Known Issue

When `packages:` is empty, `aqua g -i` ignores the ident of `registries`.

aqua.yaml

```yaml
---
# aqua - Declarative CLI Version Manager
# https://aquaproj.github.io/
registries:
  - type: standard
    ref: v1.4.0 # renovate: depName=aquaproj/aqua-registry

packages:
```

```console
$ aqua g -i cli/cli
```

## Expected Result

```yaml
---
# aqua - Declarative CLI Version Manager
# https://aquaproj.github.io/
registries:
  - type: standard
    ref: v1.4.0 # renovate: depName=aquaproj/aqua-registry
packages:
  - name: cli/cli@v2.5.1
```

## Actual Result

```yaml
---
# aqua - Declarative CLI Version Manager
# https://aquaproj.github.io/
registries:
  - type: standard
    ref: v1.4.0 # renovate: depName=aquaproj/aqua-registry
packages:
- name: cli/cli@v2.5.1
```