### PR TITLE
chore: update aqua-proxy from v1.1.0 to v1.1.2

### DIFF
--- a/pkg/controller/install/install_test.go
+++ b/pkg/controller/install/install_test.go
@@ -57,13 +57,13 @@ packages:
   path: aqua-installer
 `,
 				"/home/foo/.local/share/aquaproj-aqua/pkgs/github_content/github.com/aquaproj/aqua-installer/v1.0.0/aqua-installer/aqua-installer":        ``,
-				"/home/foo/.local/share/aquaproj-aqua/pkgs/github_release/github.com/aquaproj/aqua-proxy/v1.1.0/aqua-proxy_linux_amd64.tar.gz/aqua-proxy": ``,
+				"/home/foo/.local/share/aquaproj-aqua/pkgs/github_release/github.com/aquaproj/aqua-proxy/v1.1.2/aqua-proxy_linux_amd64.tar.gz/aqua-proxy": ``,
 				"/home/foo/.local/share/aquaproj-aqua/bin/aqua-installer":                                                                                 ``,
 				"/home/foo/.local/share/aquaproj-aqua/bin/aqua-proxy":                                                                                     ``,
 			},
 			links: map[string]string{
 				"aqua-proxy": "/home/foo/.local/share/aquaproj-aqua/bin/aqua-installer",
-				"../pkgs/github_release/github.com/aquaproj/aqua-proxy/v1.1.0/aqua-proxy_linux_amd64.tar.gz/aqua-proxy": "/home/foo/.local/share/aquaproj-aqua/bin/aqua-proxy",
+				"../pkgs/github_release/github.com/aquaproj/aqua-proxy/v1.1.2/aqua-proxy_linux_amd64.tar.gz/aqua-proxy": "/home/foo/.local/share/aquaproj-aqua/bin/aqua-proxy",
 			},
 		},
 	}

--- a/pkg/installpackage/proxy.go
+++ b/pkg/installpackage/proxy.go
@@ -16,7 +16,7 @@ func (inst *installer) InstallProxy(ctx context.Context, logE *logrus.Entry) err
 	pkg := &config.Package{
 		Package: &aqua.Package{
 			Name:    proxyName,
-			Version: "v1.1.0", // renovate: depName=aquaproj/aqua-proxy
+			Version: "v1.1.2", // renovate: depName=aquaproj/aqua-proxy
 		},
 		PackageInfo: &registry.PackageInfo{
 			Type:      "github_release",

--- a/pkg/installpackage/proxy_test.go
+++ b/pkg/installpackage/proxy_test.go
@@ -39,7 +39,7 @@ func Test_installer_InstallProxy(t *testing.T) {
 				MaxParallelism: 5,
 			},
 			files: map[string]string{
-				"/home/foo/.local/share/aquaproj-aqua/pkgs/github_release/github.com/aquaproj/aqua-proxy/v1.1.0/aqua-proxy_linux_amd64.tar.gz/aqua-proxy": "",
+				"/home/foo/.local/share/aquaproj-aqua/pkgs/github_release/github.com/aquaproj/aqua-proxy/v1.1.2/aqua-proxy_linux_amd64.tar.gz/aqua-proxy": "",
 			},
 		},
 	}


### PR DESCRIPTION
https://github.com/aquaproj/aqua/issues/850

https://github.com/aquaproj/aqua-proxy/releases/tag/v1.1.2
https://github.com/aquaproj/aqua-proxy/releases/tag/v1.1.1