### PR TITLE
fix: prevent a panic when no package matches in aqua g's fuzzy finder

### DIFF
--- a/pkg/controller/generate/finder.go
+++ b/pkg/controller/generate/finder.go
@@ -38,6 +38,9 @@ func (finder *fuzzyFinder) Find(pkgs []*FindingPackage) ([]int, error) {
 		return find(pkgs[i])
 	},
 		fuzzyfinder.WithPreviewWindow(func(i, w, h int) string {
+			if i < 0 {
+				return "No package matches"
+			}
 			return getPreview(pkgs[i], i, w)
 		}))
 }


### PR DESCRIPTION
Close #801