### PR TITLE
feat: add the information about runtime to log

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,6 +1,8 @@
 package log
 
 import (
+	"runtime"
+
 	"github.com/sirupsen/logrus"
 )
 
@@ -8,6 +10,7 @@ func New(version string) *logrus.Entry {
 	return logrus.WithFields(logrus.Fields{
 		"aqua_version": version,
 		"program":      "aqua",
+		"env":          runtime.GOOS + "/" + runtime.GOARCH,
 	})
 }
 


### PR DESCRIPTION
e.g.

```
DEBU[0000] check the permission                          aqua_version= env=darwin/arm64 file_name=golangci-lint package_name=golangci/golangci-lint package_version=v1.46.2 program=aqua registry=standard registry_ref=v2.16.0
```

```
env=darwin/arm64
```