### PR TITLE
feat: support changing GOOS and GOARCH for testing

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,9 +1,9 @@
 package config
 
 import (
-	"runtime"
 	"strings"
 
+	"github.com/aquaproj/aqua/pkg/runtime"
 	"github.com/aquaproj/aqua/pkg/template"
 	"github.com/invopop/jsonschema"
 	"github.com/sirupsen/logrus"
@@ -109,21 +109,21 @@ type File struct {
 	Src  *template.Template `json:"src,omitempty"`
 }
 
-func getArch(rosetta2 bool, replacements map[string]string) string {
-	if rosetta2 && runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
+func getArch(rosetta2 bool, replacements map[string]string, rt *runtime.Runtime) string {
+	if rosetta2 && rt.GOOS == "darwin" && rt.GOARCH == "arm64" {
 		// Rosetta 2
 		return replace("amd64", replacements)
 	}
-	return replace(runtime.GOARCH, replacements)
+	return replace(rt.GOARCH, replacements)
 }
 
-func (file *File) RenderSrc(pkg *Package, pkgInfo *PackageInfo) (string, error) {
+func (file *File) RenderSrc(pkg *Package, pkgInfo *PackageInfo, rt *runtime.Runtime) (string, error) {
 	return file.Src.Execute(map[string]interface{}{ //nolint:wrapcheck
 		"Version":  pkg.Version,
-		"GOOS":     runtime.GOOS,
-		"GOARCH":   runtime.GOARCH,
-		"OS":       replace(runtime.GOOS, pkgInfo.GetReplacements()),
-		"Arch":     getArch(pkgInfo.GetRosetta2(), pkgInfo.GetReplacements()),
+		"GOOS":     rt.GOOS,
+		"GOARCH":   rt.GOARCH,
+		"OS":       replace(rt.GOOS, pkgInfo.GetReplacements()),
+		"Arch":     getArch(pkgInfo.GetRosetta2(), pkgInfo.GetReplacements(), rt),
 		"Format":   pkgInfo.GetFormat(),
 		"FileName": file.Name,
 	})

--- a/pkg/config/override.go
+++ b/pkg/config/override.go
@@ -1,33 +1,33 @@
 package config
 
-import "runtime"
+import "github.com/aquaproj/aqua/pkg/runtime"
 
-func (pkgInfo *PackageInfo) Override(v string) error {
+func (pkgInfo *PackageInfo) Override(v string, rt *runtime.Runtime) error {
 	if err := pkgInfo.setVersion(v); err != nil {
 		return err
 	}
-	pkgInfo.override()
+	pkgInfo.override(rt)
 	return nil
 }
 
-func (pkgInfo *PackageInfo) getOverride() *Override {
+func (pkgInfo *PackageInfo) getOverride(rt *runtime.Runtime) *Override {
 	for _, ov := range pkgInfo.Overrides {
-		if ov.Match() {
+		if ov.Match(rt) {
 			return ov
 		}
 	}
 	return nil
 }
 
-func (pkgInfo *PackageInfo) override() {
+func (pkgInfo *PackageInfo) override(rt *runtime.Runtime) {
 	for _, fo := range pkgInfo.FormatOverrides {
-		if fo.GOOS == runtime.GOOS {
+		if fo.GOOS == rt.GOOS {
 			pkgInfo.Format = fo.Format
 			break
 		}
 	}
 
-	ov := pkgInfo.getOverride()
+	ov := pkgInfo.getOverride(rt)
 	if ov == nil {
 		return
 	}

--- a/pkg/config/package_info_test.go
+++ b/pkg/config/package_info_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/aquaproj/aqua/pkg/config"
+	"github.com/aquaproj/aqua/pkg/runtime"
 	"github.com/aquaproj/aqua/pkg/template"
 	"github.com/google/go-cmp/cmp"
 )
@@ -309,11 +310,12 @@ func TestPackageInfo_RenderAsset(t *testing.T) { //nolint:funlen
 			},
 		},
 	}
+	rt := runtime.New()
 	for _, d := range data {
 		d := d
 		t.Run(d.title, func(t *testing.T) {
 			t.Parallel()
-			asset, err := d.pkgInfo.RenderAsset(d.pkg)
+			asset, err := d.pkgInfo.RenderAsset(d.pkg, rt)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -385,11 +387,12 @@ func TestPackageInfo_GetPkgPath(t *testing.T) { //nolint:funlen
 			},
 		},
 	}
+	rt := runtime.New()
 	for _, d := range data {
 		d := d
 		t.Run(d.title, func(t *testing.T) {
 			t.Parallel()
-			pkgPath, err := d.pkgInfo.GetPkgPath(rootDir, d.pkg)
+			pkgPath, err := d.pkgInfo.GetPkgPath(rootDir, d.pkg, rt)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -456,11 +459,12 @@ func TestPackageInfo_GetFileSrc(t *testing.T) { //nolint:funlen
 			},
 		},
 	}
+	rt := runtime.New()
 	for _, d := range data {
 		d := d
 		t.Run(d.title, func(t *testing.T) {
 			t.Parallel()
-			asset, err := d.pkgInfo.GetFileSrc(d.pkg, d.file)
+			asset, err := d.pkgInfo.GetFileSrc(d.pkg, d.file, rt)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/config/replacements.go
+++ b/pkg/config/replacements.go
@@ -1,8 +1,7 @@
 package config
 
 import (
-	"runtime"
-
+	"github.com/aquaproj/aqua/pkg/runtime"
 	"github.com/aquaproj/aqua/pkg/template"
 )
 
@@ -16,11 +15,11 @@ type Override struct {
 	URL          *template.Template `json:"url,omitempty"`
 }
 
-func (ov *Override) Match() bool {
-	if ov.GOOS != "" && ov.GOOS != runtime.GOOS {
+func (ov *Override) Match(rt *runtime.Runtime) bool {
+	if ov.GOOS != "" && ov.GOOS != rt.GOOS {
 		return false
 	}
-	if ov.GOArch != "" && ov.GOArch != runtime.GOARCH {
+	if ov.GOArch != "" && ov.GOArch != rt.GOARCH {
 		return false
 	}
 	return true

--- a/pkg/controller/which/which_internal_test.go
+++ b/pkg/controller/which/which_internal_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aquaproj/aqua/pkg/config"
 	"github.com/aquaproj/aqua/pkg/log"
+	"github.com/aquaproj/aqua/pkg/runtime"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -53,7 +54,8 @@ func Test_controller_findExecFileFromPkg(t *testing.T) {
 		},
 	}
 	ctrl := &controller{
-		logger: log.NewLogger(""),
+		logger:  log.NewLogger(""),
+		runtime: runtime.New(),
 	}
 	for _, d := range data {
 		d := d

--- a/pkg/controller/wire.go
+++ b/pkg/controller/wire.go
@@ -20,6 +20,7 @@ import (
 	registry "github.com/aquaproj/aqua/pkg/install-registry"
 	"github.com/aquaproj/aqua/pkg/installpackage"
 	"github.com/aquaproj/aqua/pkg/log"
+	"github.com/aquaproj/aqua/pkg/runtime"
 	"github.com/google/wire"
 )
 
@@ -39,16 +40,16 @@ func InitializeGenerateCommandController(ctx context.Context, aquaVersion string
 }
 
 func InitializeInstallCommandController(ctx context.Context, aquaVersion string, param *config.Param) *install.Controller {
-	wire.Build(install.New, finder.NewConfigFinder, log.NewLogger, github.New, config.NewRootDir, registry.New, download.NewRegistryDownloader, reader.New, reader.NewFileReader, installpackage.New, download.NewPackageDownloader)
+	wire.Build(install.New, finder.NewConfigFinder, log.NewLogger, github.New, config.NewRootDir, registry.New, download.NewRegistryDownloader, reader.New, reader.NewFileReader, installpackage.New, download.NewPackageDownloader, runtime.New)
 	return &install.Controller{}
 }
 
 func InitializeWhichCommandController(ctx context.Context, aquaVersion string, param *config.Param) which.Controller {
-	wire.Build(which.New, finder.NewConfigFinder, log.NewLogger, github.New, config.NewRootDir, registry.New, download.NewRegistryDownloader, reader.New, reader.NewFileReader)
+	wire.Build(which.New, finder.NewConfigFinder, log.NewLogger, github.New, config.NewRootDir, registry.New, download.NewRegistryDownloader, reader.New, reader.NewFileReader, runtime.New)
 	return nil
 }
 
 func InitializeExecCommandController(ctx context.Context, aquaVersion string, param *config.Param) *exec.Controller {
-	wire.Build(exec.New, finder.NewConfigFinder, log.NewLogger, download.NewPackageDownloader, installpackage.New, github.New, config.NewRootDir, registry.New, download.NewRegistryDownloader, reader.New, reader.NewFileReader, which.New)
+	wire.Build(exec.New, finder.NewConfigFinder, log.NewLogger, download.NewPackageDownloader, installpackage.New, github.New, config.NewRootDir, registry.New, download.NewRegistryDownloader, reader.New, reader.NewFileReader, which.New, runtime.New)
 	return &exec.Controller{}
 }

--- a/pkg/controller/wire_gen.go
+++ b/pkg/controller/wire_gen.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aquaproj/aqua/pkg/install-registry"
 	"github.com/aquaproj/aqua/pkg/installpackage"
 	"github.com/aquaproj/aqua/pkg/log"
+	"github.com/aquaproj/aqua/pkg/runtime"
 )
 
 // Injectors from wire.go:
@@ -68,8 +69,9 @@ func InitializeInstallCommandController(ctx context.Context, aquaVersion string,
 	repositoryService := github.New(ctx)
 	registryDownloader := download.NewRegistryDownloader(repositoryService, logger)
 	installer := registry.New(rootDir, logger, registryDownloader)
-	packageDownloader := download.NewPackageDownloader(repositoryService, logger)
-	installpackageInstaller := installpackage.New(rootDir, logger, packageDownloader)
+	runtimeRuntime := runtime.New()
+	packageDownloader := download.NewPackageDownloader(repositoryService, logger, runtimeRuntime)
+	installpackageInstaller := installpackage.New(rootDir, logger, packageDownloader, runtimeRuntime)
 	controller := install.New(rootDir, configFinder, configReader, installer, installpackageInstaller)
 	return controller
 }
@@ -83,7 +85,8 @@ func InitializeWhichCommandController(ctx context.Context, aquaVersion string, p
 	repositoryService := github.New(ctx)
 	registryDownloader := download.NewRegistryDownloader(repositoryService, logger)
 	installer := registry.New(rootDir, logger, registryDownloader)
-	controller := which.New(rootDir, configFinder, configReader, logger, installer)
+	runtimeRuntime := runtime.New()
+	controller := which.New(rootDir, configFinder, configReader, logger, installer, runtimeRuntime)
 	return controller
 }
 
@@ -91,14 +94,15 @@ func InitializeExecCommandController(ctx context.Context, aquaVersion string, pa
 	rootDir := config.NewRootDir()
 	logger := log.NewLogger(aquaVersion)
 	repositoryService := github.New(ctx)
-	packageDownloader := download.NewPackageDownloader(repositoryService, logger)
-	installer := installpackage.New(rootDir, logger, packageDownloader)
+	runtimeRuntime := runtime.New()
+	packageDownloader := download.NewPackageDownloader(repositoryService, logger, runtimeRuntime)
+	installer := installpackage.New(rootDir, logger, packageDownloader, runtimeRuntime)
 	configFinder := finder.NewConfigFinder()
 	fileReader := reader.NewFileReader()
 	configReader := reader.New(fileReader)
 	registryDownloader := download.NewRegistryDownloader(repositoryService, logger)
 	registryInstaller := registry.New(rootDir, logger, registryDownloader)
-	controller := which.New(rootDir, configFinder, configReader, logger, registryInstaller)
+	controller := which.New(rootDir, configFinder, configReader, logger, registryInstaller, runtimeRuntime)
 	execController := exec.New(installer, logger, controller)
 	return execController
 }

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -9,13 +9,15 @@ import (
 	"github.com/aquaproj/aqua/pkg/config"
 	"github.com/aquaproj/aqua/pkg/github"
 	"github.com/aquaproj/aqua/pkg/log"
+	"github.com/aquaproj/aqua/pkg/runtime"
 	"github.com/sirupsen/logrus"
 	"github.com/suzuki-shunsuke/logrus-error/logerr"
 )
 
 type pkgDownloader struct {
-	github github.RepositoryService
-	logger *log.Logger
+	github  github.RepositoryService
+	logger  *log.Logger
+	runtime *runtime.Runtime
 }
 
 func (downloader *pkgDownloader) GetReadCloser(ctx context.Context, pkg *config.Package, pkgInfo *config.PackageInfo, assetName string) (io.ReadCloser, error) {
@@ -53,7 +55,7 @@ func (downloader *pkgDownloader) getReadCloserFromGitHubContent(ctx context.Cont
 }
 
 func (downloader *pkgDownloader) getReadCloserFromHTTP(ctx context.Context, pkg *config.Package, pkgInfo *config.PackageInfo) (io.ReadCloser, error) {
-	uS, err := pkgInfo.RenderURL(pkg)
+	uS, err := pkgInfo.RenderURL(pkg, downloader.runtime)
 	if err != nil {
 		return nil, err //nolint:wrapcheck
 	}

--- a/pkg/download/public.go
+++ b/pkg/download/public.go
@@ -7,16 +7,18 @@ import (
 	"github.com/aquaproj/aqua/pkg/config"
 	"github.com/aquaproj/aqua/pkg/github"
 	"github.com/aquaproj/aqua/pkg/log"
+	"github.com/aquaproj/aqua/pkg/runtime"
 )
 
 type PackageDownloader interface {
 	GetReadCloser(ctx context.Context, pkg *config.Package, pkgInfo *config.PackageInfo, assetName string) (io.ReadCloser, error)
 }
 
-func NewPackageDownloader(gh github.RepositoryService, logger *log.Logger) PackageDownloader {
+func NewPackageDownloader(gh github.RepositoryService, logger *log.Logger, rt *runtime.Runtime) PackageDownloader {
 	return &pkgDownloader{
-		github: gh,
-		logger: logger,
+		github:  gh,
+		logger:  logger,
+		runtime: rt,
 	}
 }
 

--- a/pkg/installpackage/proxy.go
+++ b/pkg/installpackage/proxy.go
@@ -34,12 +34,12 @@ func (inst *installer) InstallProxy(ctx context.Context) error {
 			},
 		},
 	}
-	assetName, err := pkgInfo.RenderAsset(pkg)
+	assetName, err := pkgInfo.RenderAsset(pkg, inst.runtime)
 	if err != nil {
 		return err //nolint:wrapcheck
 	}
 
-	pkgPath, err := pkgInfo.GetPkgPath(inst.rootDir, pkg)
+	pkgPath, err := pkgInfo.GetPkgPath(inst.rootDir, pkg, inst.runtime)
 	if err != nil {
 		return err //nolint:wrapcheck
 	}

--- a/pkg/installpackage/public.go
+++ b/pkg/installpackage/public.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aquaproj/aqua/pkg/config"
 	"github.com/aquaproj/aqua/pkg/download"
 	"github.com/aquaproj/aqua/pkg/log"
+	"github.com/aquaproj/aqua/pkg/runtime"
 )
 
 type Installer interface {
@@ -14,10 +15,11 @@ type Installer interface {
 	InstallProxy(ctx context.Context) error
 }
 
-func New(rootDir config.RootDir, logger *log.Logger, downloader download.PackageDownloader) Installer {
+func New(rootDir config.RootDir, logger *log.Logger, downloader download.PackageDownloader, rt *runtime.Runtime) Installer {
 	return &installer{
 		logger:            logger,
 		rootDir:           string(rootDir),
 		packageDownloader: downloader,
+		runtime:           rt,
 	}
 }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1,0 +1,32 @@
+package runtime
+
+import (
+	"os"
+	"runtime"
+)
+
+type Runtime struct {
+	GOOS   string
+	GOARCH string
+}
+
+func New() *Runtime {
+	return &Runtime{
+		GOOS:   goos(),
+		GOARCH: goarch(),
+	}
+}
+
+func goos() string {
+	if s := os.Getenv("AQUA_GOOS"); s != "" {
+		return s
+	}
+	return runtime.GOOS
+}
+
+func goarch() string {
+	if s := os.Getenv("AQUA_GOARCH"); s != "" {
+		return s
+	}
+	return runtime.GOARCH
+}

--- a/pkg/version-constraint/package_condition.go
+++ b/pkg/version-constraint/package_condition.go
@@ -2,10 +2,10 @@ package constraint
 
 import (
 	"fmt"
-	"runtime"
 
 	"github.com/antonmedv/expr"
 	"github.com/antonmedv/expr/vm"
+	"github.com/aquaproj/aqua/pkg/runtime"
 	"github.com/invopop/jsonschema"
 )
 
@@ -46,13 +46,13 @@ func (pkgCondition *PackageCondition) compile() error {
 	return nil
 }
 
-func (pkgCondition *PackageCondition) Check() (bool, error) {
+func (pkgCondition *PackageCondition) Check(rt *runtime.Runtime) (bool, error) {
 	if err := pkgCondition.compile(); err != nil {
 		return false, err
 	}
 	a, err := expr.Run(pkgCondition.expr, map[string]interface{}{
-		"GOOS":   runtime.GOOS,
-		"GOARCH": runtime.GOARCH,
+		"GOOS":   rt.GOOS,
+		"GOARCH": rt.GOARCH,
 	})
 	if err != nil {
 		return false, fmt.Errorf("evaluate the expression: %w", err)


### PR DESCRIPTION
Close #643

⚠️ This feature is only for aqua registry's developers.
If you don't write aqua registry, please ignore this.

## How to use

Set the environment variable `AQUA_GOOS` and `AQUA_GOARCH`.

```console
$ AQUA_GOOS=darwin AQUA_GOARCH=arm64 aqua i
$ AQUA_GOOS=darwin AQUA_GOARCH=arm64 aqua which gh
```

## Example

```console
$ go run ./cmd/aqua which gh
/Users/shunsuke-suzuki/.local/share/aquaproj-aqua/pkgs/github_release/github.com/cli/cli/v2.8.0/gh_2.8.0_macOS_amd64.tar.gz/gh_2.8.0_macOS_amd64/bin/gh

$ AQUA_GOOS=linux go run ./cmd/aqua which gh
/Users/shunsuke-suzuki/.local/share/aquaproj-aqua/pkgs/github_release/github.com/cli/cli/v2.8.0/gh_2.8.0_linux_amd64.tar.gz/gh_2.8.0_linux_amd64/bin/gh

$ AQUA_GOOS=linux AQUA_GOARCH=arm64 go run ./cmd/aqua which gh
/Users/shunsuke-suzuki/.local/share/aquaproj-aqua/pkgs/github_release/github.com/cli/cli/v2.8.0/gh_2.8.0_linux_arm64.tar.gz/gh_2.8.0_linux_arm64/bin/gh
```

```console
$ AQUA_GOOS=linux AQUA_GOARCH=arm64 go run ./cmd/aqua i       
INFO[0000] download and unarchive the package            aqua_version= package_name=aqua-proxy package_version=v0.2.1 program=aqua registry=
INFO[0000] download and unarchive the package            aqua_version= package_name=golangci/golangci-lint package_version=v1.45.2 program=aqua registry=standard
INFO[0000] download and unarchive the package            aqua_version= package_name=rhysd/actionlint package_version=v1.6.12 program=aqua registry=standard
INFO[0000] download and unarchive the package            aqua_version= package_name=reviewdog/reviewdog package_version=v0.14.0 program=aqua registry=standard

$ tree /Users/shunsuke-suzuki/.local/share/aquaproj-aqua/pkgs/github_release/github.com/reviewdog/reviewdog 
/Users/shunsuke-suzuki/.local/share/aquaproj-aqua/pkgs/github_release/github.com/reviewdog/reviewdog
├── v0.13.1
│   └── reviewdog_0.13.1_Darwin_x86_64.tar.gz
│       ├── LICENSE
│       ├── README.md
│       └── reviewdog
└── v0.14.0
    ├── reviewdog_0.14.0_Darwin_x86_64.tar.gz
    │   ├── LICENSE
    │   ├── README.md
    │   └── reviewdog
    └── reviewdog_0.14.0_Linux_arm64.tar.gz
        ├── LICENSE
        ├── README.md
        └── reviewdog
```