### PR TITLE
feat: support `overrides`

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -47,6 +47,7 @@ jobs:
     - run: gh version
     - run: tfenv --version
     - run: aqua -c tests/aqua-global.yaml g local,kubernetes-sigs/kustomize
+    - run: btop -v
 
     - run: aqua g -i suzuki-shunsuke/tfcmt
       working-directory: tests

--- a/pkg/config/override.go
+++ b/pkg/config/override.go
@@ -1,0 +1,58 @@
+package config
+
+import "runtime"
+
+func (pkgInfo *PackageInfo) Override(v string) error {
+	if err := pkgInfo.setVersion(v); err != nil {
+		return err
+	}
+	pkgInfo.override()
+	return nil
+}
+
+func (pkgInfo *PackageInfo) getOverride() *Override {
+	for _, ov := range pkgInfo.Overrides {
+		if ov.Match() {
+			return ov
+		}
+	}
+	return nil
+}
+
+func (pkgInfo *PackageInfo) override() {
+	for _, fo := range pkgInfo.FormatOverrides {
+		if fo.GOOS == runtime.GOOS {
+			pkgInfo.Format = fo.Format
+			break
+		}
+	}
+
+	ov := pkgInfo.getOverride()
+	if ov == nil {
+		return
+	}
+
+	if pkgInfo.Replacements == nil {
+		pkgInfo.Replacements = ov.Replacements
+	} else {
+		for k, v := range ov.Replacements {
+			pkgInfo.Replacements[k] = v
+		}
+	}
+
+	if ov.Format != "" {
+		pkgInfo.Format = ov.Format
+	}
+
+	if ov.Asset != nil {
+		pkgInfo.Asset = ov.Asset
+	}
+
+	if ov.Files != nil {
+		pkgInfo.Files = ov.Files
+	}
+
+	if ov.URL != nil {
+		pkgInfo.URL = ov.URL
+	}
+}

