### PR TITLE
feat: support aliases

### DIFF
--- a/json-schema/registry.json
+++ b/json-schema/registry.json
@@ -3,6 +3,18 @@
   "$id": "https://github.com/aquaproj/aqua/pkg/config/registry-content",
   "$ref": "#/$defs/RegistryContent",
   "$defs": {
+    "Alias": {
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ]
+    },
     "File": {
       "properties": {
         "name": {
@@ -210,6 +222,12 @@
         },
         "rosetta2": {
           "type": "boolean"
+        },
+        "aliases": {
+          "items": {
+            "$ref": "#/$defs/Alias"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": false,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -95,6 +95,9 @@ func (pkgInfos *PackageInfos) ToMap() (map[string]*PackageInfo, error) {
 			})
 		}
 		m[name] = pkgInfo
+		for _, alias := range pkgInfo.Aliases {
+			m[alias.Name] = pkgInfo
+		}
 	}
 	return m, nil
 }

--- a/pkg/config/package_info.go
+++ b/pkg/config/package_info.go
@@ -31,6 +31,11 @@ type PackageInfo struct {
 	SupportedIf        *constraint.PackageCondition   `yaml:"supported_if" json:"supported_if,omitempty"`
 	VersionFilter      *constraint.VersionFilter      `yaml:"version_filter" json:"version_filter,omitempty"`
 	Rosetta2           *bool                          `json:"rosetta2,omitempty"`
+	Aliases            []*Alias                       `json:"aliases,omitempty"`
+}
+
+type Alias struct {
+	Name string `json:"name"`
 }
 
 type VersionOverride struct {

--- a/pkg/controller/generate/finder.go
+++ b/pkg/controller/generate/finder.go
@@ -17,10 +17,19 @@ func (ctrl *Controller) launchFuzzyFinder(pkgs []*FindingPackage) ([]int, error)
 		}
 		fileNamesStr := strings.Join(fileNames, ", ")
 		pkgName := pkg.PackageInfo.GetName()
-		if strings.HasSuffix(pkgName, "/"+fileNamesStr) || pkgName == fileNamesStr {
-			return fmt.Sprintf("%s (%s)", pkgName, pkg.RegistryName)
+		aliases := make([]string, len(pkg.PackageInfo.Aliases))
+		for i, alias := range pkg.PackageInfo.Aliases {
+			aliases[i] = alias.Name
 		}
-		return fmt.Sprintf("%s (%s) (%s)", pkgName, pkg.RegistryName, fileNamesStr)
+		item := pkgName
+		if len(aliases) != 0 {
+			item += " (" + strings.Join(aliases, ", ") + ")"
+		}
+		item += " (" + pkg.RegistryName + ")"
+		if strings.HasSuffix(pkgName, "/"+fileNamesStr) || pkgName == fileNamesStr {
+			return item
+		}
+		return item + " (" + fileNamesStr + ")"
 	},
 		fuzzyfinder.WithPreviewWindow(func(i, w, h int) string {
 			if i < 0 {

--- a/pkg/controller/generate/generate.go
+++ b/pkg/controller/generate/generate.go
@@ -137,6 +137,12 @@ func (ctrl *Controller) outputListedPkgs(ctx context.Context, logE *logrus.Entry
 				PackageInfo:  pkg,
 				RegistryName: registryName,
 			}
+			for _, alias := range pkg.Aliases {
+				m[registryName+","+alias.Name] = &FindingPackage{
+					PackageInfo:  pkg,
+					RegistryName: registryName,
+				}
+			}
 		}
 	}
 

--- a/tests/aqua-global.yaml
+++ b/tests/aqua-global.yaml
@@ -53,3 +53,8 @@ packages:
 - name: aristocratos/btop@v1.2.6
   # replacements_overrides
   registry: local
+
+- name: ahmetb/kubens
+  # alias
+  registry: local
+  version: v0.9.4 # renovate: depName=ahmetb/kubectx

--- a/tests/registry.yaml
+++ b/tests/registry.yaml
@@ -67,3 +67,21 @@ packages:
   files:
   - name: btop
     src: bin/btop
+
+- name: ahmetb/kubectx/kubens
+  aliases:
+  - name: ahmetb/kubens
+  type: github_release
+  repo_owner: ahmetb
+  repo_name: kubectx
+  asset: "kubens_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}"
+  description: Faster way to switch between clusters and namespaces in kubectl
+  files:
+  - name: kubens
+  replacements:
+    386: i386
+    amd64: x86_64
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip


### PR DESCRIPTION
Close #674

aqua.yaml

```yaml
---
# aqua - Declarative CLI Version Manager
# https://aquaproj.github.io/
registries:
- type: local
  name: local
  path: registry.yaml
packages:
- name: ahmetb/kubens
  registry: local
  version: v0.9.4
```

registry.yaml

```yaml
packages:
- name: ahmetb/kubectx/kubens
  aliases:
  - name: ahmetb/kubens
  type: github_release
  repo_owner: ahmetb
  repo_name: kubectx
  asset: "kubens_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}"
  description: Faster way to switch between clusters and namespaces in kubectl
  files:
  - name: kubens
  replacements:
    386: i386
    amd64: x86_64
  format: tar.gz
  format_overrides:
  - goos: windows
    format: zip
```

```console
$ aqua list
local,ahmetb/kubectx/kubens
```

```console
$ aqua g local,ahmetb/kubens
- name: ahmetb/kubectx/kubens@v0.9.4
  registry: local
```

```console
$ kubens -V
0.9.4
```

```console
$ aqua i
INFO[0000] download and unarchive the package            aqua_version= package_name=ahmetb/kubens package_version=v0.9.4 program=aqua registry=local
```