### PR TITLE
fix: copy PackageInfo instead of updating

### DIFF
--- a/pkg/config/override.go
+++ b/pkg/config/override.go
@@ -2,12 +2,13 @@ package config
 
 import "github.com/aquaproj/aqua/pkg/runtime"
 
-func (pkgInfo *PackageInfo) Override(v string, rt *runtime.Runtime) error {
-	if err := pkgInfo.setVersion(v); err != nil {
-		return err
+func (pkgInfo *PackageInfo) Override(v string, rt *runtime.Runtime) (*PackageInfo, error) {
+	pkg, err := pkgInfo.setVersion(v)
+	if err != nil {
+		return nil, err
 	}
-	pkgInfo.override(rt)
-	return nil
+	pkg.override(rt)
+	return pkg, nil
 }
 
 func (pkgInfo *PackageInfo) getOverride(rt *runtime.Runtime) *Override {
@@ -17,42 +18,4 @@ func (pkgInfo *PackageInfo) getOverride(rt *runtime.Runtime) *Override {
 		}
 	}
 	return nil
-}
-
-func (pkgInfo *PackageInfo) override(rt *runtime.Runtime) {
-	for _, fo := range pkgInfo.FormatOverrides {
-		if fo.GOOS == rt.GOOS {
-			pkgInfo.Format = fo.Format
-			break
-		}
-	}
-
-	ov := pkgInfo.getOverride(rt)
-	if ov == nil {
-		return
-	}
-
-	if pkgInfo.Replacements == nil {
-		pkgInfo.Replacements = ov.Replacements
-	} else {
-		for k, v := range ov.Replacements {
-			pkgInfo.Replacements[k] = v
-		}
-	}
-
-	if ov.Format != "" {
-		pkgInfo.Format = ov.Format
-	}
-
-	if ov.Asset != nil {
-		pkgInfo.Asset = ov.Asset
-	}
-
-	if ov.Files != nil {
-		pkgInfo.Files = ov.Files
-	}
-
-	if ov.URL != nil {
-		pkgInfo.URL = ov.URL
-	}
 }

--- a/pkg/config/package_info.go
+++ b/pkg/config/package_info.go
@@ -34,8 +34,122 @@ type PackageInfo struct {
 	Aliases            []*Alias                       `json:"aliases,omitempty"`
 }
 
-type Alias struct {
-	Name string `json:"name"`
+func (pkgInfo *PackageInfo) overrideVersion(child *VersionOverride) *PackageInfo { //nolint:cyclop,funlen
+	pkg := &PackageInfo{
+		Name:        pkgInfo.Name,
+		Link:        pkgInfo.Link,
+		Description: pkgInfo.Description,
+		Aliases:     pkgInfo.Aliases,
+	}
+	if child.Type == "" {
+		pkg.Type = pkgInfo.Type
+	} else {
+		pkg.Type = child.Type
+	}
+	if child.RepoOwner == "" {
+		pkg.RepoOwner = pkgInfo.RepoOwner
+	} else {
+		pkg.RepoOwner = child.RepoOwner
+	}
+	if child.RepoName == "" {
+		pkg.RepoName = pkgInfo.RepoName
+	} else {
+		pkg.RepoName = child.RepoName
+	}
+	if child.Asset == nil {
+		pkg.Asset = pkgInfo.Asset
+	} else {
+		pkg.Asset = child.Asset
+	}
+	if child.Path == nil {
+		pkg.Path = pkgInfo.Path
+	} else {
+		pkg.Path = child.Path
+	}
+	if child.Format == "" {
+		pkg.Format = pkgInfo.Format
+	} else {
+		pkg.Format = child.Format
+	}
+	if child.Files == nil {
+		pkg.Files = pkgInfo.Files
+	} else {
+		pkg.Files = child.Files
+	}
+	if child.URL == nil {
+		pkg.URL = pkgInfo.URL
+	} else {
+		pkg.URL = child.URL
+	}
+	if child.Replacements == nil {
+		pkg.Replacements = pkgInfo.Replacements
+	} else {
+		pkg.Replacements = child.Replacements
+	}
+	if child.Overrides == nil {
+		pkg.Overrides = pkgInfo.Overrides
+	} else {
+		pkg.Overrides = child.Overrides
+	}
+	if child.FormatOverrides == nil {
+		pkg.FormatOverrides = pkgInfo.FormatOverrides
+	} else {
+		pkg.FormatOverrides = child.FormatOverrides
+	}
+	if child.SupportedIf == nil {
+		pkg.SupportedIf = pkgInfo.SupportedIf
+	} else {
+		pkg.SupportedIf = child.SupportedIf
+	}
+	if child.VersionFilter == nil {
+		pkg.VersionFilter = pkgInfo.VersionFilter
+	} else {
+		pkg.VersionFilter = child.VersionFilter
+	}
+	if child.Rosetta2 == nil {
+		pkg.Rosetta2 = pkgInfo.Rosetta2
+	} else {
+		pkg.Rosetta2 = child.Rosetta2
+	}
+	return pkg
+}
+
+func (pkgInfo *PackageInfo) override(rt *runtime.Runtime) {
+	for _, fo := range pkgInfo.FormatOverrides {
+		if fo.GOOS == rt.GOOS {
+			pkgInfo.Format = fo.Format
+			break
+		}
+	}
+
+	ov := pkgInfo.getOverride(rt)
+	if ov == nil {
+		return
+	}
+
+	if pkgInfo.Replacements == nil {
+		pkgInfo.Replacements = ov.Replacements
+	} else {
+		for k, v := range ov.Replacements {
+			pkgInfo.Replacements[k] = v
+		}
+	}
+
+	if ov.Format != "" {
+		pkgInfo.Format = ov.Format
+	}
+
+	if ov.Asset != nil {
+		pkgInfo.Asset = ov.Asset
+	}
+
+	if ov.Files != nil {
+		pkgInfo.Files = ov.Files
+	}
+
+	if ov.URL != nil {
+		pkgInfo.URL = ov.URL
+	}
 }
 
 type VersionOverride struct {
@@ -54,6 +168,10 @@ type VersionOverride struct {
 	VersionConstraints *constraint.VersionConstraints `yaml:"version_constraint" json:"version_constraint,omitempty"`
 	VersionFilter      *string                        `yaml:"version_filter" json:"version_filter,omitempty"`
 	Rosetta2           *bool                          `json:"rosetta2,omitempty"`
+}
+
+type Alias struct {
+	Name string `json:"name"`
 }
 
 func (pkgInfo *PackageInfo) GetRosetta2() bool {

--- a/pkg/config/package_info_internal_test.go
+++ b/pkg/config/package_info_internal_test.go
@@ -56,8 +56,8 @@ func TestPackageInfo_overrideVersion(t *testing.T) {
 		d := d
 		t.Run(d.title, func(t *testing.T) {
 			t.Parallel()
-			d.pkgInfo.overrideVersion(d.child)
-			if diff := cmp.Diff(d.exp, d.pkgInfo, cmp.AllowUnexported(template.Template{})); diff != "" {
+			pkgInfo := d.pkgInfo.overrideVersion(d.child)
+			if diff := cmp.Diff(d.exp, pkgInfo, cmp.AllowUnexported(template.Template{})); diff != "" {
 				t.Fatal(diff)
 			}
 		})
@@ -100,15 +100,8 @@ func TestPackageInfo_setVersion(t *testing.T) { //nolint:funlen
 		{
 			title: "child version constraint",
 			exp: &PackageInfo{
-				Type:               "github_content",
-				Path:               template.NewTemplate("bar"),
-				VersionConstraints: constraint.NewVersionConstraints(`semver(">= 0.4.0")`),
-				VersionOverrides: []*VersionOverride{
-					{
-						VersionConstraints: constraint.NewVersionConstraints(`semver("< 0.4.0")`),
-						Path:               template.NewTemplate("bar"),
-					},
-				},
+				Type: "github_content",
+				Path: template.NewTemplate("bar"),
 			},
 			pkgInfo: &PackageInfo{
 				Type:               "github_content",
@@ -128,10 +121,11 @@ func TestPackageInfo_setVersion(t *testing.T) { //nolint:funlen
 		d := d
 		t.Run(d.title, func(t *testing.T) {
 			t.Parallel()
-			if err := d.pkgInfo.setVersion(d.version); err != nil {
+			pkgInfo, err := d.pkgInfo.setVersion(d.version)
+			if err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(d.pkgInfo, d.exp, cmpopts.IgnoreUnexported(constraint.VersionConstraints{}), cmp.AllowUnexported(template.Template{})); diff != "" {
+			if diff := cmp.Diff(pkgInfo, d.exp, cmpopts.IgnoreUnexported(constraint.VersionConstraints{}), cmp.AllowUnexported(template.Template{})); diff != "" {
 				t.Fatal(diff)
 			}
 		})

--- a/pkg/config/version_override.go
+++ b/pkg/config/version_override.go
@@ -1,70 +1,24 @@
 package config
 
-func (pkgInfo *PackageInfo) setVersion(v string) error {
+func (pkgInfo *PackageInfo) setVersion(v string) (*PackageInfo, error) {
 	if pkgInfo.VersionConstraints == nil {
-		return nil
+		return pkgInfo, nil
 	}
 	a, err := pkgInfo.VersionConstraints.Check(v)
 	if err != nil {
-		return err //nolint:wrapcheck
+		return nil, err //nolint:wrapcheck
 	}
 	if a {
-		return nil
+		return pkgInfo, nil
 	}
 	for _, vo := range pkgInfo.VersionOverrides {
 		a, err := vo.VersionConstraints.Check(v)
 		if err != nil {
-			return err //nolint:wrapcheck
+			return nil, err //nolint:wrapcheck
 		}
 		if a {
-			pkgInfo.overrideVersion(vo)
-			return nil
+			return pkgInfo.overrideVersion(vo), nil
 		}
 	}
-	return nil
-}
-
-func (pkgInfo *PackageInfo) overrideVersion(child *VersionOverride) { //nolint:cyclop
-	if child.Type != "" {
-		pkgInfo.Type = child.Type
-	}
-	if child.RepoOwner != "" {
-		pkgInfo.RepoOwner = child.RepoOwner
-	}
-	if child.RepoName != "" {
-		pkgInfo.RepoName = child.RepoName
-	}
-	if child.Asset != nil {
-		pkgInfo.Asset = child.Asset
-	}
-	if child.Path != nil {
-		pkgInfo.Path = child.Path
-	}
-	if child.Format != "" {
-		pkgInfo.Format = child.Format
-	}
-	if child.Files != nil {
-		pkgInfo.Files = child.Files
-	}
-	if child.URL != nil {
-		pkgInfo.URL = child.URL
-	}
-	if child.Replacements != nil {
-		pkgInfo.Replacements = child.Replacements
-	}
-	if child.Overrides != nil {
-		pkgInfo.Overrides = child.Overrides
-	}
-	if child.FormatOverrides != nil {
-		pkgInfo.FormatOverrides = child.FormatOverrides
-	}
-	if child.SupportedIf != nil {
-		pkgInfo.SupportedIf = child.SupportedIf
-	}
-	if child.Rosetta2 != nil {
-		pkgInfo.Rosetta2 = child.Rosetta2
-	}
-	if child.VersionFilter != nil {
-		pkgInfo.VersionFilter = child.VersionFilter
-	}
+	return pkgInfo, nil
 }

--- a/pkg/controller/which/which.go
+++ b/pkg/controller/which/which.go
@@ -163,7 +163,8 @@ func (ctrl *controller) findExecFileFromPkg(registries map[string]*config.Regist
 		return nil, nil
 	}
 
-	if err := pkgInfo.Override(pkg.Version, ctrl.runtime); err != nil {
+	pkgInfo, err = pkgInfo.Override(pkg.Version, ctrl.runtime)
+	if err != nil {
 		logerr.WithError(logE, err).Warn("version constraint is invalid")
 		return nil, nil
 	}

--- a/pkg/installpackage/installer.go
+++ b/pkg/installpackage/installer.go
@@ -46,7 +46,8 @@ func (inst *installer) InstallPackages(ctx context.Context, cfg *config.Config, 
 			continue
 		}
 
-		if err := pkgInfo.Override(pkg.Version, inst.runtime); err != nil {
+		pkgInfo, err = pkgInfo.Override(pkg.Version, inst.runtime)
+		if err != nil {
 			return fmt.Errorf("evaluate version constraints: %w", err)
 		}
 		if pkgInfo.SupportedIf != nil {
@@ -122,7 +123,8 @@ func (inst *installer) InstallPackages(ctx context.Context, cfg *config.Config, 
 				return
 			}
 
-			if err := pkgInfo.Override(pkg.Version, inst.runtime); err != nil {
+			pkgInfo, err = pkgInfo.Override(pkg.Version, inst.runtime)
+			if err != nil {
 				logerr.WithError(logE, err).Error("install the package")
 				handleFailure()
 				return


### PR DESCRIPTION
Close #694

I've confirmed that the bug has been fixed.

```console
$ aqua i                                                                                                
INFO[0000] download and unarchive the package            aqua_version= package_name=Arriven/db1000n package_version=v0.8.19 program=aqua registry=standard registry_ref=v2.11.1
INFO[0000] download and unarchive the package            aqua_version= package_name=Arriven/db1000n package_version=v0.8.33 program=aqua registry=standard registry_ref=v2.11.1
```