### PR TITLE
perf: support JSON as Registry Configuration

### DIFF
--- a/pkg/config/registry_test.go
+++ b/pkg/config/registry_test.go
@@ -1,9 +1,16 @@
 package config_test
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/aquaproj/aqua/pkg/config"
+	"gopkg.in/yaml.v2"
 )
 
 func TestRegistry_GetFilePath(t *testing.T) {
@@ -68,4 +75,72 @@ func TestLocalRegistry_GetFilePath(t *testing.T) {
 			}
 		})
 	}
+}
+
+func downloadTestFile(uri, tempDir string) (string, error) {
+	req, err := http.NewRequest(http.MethodGet, uri, nil) //nolint:noctx
+	if err != nil {
+		return "", fmt.Errorf("create a request: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("send a HTTP request: %w", err)
+	}
+	defer resp.Body.Close()
+	fileName := "registry.yaml"
+	if filepath.Ext(uri) == ".json" {
+		fileName = "registry.json"
+	}
+	filePath := filepath.Join(tempDir, fileName)
+	f, err := os.Create(filePath)
+	if err != nil {
+		return "", fmt.Errorf("create a file: %w", err)
+	}
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		return "", fmt.Errorf("write a response body to a file: %w", err)
+	}
+	return filePath, nil
+}
+
+func BenchmarkReadRegistry(b *testing.B) {
+	b.Run("yaml", func(b *testing.B) {
+		registryYAML, err := downloadTestFile("https://raw.githubusercontent.com/aquaproj/aqua-registry/main/registry.yaml", b.TempDir())
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			func() {
+				f, err := os.Open(registryYAML)
+				if err != nil {
+					b.Fatal(err)
+				}
+				defer f.Close()
+				registry := &config.RegistryContent{}
+				if err := yaml.NewDecoder(f).Decode(registry); err != nil {
+					b.Fatal(err)
+				}
+			}()
+		}
+	})
+	b.Run("json", func(b *testing.B) {
+		registryJSON, err := downloadTestFile("https://raw.githubusercontent.com/aquaproj/aqua-registry/feat/registry-json/registry.json", b.TempDir())
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			func() {
+				f, err := os.Open(registryJSON)
+				if err != nil {
+					b.Fatal(err)
+				}
+				defer f.Close()
+				registry := &config.RegistryContent{}
+				if err := json.NewDecoder(f).Decode(registry); err != nil {
+					b.Fatal(err)
+				}
+			}()
+		}
+	})
 }

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -2,6 +2,7 @@ package template
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"text/template"
@@ -40,6 +41,15 @@ func (tpl *Template) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var raw string
 	if err := unmarshal(&raw); err != nil {
 		return err
+	}
+	tpl.raw = raw
+	return nil
+}
+
+func (tpl *Template) UnmarshalJSON(b []byte) error {
+	var raw string
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return fmt.Errorf("parse a template as JSON: %w", err)
 	}
 	tpl.raw = raw
 	return nil

--- a/pkg/version-constraint/package_condition.go
+++ b/pkg/version-constraint/package_condition.go
@@ -1,6 +1,7 @@
 package constraint
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/antonmedv/expr"
@@ -68,6 +69,15 @@ func (pkgCondition *PackageCondition) UnmarshalYAML(unmarshal func(interface{}) 
 	var raw string
 	if err := unmarshal(&raw); err != nil {
 		return err
+	}
+	pkgCondition.raw = raw
+	return nil
+}
+
+func (pkgCondition *PackageCondition) UnmarshalJSON(b []byte) error {
+	var raw string
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return fmt.Errorf("unmarshal package condition as JSON: %w", err)
 	}
 	pkgCondition.raw = raw
 	return nil

--- a/pkg/version-constraint/version_constraint.go
+++ b/pkg/version-constraint/version_constraint.go
@@ -1,6 +1,7 @@
 package constraint
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -101,6 +102,15 @@ func (constraints *VersionConstraints) UnmarshalYAML(unmarshal func(interface{})
 	var raw string
 	if err := unmarshal(&raw); err != nil {
 		return err
+	}
+	constraints.raw = raw
+	return nil
+}
+
+func (constraints *VersionConstraints) UnmarshalJSON(b []byte) error {
+	var raw string
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return fmt.Errorf("unmarshal version constraint as JSON: %w", err)
 	}
 	constraints.raw = raw
 	return nil

--- a/pkg/version-constraint/version_filter.go
+++ b/pkg/version-constraint/version_filter.go
@@ -1,6 +1,7 @@
 package constraint
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -78,6 +79,15 @@ func (vf *VersionFilter) UnmarshalYAML(unmarshal func(interface{}) error) error 
 	var raw string
 	if err := unmarshal(&raw); err != nil {
 		return err
+	}
+	vf.raw = raw
+	return nil
+}
+
+func (vf *VersionFilter) UnmarshalJSON(b []byte) error {
+	var raw string
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return fmt.Errorf("unmarshal version filter as JSON: %w", err)
 	}
 	vf.raw = raw
 	return nil


