### PR TITLE
feat: add 'completion bash|zsh' commands

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -57,6 +57,11 @@ jobs:
     - run: github-compare -v
     - run: terrafmt version
 
+    - name: output bash completion
+      run: aqua completion bash
+    - name: output zsh completion
+      run: aqua completion zsh
+
     - run: aqua g -i suzuki-shunsuke/tfcmt
       working-directory: tests
     - run: git diff aqua.yaml

--- a/pkg/cli/completion.go
+++ b/pkg/cli/completion.go
@@ -26,7 +26,7 @@ func (runner *Runner) newCompletionCommand() *cli.Command {
 }
 
 func (runner *Runner) bashCompletionAction(c *cli.Context) error {
-	fmt.Println(`
+	fmt.Fprintln(runner.Stdout, `
 _cli_bash_autocomplete() {
   if [[ "${COMP_WORDS[0]}" != "source" ]]; then
     local cur opts base
@@ -47,7 +47,7 @@ complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete aqua`)
 }
 
 func (runner *Runner) zshCompletionAction(c *cli.Context) error {
-	fmt.Println(`
+	fmt.Fprintln(runner.Stdout, `
 #compdef aqua
 
 _cli_zsh_autocomplete() {

--- a/pkg/cli/completion.go
+++ b/pkg/cli/completion.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+)
+
+func (runner *Runner) newCompletionCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "completion",
+		Usage: "Output shell completion script for bash or zsh",
+		Subcommands: []*cli.Command{
+			{
+				Name:   "bash",
+				Usage:  "Output shell completion script for bash",
+				Action: runner.bashCompletionAction,
+			},
+			{
+				Name:   "zsh",
+				Usage:  "Output shell completion script for zsh",
+				Action: runner.zshCompletionAction,
+			},
+		},
+	}
+}
+
+func (runner *Runner) bashCompletionAction(c *cli.Context) error {
+	fmt.Println(`
+_cli_bash_autocomplete() {
+  if [[ "${COMP_WORDS[0]}" != "source" ]]; then
+    local cur opts base
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    if [[ "$cur" == "-"* ]]; then
+      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} ${cur} --generate-bash-completion )
+    else
+      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+    fi
+    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+    return 0
+  fi
+}
+
+complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete aqua`)
+	return nil
+}
+
+func (runner *Runner) zshCompletionAction(c *cli.Context) error {
+	fmt.Println(`
+#compdef aqua
+
+_cli_zsh_autocomplete() {
+  local -a opts
+  local cur
+  cur=${words[-1]}
+  if [[ "$cur" == "-"* ]]; then
+    opts=("${(@f)$(${words[@]:0:#words[@]-1} ${cur} --generate-bash-completion)}")
+  else
+    opts=("${(@f)$(${words[@]:0:#words[@]-1} --generate-bash-completion)}")
+  fi
+
+  if [[ "${opts[1]}" != "" ]]; then
+    _describe 'values' opts
+  else
+    _files
+  fi
+}
+
+compdef _cli_zsh_autocomplete aqua`)
+	return nil
+}

--- a/pkg/cli/completion.go
+++ b/pkg/cli/completion.go
@@ -7,6 +7,8 @@ import (
 )
 
 func (runner *Runner) newCompletionCommand() *cli.Command {
+	// https://github.com/aquaproj/aqua/pull/859
+	// https://cli.urfave.org/v2/#bash-completion
 	return &cli.Command{
 		Name:  "completion",
 		Usage: "Output shell completion script for bash or zsh",
@@ -26,6 +28,8 @@ func (runner *Runner) newCompletionCommand() *cli.Command {
 }
 
 func (runner *Runner) bashCompletionAction(c *cli.Context) error {
+	// https://github.com/urfave/cli/blob/main/autocomplete/bash_autocomplete
+	// https://github.com/urfave/cli/blob/c3f51bed6fffdf84227c5b59bd3f2e90683314df/autocomplete/bash_autocomplete#L5-L20
 	fmt.Fprintln(runner.Stdout, `
 _cli_bash_autocomplete() {
   if [[ "${COMP_WORDS[0]}" != "source" ]]; then
@@ -47,6 +51,8 @@ complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete aqua`)
 }
 
 func (runner *Runner) zshCompletionAction(c *cli.Context) error {
+	// https://github.com/urfave/cli/blob/main/autocomplete/zsh_autocomplete
+	// https://github.com/urfave/cli/blob/947f9894eef4725a1c15ed75459907b52dde7616/autocomplete/zsh_autocomplete
 	fmt.Fprintln(runner.Stdout, `
 #compdef aqua
 

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -87,6 +87,7 @@ func (runner *Runner) Run(ctx context.Context, args ...string) error {
 				Usage: "cpu profile output file path",
 			},
 		},
+		EnableBashCompletion: true,
 		Commands: []*cli.Command{
 			runner.newInstallCommand(),
 			runner.newExecCommand(),
@@ -94,6 +95,7 @@ func (runner *Runner) Run(ctx context.Context, args ...string) error {
 			runner.newListCommand(),
 			runner.newWhichCommand(),
 			runner.newGenerateCommand(),
+			runner.newCompletionCommand(),
 			runner.newVersionCommand(),
 		},
 	}


### PR DESCRIPTION
Fix #856

With this fix, now you can add the following line to `.bashrc` to enable commands completion for aqua.
```
if which aqua &> /dev/null; then source <(aqua completion bash); fi
```