### PR TITLE
feat: support selecting multiple packages by tab key in `aqua g`'s fuzzy finder

### DIFF
--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -176,6 +176,7 @@ $ aqua g
 > cli                                                           └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ 
 
 Please select the package you want to install, then the package configuration is outptted.
+You can select multiple packages by tab key.
 Please copy and paste the outputted configuration in the aqua configuration file.
 
 $ aqua g # tfmigrator/cli is selected

--- a/pkg/controller/finder.go
+++ b/pkg/controller/finder.go
@@ -7,8 +7,8 @@ import (
 	"github.com/ktr0731/go-fuzzyfinder"
 )
 
-func (ctrl *Controller) launchFuzzyFinder(pkgs []*FindingPackage) (int, error) {
-	return fuzzyfinder.Find(pkgs, func(i int) string { //nolint:wrapcheck
+func (ctrl *Controller) launchFuzzyFinder(pkgs []*FindingPackage) ([]int, error) {
+	return fuzzyfinder.FindMulti(pkgs, func(i int) string { //nolint:wrapcheck
 		pkg := pkgs[i]
 		files := pkg.PackageInfo.GetFiles()
 		fileNames := make([]string, len(files))

--- a/pkg/controller/generate.go
+++ b/pkg/controller/generate.go
@@ -51,7 +51,7 @@ func (ctrl *Controller) Generate(ctx context.Context, param *Param, args ...stri
 	return ctrl.generateInsert(cfgFilePath, list)
 }
 
-func (ctrl *Controller) generate(ctx context.Context, param *Param, cfgFilePath string, args ...string) (interface{}, error) {
+func (ctrl *Controller) generate(ctx context.Context, param *Param, cfgFilePath string, args ...string) (interface{}, error) { //nolint:cyclop
 	cfg := &Config{}
 	if err := ctrl.readConfig(cfgFilePath, cfg); err != nil {
 		return nil, err
@@ -80,16 +80,19 @@ func (ctrl *Controller) generate(ctx context.Context, param *Param, cfgFilePath 
 	}
 
 	// Launch the fuzzy finder
-	idx, err := ctrl.launchFuzzyFinder(pkgs)
+	idxes, err := ctrl.launchFuzzyFinder(pkgs)
 	if err != nil {
 		if errors.Is(err, fuzzyfinder.ErrAbort) {
 			return nil, nil //nolint:nilnil
 		}
 		return nil, fmt.Errorf("find the package: %w", err)
 	}
-	pkg := pkgs[idx]
+	arr := make([]interface{}, len(idxes))
+	for i, idx := range idxes {
+		arr[i] = ctrl.getOutputtedPkg(ctx, pkgs[idx])
+	}
 
-	return []interface{}{ctrl.getOutputtedPkg(ctx, pkg)}, nil
+	return arr, nil
 }
 
 func getGeneratePkg(s string) string {


### PR DESCRIPTION
```console
$ aqua g
```

<img width="377" alt="image" src="https://user-images.githubusercontent.com/13323303/155527585-065a0f05-b030-4969-ac3f-aae92f88008c.png">

You can select multiple packages by tab key.
This feature is powered by [go-fuzzyfinder#FindMulti](https://pkg.go.dev/github.com/ktr0731/go-fuzzyfinder#FindMulti).