### PR TITLE
feat: add global command line options `-trace` and `-cpu-profile` for tracing and CPU Profiling

### DIFF
--- a/pkg/cli/exec.go
+++ b/pkg/cli/exec.go
@@ -42,6 +42,13 @@ func (runner *Runner) execAction(c *cli.Context) error {
 		return err
 	}
 	defer tracer.Stop()
+
+	cpuProfiler, err := startCPUProfile(c.String("cpu-profile"))
+	if err != nil {
+		return err
+	}
+	defer cpuProfiler.Stop()
+
 	param := &config.Param{}
 	if err := runner.setParam(c, param); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)

--- a/pkg/cli/exec.go
+++ b/pkg/cli/exec.go
@@ -37,6 +37,11 @@ https://github.com/cli/cli/releases/tag/v2.4.0`,
 }
 
 func (runner *Runner) execAction(c *cli.Context) error {
+	tracer, err := startTrace(c.String("trace"))
+	if err != nil {
+		return err
+	}
+	defer tracer.Stop()
 	param := &config.Param{}
 	if err := runner.setParam(c, param); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)

--- a/pkg/cli/generate.go
+++ b/pkg/cli/generate.go
@@ -107,6 +107,13 @@ func (runner *Runner) generateAction(c *cli.Context) error {
 		return err
 	}
 	defer tracer.Stop()
+
+	cpuProfiler, err := startCPUProfile(c.String("cpu-profile"))
+	if err != nil {
+		return err
+	}
+	defer cpuProfiler.Stop()
+
 	param := &config.Param{}
 	if err := runner.setParam(c, param); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)

--- a/pkg/cli/generate.go
+++ b/pkg/cli/generate.go
@@ -102,6 +102,11 @@ func (runner *Runner) newGenerateCommand() *cli.Command {
 }
 
 func (runner *Runner) generateAction(c *cli.Context) error {
+	tracer, err := startTrace(c.String("trace"))
+	if err != nil {
+		return err
+	}
+	defer tracer.Stop()
 	param := &config.Param{}
 	if err := runner.setParam(c, param); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -22,6 +22,11 @@ $ aqua init foo.yaml # create foo.yaml`,
 }
 
 func (runner *Runner) initAction(c *cli.Context) error {
+	tracer, err := startTrace(c.String("trace"))
+	if err != nil {
+		return err
+	}
+	defer tracer.Stop()
 	param := &config.Param{}
 	if err := runner.setParam(c, param); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -27,6 +27,13 @@ func (runner *Runner) initAction(c *cli.Context) error {
 		return err
 	}
 	defer tracer.Stop()
+
+	cpuProfiler, err := startCPUProfile(c.String("cpu-profile"))
+	if err != nil {
+		return err
+	}
+	defer cpuProfiler.Stop()
+
 	param := &config.Param{}
 	if err := runner.setParam(c, param); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)

--- a/pkg/cli/install.go
+++ b/pkg/cli/install.go
@@ -55,6 +55,13 @@ func (runner *Runner) installAction(c *cli.Context) error {
 		return err
 	}
 	defer tracer.Stop()
+
+	cpuProfiler, err := startCPUProfile(c.String("cpu-profile"))
+	if err != nil {
+		return err
+	}
+	defer cpuProfiler.Stop()
+
 	param := &config.Param{}
 	if err := runner.setParam(c, param); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)

--- a/pkg/cli/install.go
+++ b/pkg/cli/install.go
@@ -50,6 +50,11 @@ $ aqua i -a
 }
 
 func (runner *Runner) installAction(c *cli.Context) error {
+	tracer, err := startTrace(c.String("trace"))
+	if err != nil {
+		return err
+	}
+	defer tracer.Stop()
 	param := &config.Param{}
 	if err := runner.setParam(c, param); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)

--- a/pkg/cli/list.go
+++ b/pkg/cli/list.go
@@ -28,6 +28,11 @@ standard,abs-lang/abs
 }
 
 func (runner *Runner) listAction(c *cli.Context) error {
+	tracer, err := startTrace(c.String("trace"))
+	if err != nil {
+		return err
+	}
+	defer tracer.Stop()
 	param := &config.Param{}
 	if err := runner.setParam(c, param); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)

--- a/pkg/cli/list.go
+++ b/pkg/cli/list.go
@@ -33,6 +33,13 @@ func (runner *Runner) listAction(c *cli.Context) error {
 		return err
 	}
 	defer tracer.Stop()
+
+	cpuProfiler, err := startCPUProfile(c.String("cpu-profile"))
+	if err != nil {
+		return err
+	}
+	defer cpuProfiler.Stop()
+
 	param := &config.Param{}
 	if err := runner.setParam(c, param); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)

