### PR TITLE
feat: support `replacements_overrides`

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -47,6 +47,7 @@ jobs:
     - run: gh version
     - run: tfenv --version
     - run: aqua -c tests/aqua-global.yaml g local,kubernetes-sigs/kustomize
+    - run: btop -v
 
     - run: aqua g -i suzuki-shunsuke/tfcmt
       working-directory: tests

--- a/pkg/config/package_info_test.go
+++ b/pkg/config/package_info_test.go
@@ -190,7 +190,7 @@ func TestPackageInfo_GetReplacements(t *testing.T) {
 		},
 		{
 			title:   "empty",
-			exp:     nil,
+			exp:     map[string]string{},
 			pkgInfo: &config.PackageInfo{},
 		},
 	}

--- a/pkg/config/replacements.go
+++ b/pkg/config/replacements.go
@@ -1,5 +1,11 @@
 package config
 
+type ReplacementsOverride struct {
+	GOOS         string
+	GOArch       string
+	Replacements map[string]string
+}
+
 func replace(key string, replacements map[string]string) string {
 	a := replacements[key]
 	if a == "" {

--- a/tests/aqua-global.yaml
+++ b/tests/aqua-global.yaml
@@ -49,3 +49,7 @@ packages:
 - name: containerd/nerdctl@v0.18.0
   # supported_if
   registry: local
+
+- name: aristocratos/btop@v1.2.5
+  # replacements_overrides
+  registry: local

--- a/tests/registry.yaml
+++ b/tests/registry.yaml
@@ -48,3 +48,22 @@ packages:
   repo_name: nerdctl
   asset: 'nerdctl-{{trimV .Version}}-{{.OS}}-{{.Arch}}.tar.gz'
   supported_if: GOOS != "darwin" # supported_if
+
+- type: github_release
+  repo_owner: aristocratos
+  repo_name: btop
+  asset: 'btop-{{.Arch}}-{{.OS}}.tbz'
+  format: tar.bz2
+  description: 'A monitor of resources'
+  replacements:
+    linux: linux-musl
+    darwin: macos-monterey
+    amd64: x86_64
+  replacements_overrides:
+  - goos: linux
+    goarch: arm64
+    replacements:
+      arm64: aarch64
+  files:
+  - name: btop
+    src: bin/btop


### PR DESCRIPTION
Close #607

https://github.com/aquaproj/aqua-registry/blob/a562055e92306d18dc0852319a6ddafdde644367/registry.yaml#L316-L328

AS IS

```yaml
- type: github_release
  repo_owner: aristocratos
  repo_name: btop
  asset: 'btop-{{if and (eq .GOOS "linux") (eq .GOARCH "arm64")}}aarch64{{else}}{{.Arch}}{{end}}-{{.OS}}.tbz'
  format: tar.bz2
  description: 'A monitor of resources'
  replacements:
    linux: linux-musl
    darwin: macos-monterey
    amd64: x86_64
  files:
  - name: btop
    src: bin/btop
```

TO BE

```yaml
- type: github_release
  repo_owner: aristocratos
  repo_name: btop
  asset: 'btop-{{.Arch}}-{{.OS}}.tbz'
  format: tar.bz2
  description: 'A monitor of resources'
  replacements:
    linux: linux-musl
    darwin: macos-monterey
    amd64: x86_64
  replacements_overrides:
  - goos: linux
    goarch: arm64
    replacements:
      arm64: aarch64
  files:
  - name: btop
    src: bin/btop
```