--- a/pkg/config/package_info.go
+++ b/pkg/config/package_info.go
@@ -12,25 +12,25 @@ import (
 )
 
 type PackageInfo struct {
-	Name                  string
-	Type                  string `validate:"required"`
-	RepoOwner             string `yaml:"repo_owner"`
-	RepoName              string `yaml:"repo_name"`
-	Asset                 *template.Template
-	Path                  *template.Template
-	Format                string
-	Files                 []*File
-	URL                   *template.Template
-	Description           string
-	Link                  string
-	Replacements          map[string]string
-	ReplacementsOverrides []*ReplacementsOverride        `yaml:"replacements_overrides"`
-	FormatOverrides       []*FormatOverride              `yaml:"format_overrides"`
-	VersionConstraints    *constraint.VersionConstraints `yaml:"version_constraint"`
-	VersionOverrides      []*PackageInfo                 `yaml:"version_overrides"`
-	SupportedIf           *constraint.PackageCondition   `yaml:"supported_if"`
-	VersionFilter         *constraint.VersionFilter      `yaml:"version_filter"`
-	Rosetta2              *bool
+	Name               string
+	Type               string `validate:"required"`
+	RepoOwner          string `yaml:"repo_owner"`
+	RepoName           string `yaml:"repo_name"`
+	Asset              *template.Template
+	Path               *template.Template
+	Format             string
+	Files              []*File
+	URL                *template.Template
+	Description        string
+	Link               string
+	Replacements       map[string]string
+	Overrides          []*Override
+	FormatOverrides    []*FormatOverride              `yaml:"format_overrides"`
+	VersionConstraints *constraint.VersionConstraints `yaml:"version_constraint"`
+	VersionOverrides   []*PackageInfo                 `yaml:"version_overrides"`
+	SupportedIf        *constraint.PackageCondition   `yaml:"supported_if"`
+	VersionFilter      *constraint.VersionFilter      `yaml:"version_filter"`
+	Rosetta2           *bool
 }
 
 func (pkgInfo *PackageInfo) GetRosetta2() bool {
@@ -65,11 +65,6 @@ func (pkgInfo *PackageInfo) GetFormat() string {
 	if pkgInfo.Type == PkgInfoTypeGitHubArchive {
 		return "tar.gz"
 	}
-	for _, arcTypeOverride := range pkgInfo.FormatOverrides {
-		if arcTypeOverride.GOOS == runtime.GOOS {
-			return arcTypeOverride.Format
-		}
-	}
 	return pkgInfo.Format
 }
 
@@ -99,93 +94,12 @@ func (pkgInfo *PackageInfo) GetType() string {
 	return pkgInfo.Type
 }
 
-func (pkgInfo *PackageInfo) SetVersion(v string) (*PackageInfo, error) {
-	if pkgInfo.VersionConstraints == nil {
-		return pkgInfo, nil
-	}
-	a, err := pkgInfo.VersionConstraints.Check(v)
-	if err != nil {
-		return nil, err //nolint:wrapcheck
-	}
-	if a {
-		return pkgInfo, nil
-	}
-	for _, vo := range pkgInfo.VersionOverrides {
-		a, err := vo.VersionConstraints.Check(v)
-		if err != nil {
-			return nil, err //nolint:wrapcheck
-		}
-		if a {
-			pkgInfo.override(vo)
-			return pkgInfo, nil
-		}
-	}
-	return pkgInfo, nil
-}
-
-func (pkgInfo *PackageInfo) override(child *PackageInfo) { //nolint:cyclop
-	if child.Type != "" {
-		pkgInfo.Type = child.Type
-	}
-	if child.RepoOwner != "" {
-		pkgInfo.RepoOwner = child.RepoOwner
-	}
-	if child.RepoName != "" {
-		pkgInfo.RepoName = child.RepoName
-	}
-	if child.Asset != nil {
-		pkgInfo.Asset = child.Asset
-	}
-	if child.Path != nil {
-		pkgInfo.Path = child.Path
-	}
-	if child.Format != "" {
-		pkgInfo.Format = child.Format
-	}
-	if child.Files != nil {
-		pkgInfo.Files = child.Files
-	}
-	if child.URL != nil {
-		pkgInfo.URL = child.URL
-	}
-	if child.Replacements != nil {
-		pkgInfo.Replacements = child.Replacements
-	}
-	if child.ReplacementsOverrides != nil {
-		pkgInfo.ReplacementsOverrides = child.ReplacementsOverrides
-	}
-	if child.FormatOverrides != nil {
-		pkgInfo.FormatOverrides = child.FormatOverrides
-	}
-	if child.SupportedIf != nil {
-		pkgInfo.SupportedIf = child.SupportedIf
-	}
-	if child.Rosetta2 != nil {
-		pkgInfo.Rosetta2 = child.Rosetta2
-	}
-	if child.VersionFilter != nil {
-		pkgInfo.VersionFilter = child.VersionFilter
-	}
-}
-
 func (pkgInfo *PackageInfo) GetReplacements() map[string]string {
-	m := make(map[string]string, len(pkgInfo.Replacements))
-	for k, v := range pkgInfo.Replacements {
-		m[k] = v
-	}
-	for _, ro := range pkgInfo.ReplacementsOverrides {
-		if ro.GOOS != "" && ro.GOOS != runtime.GOOS {
-			continue
-		}
-		if ro.GOArch != "" && ro.GOArch != runtime.GOARCH {
-			continue
-		}
-		for k, v := range ro.Replacements {
-			m[k] = v
-		}
-		return m
-	}
-	return m
+	return pkgInfo.Replacements
+}
+
+func (pkgInfo *PackageInfo) GetAsset() *template.Template {
+	return pkgInfo.Asset
 }
 
 func (pkgInfo *PackageInfo) GetPkgPath(rootDir string, pkg *Package) (string, error) {

--- a/pkg/config/package_info_test.go
+++ b/pkg/config/package_info_test.go
@@ -190,7 +190,7 @@ func TestPackageInfo_GetReplacements(t *testing.T) {
 		},
 		{
 			title:   "empty",
-			exp:     nil,
+			exp:     map[string]string{},
 			pkgInfo: &config.PackageInfo{},
 		},
 	}

--- a/pkg/config/package_info_test.go
+++ b/pkg/config/package_info_test.go
@@ -5,9 +5,7 @@ import (
 
 	"github.com/aquaproj/aqua/pkg/config"
 	"github.com/aquaproj/aqua/pkg/template"
-	constraint "github.com/aquaproj/aqua/pkg/version-constraint"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestPackageInfo_GetName(t *testing.T) {
@@ -190,7 +188,7 @@ func TestPackageInfo_GetReplacements(t *testing.T) {
 		},
 		{
 			title:   "empty",
-			exp:     map[string]string{},
+			exp:     nil,
 			pkgInfo: &config.PackageInfo{},
 		},
 	}
@@ -468,81 +466,6 @@ func TestPackageInfo_GetFileSrc(t *testing.T) { //nolint:funlen
 			}
 			if asset != d.exp {
 				t.Fatalf("wanted %v, got %v", d.exp, asset)
-			}
-		})
-	}
-}
-
-func TestPackageInfo_SetVersion(t *testing.T) { //nolint:funlen
-	t.Parallel()
-	data := []struct {
-		title   string
-		version string
-		pkgInfo *config.PackageInfo
-		exp     *config.PackageInfo
-	}{
-		{
-			title: "no version constraint",
-			exp: &config.PackageInfo{
-				Type: "github_content",
-				Path: template.NewTemplate("foo"),
-			},
-			pkgInfo: &config.PackageInfo{
-				Type: "github_content",
-				Path: template.NewTemplate("foo"),
-			},
-		},
-		{
-			title: "version constraint",
-			exp: &config.PackageInfo{
-				Type:               "github_content",
-				Path:               template.NewTemplate("foo"),
-				VersionConstraints: constraint.NewVersionConstraints(`semver(">= 0.4.0")`),
-			},
-			pkgInfo: &config.PackageInfo{
-				Type:               "github_content",
-				Path:               template.NewTemplate("foo"),
-				VersionConstraints: constraint.NewVersionConstraints(`semver(">= 0.4.0")`),
-			},
-			version: "v0.5.0",
-		},
-		{
-			title: "child version constraint",
-			exp: &config.PackageInfo{
-				Type:               "github_content",
-				Path:               template.NewTemplate("bar"),
-				VersionConstraints: constraint.NewVersionConstraints(`semver(">= 0.4.0")`),
-				VersionOverrides: []*config.PackageInfo{
-					{
-						VersionConstraints: constraint.NewVersionConstraints(`semver("< 0.4.0")`),
-						Path:               template.NewTemplate("bar"),
-					},
-				},
-			},
-			pkgInfo: &config.PackageInfo{
-				Type:               "github_content",
-				Path:               template.NewTemplate("foo"),
-				VersionConstraints: constraint.NewVersionConstraints(`semver(">= 0.4.0")`),
-				VersionOverrides: []*config.PackageInfo{
-					{
-						VersionConstraints: constraint.NewVersionConstraints(`semver("< 0.4.0")`),
-						Path:               template.NewTemplate("bar"),
-					},
-				},
-			},
-			version: "v0.3.0",
-		},
-	}
-	for _, d := range data {
-		d := d
-		t.Run(d.title, func(t *testing.T) {
-			t.Parallel()
-			pkgInfo, err := d.pkgInfo.SetVersion(d.version)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if diff := cmp.Diff(pkgInfo, d.exp, cmpopts.IgnoreUnexported(constraint.VersionConstraints{}), cmp.AllowUnexported(template.Template{})); diff != "" {
-				t.Fatal(diff)
 			}
 		})
 	}

--- a/pkg/config/replacements.go
+++ b/pkg/config/replacements.go
@@ -1,5 +1,11 @@
 package config
 
+type ReplacementsOverride struct {
+	GOOS         string
+	GOArch       string
+	Replacements map[string]string
+}
+
 func replace(key string, replacements map[string]string) string {
 	a := replacements[key]
 	if a == "" {

--- a/pkg/config/replacements.go
+++ b/pkg/config/replacements.go
@@ -1,9 +1,29 @@
 package config
 
-type ReplacementsOverride struct {
+import (
+	"runtime"
+
+	"github.com/aquaproj/aqua/pkg/template"
+)
+
+type Override struct {
 	GOOS         string
 	GOArch       string
 	Replacements map[string]string
+	Format       string
+	Asset        *template.Template
+	Files        []*File
+	URL          *template.Template
+}
+
+func (ov *Override) Match() bool {
+	if ov.GOOS != "" && ov.GOOS != runtime.GOOS {
+		return false
+	}
+	if ov.GOArch != "" && ov.GOArch != runtime.GOARCH {
+		return false
+	}
+	return true
 }
 
 func replace(key string, replacements map[string]string) string {

--- a/pkg/config/version_override.go
+++ b/pkg/config/version_override.go
@@ -1,0 +1,70 @@
+package config
+
+func (pkgInfo *PackageInfo) setVersion(v string) error {
+	if pkgInfo.VersionConstraints == nil {
+		return nil
+	}
+	a, err := pkgInfo.VersionConstraints.Check(v)
+	if err != nil {
+		return err //nolint:wrapcheck
+	}
+	if a {
+		return nil
+	}
+	for _, vo := range pkgInfo.VersionOverrides {
+		a, err := vo.VersionConstraints.Check(v)
+		if err != nil {
+			return err //nolint:wrapcheck
+		}
+		if a {
+			pkgInfo.overrideVersion(vo)
+			return nil
+		}
+	}
+	return nil
+}
+
+func (pkgInfo *PackageInfo) overrideVersion(child *PackageInfo) { //nolint:cyclop
+	if child.Type != "" {
+		pkgInfo.Type = child.Type
+	}
+	if child.RepoOwner != "" {
+		pkgInfo.RepoOwner = child.RepoOwner
+	}
+	if child.RepoName != "" {
+		pkgInfo.RepoName = child.RepoName
+	}
+	if child.Asset != nil {
+		pkgInfo.Asset = child.Asset
+	}
+	if child.Path != nil {
+		pkgInfo.Path = child.Path
+	}
+	if child.Format != "" {
+		pkgInfo.Format = child.Format
+	}
+	if child.Files != nil {
+		pkgInfo.Files = child.Files
+	}
+	if child.URL != nil {
+		pkgInfo.URL = child.URL
+	}
+	if child.Replacements != nil {
+		pkgInfo.Replacements = child.Replacements
+	}
+	if child.Overrides != nil {
+		pkgInfo.Overrides = child.Overrides
+	}
+	if child.FormatOverrides != nil {
+		pkgInfo.FormatOverrides = child.FormatOverrides
+	}
+	if child.SupportedIf != nil {
+		pkgInfo.SupportedIf = child.SupportedIf
+	}
+	if child.Rosetta2 != nil {
+		pkgInfo.Rosetta2 = child.Rosetta2
+	}
+	if child.VersionFilter != nil {
+		pkgInfo.VersionFilter = child.VersionFilter
+	}
+}

--- a/pkg/controller/which/which.go
+++ b/pkg/controller/which/which.go
@@ -166,8 +166,7 @@ func (ctrl *controller) findExecFileFromPkg(registries map[string]*config.Regist
 		return nil, nil
 	}
 
-	pkgInfo, err = pkgInfo.SetVersion(pkg.Version)
-	if err != nil {
+	if err := pkgInfo.Override(pkg.Version); err != nil {
 		logerr.WithError(logE, err).Warn("version constraint is invalid")
 		return nil, nil
 	}

--- a/pkg/installpackage/installer.go
+++ b/pkg/installpackage/installer.go
@@ -47,8 +47,8 @@ func (inst *installer) InstallPackages(ctx context.Context, cfg *config.Config, 
 			failed = true
 			continue
 		}
-		pkgInfo, err = pkgInfo.SetVersion(pkg.Version)
-		if err != nil {
+
+		if err := pkgInfo.Override(pkg.Version); err != nil {
 			return fmt.Errorf("evaluate version constraints: %w", err)
 		}
 		if pkgInfo.SupportedIf != nil {
@@ -115,8 +115,8 @@ func (inst *installer) InstallPackages(ctx context.Context, cfg *config.Config, 
 				handleFailure()
 				return
 			}
-			pkgInfo, err = pkgInfo.SetVersion(pkg.Version)
-			if err != nil {
+
+			if err := pkgInfo.Override(pkg.Version); err != nil {
 				logerr.WithError(logE, err).Error("install the package")
 				handleFailure()
 				return

--- a/tests/aqua-global.yaml
+++ b/tests/aqua-global.yaml
@@ -49,3 +49,7 @@ packages:
 - name: containerd/nerdctl@v0.18.0
   # supported_if
   registry: local
+
+- name: aristocratos/btop@v1.2.5
+  # replacements_overrides
+  registry: local

--- a/tests/registry.yaml
+++ b/tests/registry.yaml
@@ -48,3 +48,22 @@ packages:
   repo_name: nerdctl
   asset: 'nerdctl-{{trimV .Version}}-{{.OS}}-{{.Arch}}.tar.gz'
   supported_if: GOOS != "darwin" # supported_if
+
+- type: github_release
+  repo_owner: aristocratos
+  repo_name: btop
+  asset: 'btop-{{.Arch}}-{{.OS}}.tbz'
+  format: tar.bz2
+  description: 'A monitor of resources'
+  replacements:
+    linux: linux-musl
+    darwin: macos-monterey
+    amd64: x86_64
+  replacements_overrides:
+  - goos: linux
+    goarch: arm64
+    replacements:
+      arm64: aarch64
+  files:
+  - name: btop
+    src: bin/btop

--- a/tests/registry.yaml
+++ b/tests/registry.yaml
@@ -59,7 +59,7 @@ packages:
     linux: linux-musl
     darwin: macos-monterey
     amd64: x86_64
-  replacements_overrides:
+  overrides:
   - goos: linux
     goarch: arm64
     replacements:


### PR DESCRIPTION
Close #607

This adds `overrides` in Registry Configuration. https://aquaproj.github.io/docs/reference/registry-config

You can override the following attributes on the specific `GOOS` and `GOARCH`.

* replacements
* format
* asset
* url
* files

e.g. On Linux ARM64, `Arch` becomes `aarch64`.

```yaml
  overrides:
  - goos: linux
    replacements:
      arm64: aarch64
```

In case of `replacements`, maps are merged.

Either `goos` or `goarch` is required.

e.g.

```yaml
  asset: arkade
  overrides:
  - goos: linux
    goarch: arm64
    asset: 'arkade-{{.Arch}}'
  - goos: darwin
    goarch: amd64
    asset: 'arkade-darwin'
  - goos: darwin 
    asset: 'arkade-darwin-{{.Arch}}'
```

Even if multiple elements are matched, only first element is applied.
For example, Darwin AMD64 matches with second element but the second element isn't applied beause the first element is matched.

```yaml
  - goos: darwin
    goarch: amd64
    asset: 'arkade-darwin'
  - goos: darwin 
    asset: 'arkade-darwin-{{.Arch}}'
```

## Why is this feature needed?

To make `asset`, `files`, and `url` configuration simple.
Using `overrides` you can replace `if` conditions in template strings.