--- a/pkg/cli/profile.go
+++ b/pkg/cli/profile.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"runtime/pprof"
+)
+
+type CPUProfiler struct {
+	f io.Closer
+}
+
+func (cp *CPUProfiler) Stop() {
+	if cp == nil {
+		return
+	}
+	pprof.StopCPUProfile()
+	cp.f.Close()
+}
+
+func startCPUProfile(p string) (*CPUProfiler, error) {
+	if p == "" {
+		return nil, nil //nolint:nilnil
+	}
+	f, err := os.Create(p)
+	if err != nil {
+		return nil, fmt.Errorf("create a cpu profile output file: %w", err)
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("start a trace: %w", err)
+	}
+	return &CPUProfiler{
+		f: f,
+	}, nil
+}

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"runtime/trace"
 	"time"
 
 	"github.com/aquaproj/aqua/pkg/config"
@@ -83,6 +82,10 @@ func (runner *Runner) Run(ctx context.Context, args ...string) error {
 				Name:  "trace",
 				Usage: "trace output file path",
 			},
+			&cli.StringFlag{
+				Name:  "cpu-profile",
+				Usage: "cpu profile output file path",
+			},
 		},
 		Commands: []*cli.Command{
 			runner.newInstallCommand(),
@@ -103,32 +106,4 @@ func exitErrHandlerFunc(c *cli.Context, err error) {
 		cli.HandleExitCoder(err)
 		return
 	}
-}
-
-type Tracer struct {
-	f io.Closer
-}
-
-func (t *Tracer) Stop() {
-	if t == nil {
-		return
-	}
-	trace.Stop()
-}
-
-func startTrace(p string) (*Tracer, error) {
-	if p == "" {
-		return nil, nil //nolint:nilnil
-	}
-	f, err := os.Create(p)
-	if err != nil {
-		return nil, fmt.Errorf("create a trace output file: %w", err)
-	}
-	if err := trace.Start(f); err != nil {
-		f.Close()
-		return nil, fmt.Errorf("start a trace: %w", err)
-	}
-	return &Tracer{
-		f: f,
-	}, nil
 }

--- a/pkg/cli/trace.go
+++ b/pkg/cli/trace.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"runtime/trace"
+)
+
+type Tracer struct {
+	f io.Closer
+}
+
+func (t *Tracer) Stop() {
+	if t == nil {
+		return
+	}
+	trace.Stop()
+	t.f.Close()
+}
+
+func startTrace(p string) (*Tracer, error) {
+	if p == "" {
+		return nil, nil //nolint:nilnil
+	}
+	f, err := os.Create(p)
+	if err != nil {
+		return nil, fmt.Errorf("create a trace output file: %w", err)
+	}
+	if err := trace.Start(f); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("start a trace: %w", err)
+	}
+	return &Tracer{
+		f: f,
+	}, nil
+}

--- a/pkg/cli/which.go
+++ b/pkg/cli/which.go
@@ -40,6 +40,13 @@ func (runner *Runner) whichAction(c *cli.Context) error {
 		return err
 	}
 	defer tracer.Stop()
+
+	cpuProfiler, err := startCPUProfile(c.String("cpu-profile"))
+	if err != nil {
+		return err
+	}
+	defer cpuProfiler.Stop()
+
 	param := &config.Param{}
 	if err := runner.setParam(c, param); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)

--- a/pkg/cli/which.go
+++ b/pkg/cli/which.go
@@ -35,6 +35,11 @@ FATA[0000] aqua failed                                   aqua_version=0.8.6 erro
 }
 
 func (runner *Runner) whichAction(c *cli.Context) error {
+	tracer, err := startTrace(c.String("trace"))
+	if err != nil {
+		return err
+	}
+	defer tracer.Stop()
 	param := &config.Param{}
 	if err := runner.setParam(c, param); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)


### PR DESCRIPTION
Add global command line options `-trace` and `-cpu-profile`.
This is useful for the performance tuning.

The following Go's standard libraries are used.

* https://pkg.go.dev/runtime/trace
* https://pkg.go.dev/runtime/pprof

## How to use

All sub commands except for `help` and `version` commands support this option.

### Tracing with `runtime/trace`

```console
$ aqua -trace trace.out exec -- gh version # a file trace.out is created
$ go tool trace trace.out
2022/06/01 11:18:47 Parsing trace...
2022/06/01 11:18:47 Splitting trace...
2022/06/01 11:18:47 Opening browser. Trace viewer is listening on http://127.0.0.1:58380
```

<img width="1439" alt="image" src="https://user-images.githubusercontent.com/13323303/171315748-2ef0945d-ccc0-45f6-af54-b46bdcfb55d6.png">

### CPU Profiling with `runtime/pprof`

```console
$ aqua -cpu-profile pprof.out exec -- gh version # a file pprof.out is created
$ go tool pprof -http=":8000" "$(which aqua)" pprof.out
```

<img width="1422" alt="image" src="https://user-images.githubusercontent.com/13323303/171329271-c3445a29-6ebc-4740-88fa-2668eeb672f3.png">