### PR TITLE
Benchmark Testing: make RegistryContent struct simple

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -112,6 +112,11 @@ type FormatOverride struct {
 	Format string `yaml:"format" json:"format" jsonschema:"example=tar.gz,example=raw"`
 }
 
+type FileSimple struct {
+	Name string `validate:"required" json:"name,omitempty"`
+	Src  string `json:"src,omitempty"`
+}
+
 type File struct {
 	Name string             `validate:"required" json:"name,omitempty"`
 	Src  *template.Template `json:"src,omitempty"`

--- a/pkg/config/package_info.go
+++ b/pkg/config/package_info.go
@@ -11,6 +11,29 @@ import (
 	constraint "github.com/aquaproj/aqua/pkg/version-constraint"
 )
 
+type PackageInfoSimple struct {
+	Name               string                   `json:"name,omitempty"`
+	Type               string                   `validate:"required" json:"type" jsonschema:"enum=github_release,enum=github_content,enum=github_archive,enum=http"`
+	RepoOwner          string                   `yaml:"repo_owner" json:"repo_owner,omitempty"`
+	RepoName           string                   `yaml:"repo_name" json:"repo_name,omitempty"`
+	Asset              string                   `json:"asset,omitempty"`
+	Path               string                   `json:"path,omitempty"`
+	Format             string                   `json:"format,omitempty" jsonschema:"example=tar.gz,example=raw"`
+	Files              []*FileSimple            `json:"files,omitempty"`
+	URL                string                   `json:"url,omitempty"`
+	Description        string                   `json:"description,omitempty"`
+	Link               string                   `json:"link,omitempty"`
+	Replacements       map[string]string        `json:"replacements,omitempty"`
+	Overrides          []*OverrideSimple        `json:"overrides,omitempty"`
+	FormatOverrides    []*FormatOverride        `yaml:"format_overrides" json:"format_overrides,omitempty"`
+	VersionConstraints string                   `yaml:"version_constraint" json:"version_constraint,omitempty"`
+	VersionOverrides   []*VersionOverrideSimple `yaml:"version_overrides" json:"version_overrides,omitempty"`
+	SupportedIf        string                   `yaml:"supported_if" json:"supported_if,omitempty"`
+	VersionFilter      string                   `yaml:"version_filter" json:"version_filter,omitempty"`
+	Rosetta2           *bool                    `json:"rosetta2,omitempty"`
+	Aliases            []*Alias                 `json:"aliases,omitempty"`
+}
+
 type PackageInfo struct {
 	Name               string                         `json:"name,omitempty"`
 	Type               string                         `validate:"required" json:"type" jsonschema:"enum=github_release,enum=github_content,enum=github_archive,enum=http"`
@@ -36,6 +59,24 @@ type PackageInfo struct {
 
 type Alias struct {
 	Name string `json:"name"`
+}
+
+type VersionOverrideSimple struct {
+	Type               string            `json:"type,omitempty" jsonschema:"enum=github_release,enum=github_content,enum=github_archive,enum=http"`
+	RepoOwner          string            `yaml:"repo_owner" json:"repo_owner,omitempty"`
+	RepoName           string            `yaml:"repo_name" json:"repo_name,omitempty"`
+	Asset              string            `json:"asset,omitempty"`
+	Path               string            `json:"path,omitempty"`
+	Format             string            `json:"format,omitempty" jsonschema:"example=tar.gz,example=raw"`
+	Files              []*FileSimple     `json:"files,omitempty"`
+	URL                string            `json:"url,omitempty"`
+	Replacements       map[string]string `json:"replacements,omitempty"`
+	Overrides          []*OverrideSimple `json:"overrides,omitempty"`
+	FormatOverrides    []*FormatOverride `yaml:"format_overrides" json:"format_overrides,omitempty"`
+	SupportedIf        string            `yaml:"supported_if" json:"supported_if,omitempty"`
+	VersionConstraints string            `yaml:"version_constraint" json:"version_constraint,omitempty"`
+	VersionFilter      string            `yaml:"version_filter" json:"version_filter,omitempty"`
+	Rosetta2           *bool             `json:"rosetta2,omitempty"`
 }
 
 type VersionOverride struct {

--- a/pkg/config/registry.go
+++ b/pkg/config/registry.go
@@ -16,6 +16,10 @@ var (
 	errRefIsRequired       = errors.New("ref is required for github_content registry")
 )
 
+type RegistryContentSimple struct {
+	PackageInfos []*PackageInfoSimple `yaml:"packages" validate:"dive" json:"packages"`
+}
+
 type RegistryContent struct {
 	PackageInfos PackageInfos `yaml:"packages" validate:"dive" json:"packages"`
 }

--- a/pkg/config/registry_test.go
+++ b/pkg/config/registry_test.go
@@ -102,7 +102,7 @@ func downloadTestFile(uri, tempDir string) (string, error) {
 	return filePath, nil
 }
 
-func BenchmarkReadRegistry(b *testing.B) {
+func BenchmarkReadRegistry(b *testing.B) { //nolint:gocognit,funlen,cyclop
 	b.Run("yaml", func(b *testing.B) {
 		registryYAML, err := downloadTestFile("https://raw.githubusercontent.com/aquaproj/aqua-registry/v2.11.1/registry.yaml", b.TempDir())
 		if err != nil {
@@ -137,6 +137,46 @@ func BenchmarkReadRegistry(b *testing.B) {
 				}
 				defer f.Close()
 				registry := &config.RegistryContent{}
+				if err := json.NewDecoder(f).Decode(registry); err != nil {
+					b.Fatal(err)
+				}
+			}()
+		}
+	})
+	b.Run("yaml-simple", func(b *testing.B) {
+		registryYAML, err := downloadTestFile("https://raw.githubusercontent.com/aquaproj/aqua-registry/v2.11.1/registry.yaml", b.TempDir())
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			func() {
+				f, err := os.Open(registryYAML)
+				if err != nil {
+					b.Fatal(err)
+				}
+				defer f.Close()
+				registry := &config.RegistryContentSimple{}
+				if err := yaml.NewDecoder(f).Decode(registry); err != nil {
+					b.Fatal(err)
+				}
+			}()
+		}
+	})
+	b.Run("json-simple", func(b *testing.B) {
+		registryJSON, err := downloadTestFile("https://raw.githubusercontent.com/aquaproj/aqua-registry/v2.11.1/registry.json", b.TempDir())
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			func() {
+				f, err := os.Open(registryJSON)
+				if err != nil {
+					b.Fatal(err)
+				}
+				defer f.Close()
+				registry := &config.RegistryContentSimple{}
 				if err := json.NewDecoder(f).Decode(registry); err != nil {
 					b.Fatal(err)
 				}

--- a/pkg/config/replacements.go
+++ b/pkg/config/replacements.go
@@ -5,6 +5,16 @@ import (
 	"github.com/aquaproj/aqua/pkg/template"
 )
 
+type OverrideSimple struct {
+	GOOS         string            `json:"goos,omitempty" jsonschema:"enum=aix,enum=android,enum=darwin,enum=dragonfly,enum=freebsd,enum=illumos,enum=ios,enum=js,enum=linux,enum=netbsd,enum=openbsd,enum=plan9,enum=solaris,enum=windows"`
+	GOArch       string            `json:"goarch,omitempty" jsonschema:"enum=386,enum=amd64,enum=arm,enum=arm64,enum=mips,enum=mips64,enum=mips64le,enum=mipsle,enum=ppc64,enum=ppc64le,enum=riscv64,enum=s390x,enum=wasm"`
+	Replacements map[string]string `json:"replacements,omitempty"`
+	Format       string            `json:"format,omitempty" jsonschema:"example=tar.gz,example=raw"`
+	Asset        string            `json:"asset,omitempty"`
+	Files        []*FileSimple     `json:"files,omitempty"`
+	URL          string            `json:"url,omitempty"`
+}
+
 type Override struct {
 	GOOS         string             `json:"goos,omitempty" jsonschema:"enum=aix,enum=android,enum=darwin,enum=dragonfly,enum=freebsd,enum=illumos,enum=ios,enum=js,enum=linux,enum=netbsd,enum=openbsd,enum=plan9,enum=solaris,enum=windows"`
 	GOArch       string             `json:"goarch,omitempty" jsonschema:"enum=386,enum=amd64,enum=arm,enum=arm64,enum=mips,enum=mips64,enum=mips64le,enum=mipsle,enum=ppc64,enum=ppc64le,enum=riscv64,enum=s390x,enum=wasm"`


### PR DESCRIPTION
#693

I've confirmed that the performance is improved by making the struct `RegistryContent` simple.

```console
$ go test -bench . -benchmem 
goos: darwin
goarch: arm64
pkg: github.com/aquaproj/aqua/pkg/config
BenchmarkReadRegistry/yaml-8         	     193	   5649011 ns/op	 2613092 B/op	   59282 allocs/op
BenchmarkReadRegistry/json-8         	     705	   1757866 ns/op	 1087853 B/op	   10940 allocs/op
BenchmarkReadRegistry/yaml-simple-8  	     214	   5562417 ns/op	 2571065 B/op	   56714 allocs/op
BenchmarkReadRegistry/json-simple-8  	     811	   1434173 ns/op	  949979 B/op	    8372 allocs/op
PASS
ok  	github.com/aquaproj/aqua/pkg/config	8.897s
```

Change `*template.Template` to `string`, etc.