### PR TITLE
feat: support specifying revision as version for github_archive and go package

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -52,6 +52,8 @@ jobs:
       env:
         AQUA_EXPERIMENTAL_X_SYS_EXEC: "true"
     - run: wire --help
+    - run: gox --help
+    - run: bats -v
 
     - run: aqua g -i suzuki-shunsuke/tfcmt
       working-directory: tests

--- a/pkg/controller/generate/generate_test.go
+++ b/pkg/controller/generate/generate_test.go
@@ -233,7 +233,7 @@ packages:
 				}
 			}
 			configFinder := finder.NewConfigFinder(fs)
-			gh := githubSvc.NewMock(d.releases, nil, "")
+			gh := githubSvc.NewMock(d.releases, nil, "", nil)
 			downloader := download.NewRegistryDownloader(gh, download.NewHTTPDownloader(http.DefaultClient))
 			registryInstaller := registry.New(d.param, downloader, fs)
 			configReader := reader.New(fs)

--- a/pkg/controller/initcmd/init_test.go
+++ b/pkg/controller/initcmd/init_test.go
@@ -66,7 +66,7 @@ packages:
 					t.Fatal(err)
 				}
 			}
-			gh := githubSvc.NewMock(d.releases, nil, "")
+			gh := githubSvc.NewMock(d.releases, nil, "", nil)
 			ctrl := initcmd.New(gh, fs)
 			if err := ctrl.Init(ctx, "", logE); err != nil {
 				if d.isErr {

--- a/pkg/download/download_test.go
+++ b/pkg/download/download_test.go
@@ -59,7 +59,7 @@ func Test_pkgDownloader_GetReadCloser(t *testing.T) { //nolint:funlen,maintidx
 			},
 			assetName: "ci-info-2.0.3_linux_amd64.tar.gz",
 			exp:       "foo",
-			github:    githubSvc.NewMock(nil, nil, "foo"),
+			github:    githubSvc.NewMock(nil, nil, "foo", nil),
 			httpClient: &http.Client{
 				Transport: &flute.Transport{
 					Services: []flute.Service{
@@ -116,7 +116,7 @@ func Test_pkgDownloader_GetReadCloser(t *testing.T) { //nolint:funlen,maintidx
 						},
 					},
 				},
-			}, nil, "foo"),
+			}, nil, "foo", nil),
 			httpClient: &http.Client{
 				Transport: &flute.Transport{
 					Services: []flute.Service{
@@ -164,7 +164,7 @@ func Test_pkgDownloader_GetReadCloser(t *testing.T) { //nolint:funlen,maintidx
 			},
 			assetName: "aqua-installer",
 			exp:       "foo",
-			github:    githubSvc.NewMock(nil, nil, "foo"),
+			github:    githubSvc.NewMock(nil, nil, "foo", nil),
 			httpClient: &http.Client{
 				Transport: &flute.Transport{
 					Services: []flute.Service{
@@ -214,7 +214,7 @@ func Test_pkgDownloader_GetReadCloser(t *testing.T) { //nolint:funlen,maintidx
 			exp:       "github-content",
 			github: githubSvc.NewMock(nil, &github.RepositoryContent{
 				Content: stringP("github-content"),
-			}, "foo"),
+			}, "foo", nil),
 			httpClient: &http.Client{
 				Transport: &flute.Transport{
 					Services: []flute.Service{
@@ -260,7 +260,7 @@ func Test_pkgDownloader_GetReadCloser(t *testing.T) { //nolint:funlen,maintidx
 				RepoName:  "tfenv",
 			},
 			exp:    "foo",
-			github: githubSvc.NewMock(nil, nil, "foo"),
+			github: githubSvc.NewMock(nil, nil, "foo", nil),
 			httpClient: &http.Client{
 				Transport: &flute.Transport{
 					Services: []flute.Service{

--- a/pkg/download/registry_test.go
+++ b/pkg/download/registry_test.go
@@ -69,7 +69,7 @@ func Test_registryDownloader_GetGitHubContentFile(t *testing.T) { //nolint:funle
 			exp:       "foo",
 			github: githubSvc.NewMock(nil, &github.RepositoryContent{
 				Content: stringP("foo"),
-			}, ""),
+			}, "", nil),
 			httpClient: &http.Client{
 				Transport: &flute.Transport{
 					Services: []flute.Service{

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 
 	"github.com/google/go-github/v44/github"
@@ -17,6 +18,7 @@ type RepositoryService interface {
 	DownloadReleaseAsset(ctx context.Context, owner, repoName string, assetID int64, httpClient *http.Client) (io.ReadCloser, string, error)
 	ListReleases(ctx context.Context, owner, repo string, opts *github.ListOptions) ([]*github.RepositoryRelease, *github.Response, error)
 	ListTags(ctx context.Context, owner string, repo string, opts *github.ListOptions) ([]*github.RepositoryTag, *github.Response, error)
+	GetArchiveLink(ctx context.Context, owner, repo string, archiveformat github.ArchiveFormat, opts *github.RepositoryContentGetOptions, followRedirects bool) (*url.URL, *github.Response, error)
 }
 
 func New(ctx context.Context) RepositoryService {

--- a/pkg/github/mock.go
+++ b/pkg/github/mock.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/google/go-github/v44/github"
@@ -15,6 +16,7 @@ var (
 	errTagNotFound     = errors.New("tag isn't found")
 	errAssetNotFound   = errors.New("asset isn't found")
 	errContentNotFound = errors.New("content isn't found")
+	errGetTar          = errors.New("failed to get tar")
 )
 
 type mockRepositoryService struct {
@@ -22,13 +24,15 @@ type mockRepositoryService struct {
 	content  *github.RepositoryContent
 	tags     []*github.RepositoryTag
 	asset    string
+	url      *url.URL
 }
 
-func NewMock(releases []*github.RepositoryRelease, content *github.RepositoryContent, asset string) RepositoryService {
+func NewMock(releases []*github.RepositoryRelease, content *github.RepositoryContent, asset string, url *url.URL) RepositoryService {
 	return &mockRepositoryService{
 		releases: releases,
 		content:  content,
 		asset:    asset,
+		url:      url,
 	}
 }
 
@@ -72,4 +76,11 @@ func (svc *mockRepositoryService) ListTags(ctx context.Context, owner string, re
 		return nil, nil, errTagNotFound
 	}
 	return svc.tags, nil, nil
+}
+
+func (svc *mockRepositoryService) GetArchiveLink(ctx context.Context, owner, repo string, archiveformat github.ArchiveFormat, opts *github.RepositoryContentGetOptions, followRedirects bool) (*url.URL, *github.Response, error) {
+	if svc.url == nil {
+		return nil, nil, errGetTar
+	}
+	return svc.url, nil, nil
 }

--- a/tests/aqua-global.yaml
+++ b/tests/aqua-global.yaml
@@ -62,3 +62,12 @@ packages:
 - name: google/wire@v0.5.0
   # type: go
   registry: local
+
+- name: mitchellh/gox
+  registry: local
+  # specify revision
+  version: 8c3b2b9e647dc52457d6ee7b5adcf97e2bafe131
+
+- name: bats-core/bats-core
+  # specify revision
+  version: 9695e7c589a07756c999893764ccd9a506a47f89


### PR DESCRIPTION
Close #812

e.g. aqua.yaml

```yaml
- name: mitchellh/gox
  registry: local
  version: 8c3b2b9e647dc52457d6ee7b5adcf97e2bafe131

- name: bats-core/bats-core
  # specify revision
  version: 9695e7c589a07756c999893764ccd9a506a47f89
```