### PR DESCRIPTION
Close #677

## Benchmark Tests

Compare JSON with YAML.

```console
$ go test -bench . -benchmem
goos: darwin
goarch: arm64
pkg: github.com/aquaproj/aqua/pkg/config
BenchmarkReadRegistry/yaml-8         	     198	   5812580 ns/op	 2613083 B/op	   59282 allocs/op
BenchmarkReadRegistry/json-8         	     588	   1711825 ns/op	 1087863 B/op	   10940 allocs/op
PASS
ok  	github.com/aquaproj/aqua/pkg/config	5.779s
```

JSON is much faster than YAML.

## Benchmark Tests with hyperfine

https://github.com/sharkdp/hyperfine

```console
$ hyperfine --version
hyperfine 1.13.0
```

```yaml
---
# aqua - Declarative CLI Version Manager
# https://aquaproj.github.io/
registries:
  - type: local
    name: local
    path: registry.json # registry.yaml

packages:
  - name: suzuki-shunsuke/tfcmt@v3.2.1
    registry: local
```

```console
$ hyperfine -N --warmup 3 'tfcmt -v' '/Users/shunsukesuzuki/.local/share/aquaproj-aqua/pkgs/github_release/github.com/suzuki-shunsuke/tfcmt/v3.2.1/tfcmt_darwin_arm64.tar.gz/tfcmt -v'
Benchmark 1: tfcmt -v
  Time (mean ± σ):      19.2 ms ±   0.3 ms    [User: 15.3 ms, System: 5.8 ms]
  Range (min … max):    18.4 ms …  20.1 ms    159 runs
 
Benchmark 2: /Users/shunsukesuzuki/.local/share/aquaproj-aqua/pkgs/github_release/github.com/suzuki-shunsuke/tfcmt/v3.2.1/tfcmt_darwin_arm64.tar.gz/tfcmt -v
  Time (mean ± σ):       3.2 ms ±   0.1 ms    [User: 1.9 ms, System: 1.0 ms]
  Range (min … max):     3.1 ms …   3.8 ms    898 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Summary
  '/Users/shunsukesuzuki/.local/share/aquaproj-aqua/pkgs/github_release/github.com/suzuki-shunsuke/tfcmt/v3.2.1/tfcmt_darwin_arm64.tar.gz/tfcmt -v' ran
    5.92 ± 0.16 times faster than 'tfcmt -v'
```

```console
$ hyperfine -N --warmup 3 'tfcmt -v' '/Users/shunsukesuzuki/.local/share/aquaproj-aqua/pkgs/github_release/github.com/suzuki-shunsuke/tfcmt/v3.2.1/tfcmt_darwin_arm64.tar.gz/tfcmt -v'
Benchmark 1: tfcmt -v
  Time (mean ± σ):      15.0 ms ±   0.2 ms    [User: 9.9 ms, System: 5.3 ms]
  Range (min … max):    14.4 ms …  15.5 ms    198 runs
 
Benchmark 2: /Users/shunsukesuzuki/.local/share/aquaproj-aqua/pkgs/github_release/github.com/suzuki-shunsuke/tfcmt/v3.2.1/tfcmt_darwin_arm64.tar.gz/tfcmt -v
  Time (mean ± σ):       3.3 ms ±   0.1 ms    [User: 1.9 ms, System: 1.0 ms]
  Range (min … max):     3.1 ms …   4.0 ms    928 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Summary
  '/Users/shunsukesuzuki/.local/share/aquaproj-aqua/pkgs/github_release/github.com/suzuki-shunsuke/tfcmt/v3.2.1/tfcmt_darwin_arm64.tar.gz/tfcmt -v' ran
    4.62 ± 0.13 times faster than 'tfcmt -v'
```

```console
$ hyperfine -N --warmup 3 'env AQUA_CONFIG=aqua.yaml tfcmt -v' 'env AQUA_CONFIG=aqua-json.yaml tfcmt -v'
Benchmark 1: env AQUA_CONFIG=aqua.yaml tfcmt -v
  Time (mean ± σ):      24.4 ms ±   0.4 ms    [User: 17.1 ms, System: 7.1 ms]
  Range (min … max):    23.6 ms …  25.4 ms    121 runs
 
Benchmark 2: env AQUA_CONFIG=aqua-json.yaml tfcmt -v
  Time (mean ± σ):      20.2 ms ±   0.4 ms    [User: 11.4 ms, System: 6.5 ms]
  Range (min … max):    19.4 ms …  21.1 ms    144 runs
 
Summary
  'env AQUA_CONFIG=aqua-json.yaml tfcmt -v' ran
    1.21 ± 0.03 times faster than 'env AQUA_CONFIG=aqua.yaml tfcmt -v'
```