### PR TITLE
ci: test unknown type package

### DIFF
--- a/tests/registry.yaml
+++ b/tests/registry.yaml
@@ -95,3 +95,7 @@ packages:
   - name: wire
     src: ./cmd/wire
     dir: "wire-{{trimV .Version}}"
+
+# unknown package type
+- type: foo
+  name: foo


### PR DESCRIPTION
aqua shouldn't return error