### PR TITLE
feat: support building Go tool to install

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -51,6 +51,7 @@ jobs:
     - run: btop -v
       env:
         AQUA_EXPERIMENTAL_X_SYS_EXEC: "true"
+    - run: wire --help
 
     - run: aqua g -i suzuki-shunsuke/tfcmt
       working-directory: tests

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -69,6 +69,7 @@ const (
 	PkgInfoTypeGitHubContent = "github_content"
 	PkgInfoTypeGitHubArchive = "github_archive"
 	PkgInfoTypeHTTP          = "http"
+	PkgInfoTypeGo            = "go"
 )
 
 func (registries *Registries) UnmarshalYAML(unmarshal func(interface{}) error) error {
@@ -115,6 +116,7 @@ type FormatOverride struct {
 type File struct {
 	Name string `validate:"required" json:"name,omitempty"`
 	Src  string `json:"src,omitempty"`
+	Dir  string `json:"dir,omitempty"`
 }
 
 func getArch(rosetta2 bool, replacements map[string]string, rt *runtime.Runtime) string {
@@ -127,6 +129,18 @@ func getArch(rosetta2 bool, replacements map[string]string, rt *runtime.Runtime)
 
 func (file *File) RenderSrc(pkg *Package, pkgInfo *PackageInfo, rt *runtime.Runtime) (string, error) {
 	return template.Execute(file.Src, map[string]interface{}{ //nolint:wrapcheck
+		"Version":  pkg.Version,
+		"GOOS":     rt.GOOS,
+		"GOARCH":   rt.GOARCH,
+		"OS":       replace(rt.GOOS, pkgInfo.GetReplacements()),
+		"Arch":     getArch(pkgInfo.GetRosetta2(), pkgInfo.GetReplacements(), rt),
+		"Format":   pkgInfo.GetFormat(),
+		"FileName": file.Name,
+	})
+}
+
+func (file *File) RenderDir(pkg *Package, pkgInfo *PackageInfo, rt *runtime.Runtime) (string, error) {
+	return template.Execute(file.Dir, map[string]interface{}{ //nolint:wrapcheck
 		"Version":  pkg.Version,
 		"GOOS":     rt.GOOS,
 		"GOARCH":   rt.GOARCH,

--- a/pkg/config/package_info.go
+++ b/pkg/config/package_info.go
@@ -201,7 +201,7 @@ func (pkgInfo *PackageInfo) GetLink() string {
 }
 
 func (pkgInfo *PackageInfo) GetFormat() string {
-	if pkgInfo.Type == PkgInfoTypeGitHubArchive {
+	if pkgInfo.Type == PkgInfoTypeGitHubArchive || pkgInfo.Type == PkgInfoTypeGo {
 		return "tar.gz"
 	}
 	return pkgInfo.Format
@@ -249,6 +249,8 @@ func (pkgInfo *PackageInfo) GetPkgPath(rootDir string, pkg *Package, rt *runtime
 	switch pkgInfo.Type {
 	case PkgInfoTypeGitHubArchive:
 		return filepath.Join(rootDir, "pkgs", pkgInfo.GetType(), "github.com", pkgInfo.RepoOwner, pkgInfo.RepoName, pkg.Version), nil
+	case PkgInfoTypeGo:
+		return filepath.Join(rootDir, "pkgs", pkgInfo.GetType(), "github.com", pkgInfo.RepoOwner, pkgInfo.RepoName, pkg.Version, "src"), nil
 	case PkgInfoTypeGitHubContent, PkgInfoTypeGitHubRelease:
 		return filepath.Join(rootDir, "pkgs", pkgInfo.GetType(), "github.com", pkgInfo.RepoOwner, pkgInfo.RepoName, pkg.Version, assetName), nil
 	case PkgInfoTypeHTTP:
@@ -270,7 +272,7 @@ func (pkgInfo *PackageInfo) Validate() error { //nolint:cyclop
 		return errPkgNameIsRequired
 	}
 	switch pkgInfo.Type {
-	case PkgInfoTypeGitHubArchive:
+	case PkgInfoTypeGitHubArchive, PkgInfoTypeGo:
 		if !pkgInfo.HasRepo() {
 			return errRepoRequired
 		}
@@ -302,7 +304,7 @@ func (pkgInfo *PackageInfo) Validate() error { //nolint:cyclop
 
 func (pkgInfo *PackageInfo) RenderAsset(pkg *Package, rt *runtime.Runtime) (string, error) {
 	switch pkgInfo.Type {
-	case PkgInfoTypeGitHubArchive:
+	case PkgInfoTypeGitHubArchive, PkgInfoTypeGo:
 		return "", nil
 	case PkgInfoTypeGitHubContent:
 		s, err := pkgInfo.renderTemplateString(*pkgInfo.Path, pkg, rt)

--- a/pkg/controller/exec/exec_test.go
+++ b/pkg/controller/exec/exec_test.go
@@ -123,8 +123,8 @@ packages:
 			osEnv := osenv.NewMock(d.env)
 			whichCtrl := which.New(d.param, finder.NewConfigFinder(fs), reader.New(fs), registry.New(d.param, downloader, fs), d.rt, osEnv, fs, linker)
 			pkgDownloader := download.NewPackageDownloader(nil, d.rt, download.NewHTTPDownloader(http.DefaultClient))
-			pkgInstaller := installpackage.New(d.param, pkgDownloader, d.rt, fs, linker)
 			executor := exec.NewMock(0, nil)
+			pkgInstaller := installpackage.New(d.param, pkgDownloader, d.rt, fs, linker, executor)
 			ctrl := execCtrl.New(pkgInstaller, whichCtrl, executor, osEnv, fs)
 			if err := ctrl.Exec(ctx, d.param, d.exeName, d.args, logE); err != nil {
 				if d.isErr {

--- a/pkg/controller/install/install_test.go
+++ b/pkg/controller/install/install_test.go
@@ -10,6 +10,7 @@ import (
 	reader "github.com/aquaproj/aqua/pkg/config-reader"
 	"github.com/aquaproj/aqua/pkg/controller/install"
 	"github.com/aquaproj/aqua/pkg/download"
+	"github.com/aquaproj/aqua/pkg/exec"
 	registry "github.com/aquaproj/aqua/pkg/install-registry"
 	"github.com/aquaproj/aqua/pkg/installpackage"
 	"github.com/aquaproj/aqua/pkg/link"
@@ -86,7 +87,8 @@ packages:
 				}
 			}
 			downloader := download.NewPackageDownloader(nil, d.rt, download.NewHTTPDownloader(http.DefaultClient))
-			pkgInstaller := installpackage.New(d.param, downloader, d.rt, fs, linker)
+			executor := exec.NewMock(0, nil)
+			pkgInstaller := installpackage.New(d.param, downloader, d.rt, fs, linker, executor)
 			ctrl := install.New(d.param, finder.NewConfigFinder(fs), reader.New(fs), registry.New(d.param, registryDownloader, fs), pkgInstaller, fs)
 			if err := ctrl.Install(ctx, d.param, logE); err != nil {
 				if d.isErr {

--- a/pkg/controller/which/which.go
+++ b/pkg/controller/which/which.go
@@ -66,7 +66,19 @@ func (ctrl *controller) Which(ctx context.Context, param *config.Param, exeName 
 	})
 }
 
+func (ctrl *controller) whichFileGo(pkg *config.Package, pkgInfo *config.PackageInfo, file *config.File) (*Which, error) {
+	return &Which{
+		Package: pkg,
+		PkgInfo: pkgInfo,
+		File:    file,
+		ExePath: filepath.Join(ctrl.rootDir, "pkgs", pkgInfo.GetType(), "github.com", pkgInfo.RepoOwner, pkgInfo.RepoName, pkg.Version, "bin", file.Name),
+	}, nil
+}
+
 func (ctrl *controller) whichFile(pkg *config.Package, pkgInfo *config.PackageInfo, file *config.File) (*Which, error) {
+	if pkgInfo.Type == "go" {
+		return ctrl.whichFileGo(pkg, pkgInfo, file)
+	}
 	fileSrc, err := pkgInfo.GetFileSrc(pkg, file, ctrl.runtime)
 	if err != nil {
 		return nil, fmt.Errorf("get file_src: %w", err)

--- a/pkg/controller/wire.go
+++ b/pkg/controller/wire.go
@@ -44,7 +44,7 @@ func InitializeGenerateCommandController(ctx context.Context, param *config.Para
 }
 
 func InitializeInstallCommandController(ctx context.Context, param *config.Param, httpClient *http.Client) *install.Controller {
-	wire.Build(install.New, finder.NewConfigFinder, github.New, registry.New, download.NewRegistryDownloader, reader.New, installpackage.New, download.NewPackageDownloader, runtime.New, afero.NewOsFs, link.New, download.NewHTTPDownloader)
+	wire.Build(install.New, finder.NewConfigFinder, github.New, registry.New, download.NewRegistryDownloader, reader.New, installpackage.New, download.NewPackageDownloader, runtime.New, afero.NewOsFs, link.New, download.NewHTTPDownloader, exec.New)
 	return &install.Controller{}
 }
 

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -24,7 +24,7 @@ func (downloader *pkgDownloader) GetReadCloser(ctx context.Context, pkg *config.
 		return downloader.getReadCloserFromGitHubRelease(ctx, pkg, pkgInfo, assetName, logE)
 	case config.PkgInfoTypeGitHubContent:
 		return downloader.getReadCloserFromGitHubContent(ctx, pkg, pkgInfo, assetName)
-	case config.PkgInfoTypeGitHubArchive:
+	case config.PkgInfoTypeGitHubArchive, config.PkgInfoTypeGo:
 		return downloader.getReadCloserFromGitHubArchive(ctx, pkg, pkgInfo)
 	case config.PkgInfoTypeHTTP:
 		return downloader.getReadCloserFromHTTP(ctx, pkg, pkgInfo)

--- a/pkg/installpackage/installer_test.go
+++ b/pkg/installpackage/installer_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aquaproj/aqua/pkg/config"
 	"github.com/aquaproj/aqua/pkg/download"
+	"github.com/aquaproj/aqua/pkg/exec"
 	"github.com/aquaproj/aqua/pkg/installpackage"
 	"github.com/aquaproj/aqua/pkg/link"
 	"github.com/aquaproj/aqua/pkg/runtime"
@@ -28,6 +29,7 @@ func Test_installer_InstallPackages(t *testing.T) { //nolint:funlen
 		rt         *runtime.Runtime
 		cfg        *config.Config
 		registries map[string]*config.RegistryContent
+		executor   exec.Executor
 		binDir     string
 		onlyLink   bool
 		isTest     bool
@@ -200,7 +202,7 @@ func Test_installer_InstallPackages(t *testing.T) { //nolint:funlen
 				}
 			}
 			downloader := download.NewPackageDownloader(nil, d.rt, download.NewHTTPDownloader(http.DefaultClient))
-			ctrl := installpackage.New(d.param, downloader, d.rt, fs, linker)
+			ctrl := installpackage.New(d.param, downloader, d.rt, fs, linker, d.executor)
 			if err := ctrl.InstallPackages(ctx, d.cfg, d.registries, d.binDir, d.onlyLink, d.isTest, logE); err != nil {
 				if d.isErr {
 					return
@@ -217,14 +219,15 @@ func Test_installer_InstallPackages(t *testing.T) { //nolint:funlen
 func Test_installer_InstallPackage(t *testing.T) { //nolint:funlen
 	t.Parallel()
 	data := []struct {
-		name    string
-		files   map[string]string
-		param   *config.Param
-		rt      *runtime.Runtime
-		pkgInfo *config.PackageInfo
-		pkg     *config.Package
-		isTest  bool
-		isErr   bool
+		name     string
+		files    map[string]string
+		param    *config.Param
+		rt       *runtime.Runtime
+		pkgInfo  *config.PackageInfo
+		pkg      *config.Package
+		executor exec.Executor
+		isTest   bool
+		isErr    bool
 	}{
 		{
 			name: "file already exists",
@@ -264,7 +267,7 @@ func Test_installer_InstallPackage(t *testing.T) { //nolint:funlen
 				}
 			}
 			downloader := download.NewPackageDownloader(nil, d.rt, download.NewHTTPDownloader(http.DefaultClient))
-			ctrl := installpackage.New(d.param, downloader, d.rt, fs, nil)
+			ctrl := installpackage.New(d.param, downloader, d.rt, fs, nil, d.executor)
 			if err := ctrl.InstallPackage(ctx, d.pkgInfo, d.pkg, d.isTest, logE); err != nil {
 				if d.isErr {
 					return

--- a/pkg/installpackage/proxy_test.go
+++ b/pkg/installpackage/proxy_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aquaproj/aqua/pkg/config"
 	"github.com/aquaproj/aqua/pkg/download"
+	"github.com/aquaproj/aqua/pkg/exec"
 	"github.com/aquaproj/aqua/pkg/installpackage"
 	"github.com/aquaproj/aqua/pkg/link"
 	"github.com/aquaproj/aqua/pkg/runtime"
@@ -17,12 +18,13 @@ import (
 func Test_installer_InstallProxy(t *testing.T) {
 	t.Parallel()
 	data := []struct {
-		name  string
-		files map[string]string
-		param *config.Param
-		rt    *runtime.Runtime
-		links map[string]string
-		isErr bool
+		name     string
+		files    map[string]string
+		param    *config.Param
+		rt       *runtime.Runtime
+		executor exec.Executor
+		links    map[string]string
+		isErr    bool
 	}{
 		{
 			name: "file already exists",
@@ -60,7 +62,7 @@ func Test_installer_InstallProxy(t *testing.T) {
 				}
 			}
 			downloader := download.NewPackageDownloader(nil, d.rt, download.NewHTTPDownloader(http.DefaultClient))
-			ctrl := installpackage.New(d.param, downloader, d.rt, fs, linker)
+			ctrl := installpackage.New(d.param, downloader, d.rt, fs, linker, d.executor)
 			if err := ctrl.InstallProxy(ctx, logE); err != nil {
 				if d.isErr {
 					return

--- a/pkg/installpackage/public.go
+++ b/pkg/installpackage/public.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aquaproj/aqua/pkg/config"
 	"github.com/aquaproj/aqua/pkg/download"
+	"github.com/aquaproj/aqua/pkg/exec"
 	"github.com/aquaproj/aqua/pkg/link"
 	"github.com/aquaproj/aqua/pkg/runtime"
 	"github.com/sirupsen/logrus"
@@ -17,7 +18,7 @@ type Installer interface {
 	InstallProxy(ctx context.Context, logE *logrus.Entry) error
 }
 
-func New(param *config.Param, downloader download.PackageDownloader, rt *runtime.Runtime, fs afero.Fs, linker link.Linker) Installer {
+func New(param *config.Param, downloader download.PackageDownloader, rt *runtime.Runtime, fs afero.Fs, linker link.Linker, executor exec.Executor) Installer {
 	return &installer{
 		rootDir:           param.RootDir,
 		maxParallelism:    param.MaxParallelism,
@@ -25,5 +26,6 @@ func New(param *config.Param, downloader download.PackageDownloader, rt *runtime
 		runtime:           rt,
 		fs:                fs,
 		linker:            linker,
+		executor:          executor,
 	}
 }

--- a/tests/aqua-global.yaml
+++ b/tests/aqua-global.yaml
@@ -58,3 +58,7 @@ packages:
   # alias
   registry: local
   version: v0.9.4 # renovate: depName=ahmetb/kubectx
+
+- name: google/wire@v0.5.0
+  # type: go
+  registry: local

--- a/tests/registry.yaml
+++ b/tests/registry.yaml
@@ -85,3 +85,13 @@ packages:
   format_overrides:
   - goos: windows
     format: zip
+
+# Go
+- type: go
+  repo_owner: google
+  repo_name: wire
+  description: Compile-time Dependency Injection for Go
+  files:
+  - name: wire
+    src: ./cmd/wire
+    dir: "wire-{{trimV .Version}}"


### PR DESCRIPTION
Close #798

## Example

registry.yaml

```yaml
packages:
  - type: go
    repo_owner: mitchellh
    repo_name: gox
    description: A dead simple, no frills Go cross compile tool
    files:
      - name: gox
        dir: "gox-{{trimV .Version}}"
```

aqua.yaml

```
registries:
  - name: standard
    type: local
    path: registry.yaml
packages:
- name: mitchellh/gox@v1.0.1
```

```console
$ aqua i                                                 
INFO[0000] create a symbolic link                        aqua_version= env=darwin/arm64 link_file=/Users/shunsukesuzuki/.local/share/aquaproj-aqua/bin/gox new=aqua-proxy package_name=mitchellh/gox package_version=v1.0.1 program=aqua registry=standard
INFO[0000] download and unarchive the package            aqua_version= env=darwin/arm64 package_name=mitchellh/gox package_version=v1.0.1 program=aqua registry=standard
INFO[0000] building Go tool                              aqua_version= env=darwin/arm64 exe_path=/Users/shunsukesuzuki/.local/share/aquaproj-aqua/pkgs/go/github.com/mitchellh/gox/v1.0.1/bin/gox file_name=gox go_build_dir=/Users/shunsukesuzuki/.local/share/aquaproj-aqua/pkgs/go/github.com/mitchellh/gox/v1.0.1/src/gox-1.0.1 go_src=. package_name=mitchellh/gox package_version=v1.0.1 program=aqua registry=standard
```

```console
$ aqua which gox
/Users/shunsukesuzuki/.local/share/aquaproj-aqua/pkgs/go/github.com/mitchellh/gox/v1.0.1/bin/gox
```

```console
$ tree /Users/shunsukesuzuki/.local/share/aquaproj-aqua/pkgs/go/github.com/mitchellh/gox/v1.0.1
```

<details>

```
/Users/shunsukesuzuki/.local/share/aquaproj-aqua/pkgs/go/github.com/mitchellh/gox/v1.0.1
├── bin
│   └── gox
└── src
    └── gox-1.0.1
        ├── Gopkg.lock
        ├── Gopkg.toml
        ├── LICENSE
        ├── README.md
        ├── appveyor.yml
        ├── env_override.go
        ├── go.go
        ├── go.mod
        ├── go.sum
        ├── go_test.go
        ├── main.go
        ├── main_osarch.go
        ├── platform.go
        ├── platform_flag.go
        ├── platform_flag_test.go
        ├── platform_test.go
        ├── toolchain.go
        └── vendor
            ├── github.com
            │   ├── hashicorp
            │   │   └── go-version
            │   │       ├── LICENSE
            │   │       ├── README.md
            │   │       ├── constraint.go
            │   │       ├── constraint_test.go
            │   │       ├── version.go
            │   │       ├── version_collection.go
            │   │       ├── version_collection_test.go
            │   │       └── version_test.go
            │   └── mitchellh
            │       └── iochan
            │           ├── LICENSE.md
            │           ├── README.md
            │           ├── iochan.go
            │           └── iochan_test.go
            └── vendor.json

9 directories, 31 files
```

</details>

```console
$ gox -help
```

<details>

```
Usage: gox [options] [packages]

  Gox cross-compiles Go applications in parallel.

  If no specific operating systems or architectures are specified, Gox
  will build for all pairs supported by your version of Go.

Options:

  -arch=""            Space-separated list of architectures to build for
  -build-toolchain    Build cross-compilation toolchain
  -cgo                Sets CGO_ENABLED=1, requires proper C toolchain (advanced)
  -gcflags=""         Additional '-gcflags' value to pass to go build
  -ldflags=""         Additional '-ldflags' value to pass to go build
  -asmflags=""        Additional '-asmflags' value to pass to go build
  -tags=""            Additional '-tags' value to pass to go build
  -mod=""             Additional '-mod' value to pass to go build
  -os=""              Space-separated list of operating systems to build for
  -osarch=""          Space-separated list of os/arch pairs to build for
  -osarch-list        List supported os/arch pairs for your Go version
  -output="foo"       Output path template. See below for more info
  -parallel=-1        Amount of parallelism, defaults to number of CPUs
  -gocmd="go"         Build command, defaults to Go
  -rebuild            Force rebuilding of package that were up to date
  -verbose            Verbose mode

Output path template:

  The output path for the compiled binaries is specified with the
  "-output" flag. The value is a string that is a Go text template.
  The default value is "{{.Dir}}_{{.OS}}_{{.Arch}}". The variables and
  their values should be self-explanatory.

Platforms (OS/Arch):

  The operating systems and architectures to cross-compile for may be
  specified with the "-arch" and "-os" flags. These are space separated lists
  of valid GOOS/GOARCH values to build for, respectively. You may prefix an
  OS or Arch with "!" to negate and not build for that platform. If the list
  is made up of only negations, then the negations will come from the default
  list.

  Additionally, the "-osarch" flag may be used to specify complete os/arch
  pairs that should be built or ignored. The syntax for this is what you would
  expect: "darwin/amd64" would be a valid osarch value. Multiple can be space
  separated. An os/arch pair can begin with "!" to not build for that platform.

  The "-osarch" flag has the highest precedent when determing whether to
  build for a platform. If it is included in the "-osarch" list, it will be
  built even if the specific os and arch is negated in "-os" and "-arch",
  respectively.

Platform Overrides:

  The "-gcflags", "-ldflags" and "-asmflags" options can be overridden per-platform
  by using environment variables. Gox will look for environment variables
  in the following format and use those to override values if they exist:

    GOX_[OS]_[ARCH]_GCFLAGS
    GOX_[OS]_[ARCH]_LDFLAGS
    GOX_[OS]_[ARCH]_ASMFLAGS
```

</details>