### PR TITLE
use yaml.v2 for registry parsing

### DIFF
--- a/pkg/controller/registry.go
+++ b/pkg/controller/registry.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-github/v39/github"
 	"github.com/sirupsen/logrus"
 	"github.com/suzuki-shunsuke/logrus-error/logerr"
-	"gopkg.in/yaml.v2" // read from yaml.v2 for performance
+	"gopkg.in/yaml.v2"
 )
 
 type Registry struct {

--- a/pkg/controller/registry.go
+++ b/pkg/controller/registry.go
@@ -9,10 +9,10 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/goccy/go-yaml"
 	"github.com/google/go-github/v39/github"
 	"github.com/sirupsen/logrus"
 	"github.com/suzuki-shunsuke/logrus-error/logerr"
+	"gopkg.in/yaml.v2" // read from yaml.v2 for performance
 )
 
 type Registry struct {


### PR DESCRIPTION
This rolls back the change in yaml modules for reading the registries. resolves #582 

```
─❯ time ./aqua.out which actionlint >/dev/null
________________________________________________________
Executed in   19.76 millis    fish           external
   usr time   19.89 millis  768.00 micros   19.12 millis
   sys time    4.91 millis  137.00 micros    4.77 millis
```