### PR TITLE
fix: change the default path of AQUA_ROOT_DIR on Windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2
+	github.com/adrg/xdg v0.4.0 // indirect
 	github.com/antonmedv/expr v1.9.0
 	github.com/go-playground/validator/v10 v10.11.0 // indirect
 	github.com/goccy/go-yaml v1.9.5

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030I
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/sprig/v3 v3.2.2 h1:17jRggJu518dr3QaafizSXOjKYp94wKfABxUmyxvxX8=
 github.com/Masterminds/sprig/v3 v3.2.2/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFPhxNuwnnxkKlk=
+github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
+github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/andybalholm/brotli v1.0.1 h1:KqhlKozYbRtJvsPrrEeXcO+N2l6NYT5A2QAFmSULpEc=
 github.com/andybalholm/brotli v1.0.1/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/antonmedv/expr v1.9.0 h1:j4HI3NHEdgDnN9p6oI6Ndr0G5QryMY0FNxT4ONrFDGU=
@@ -448,6 +450,7 @@ golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c h1:aFV+BgZ4svzjfabn8ERpuB4JI4N6/rdy1iusx77G3oU=
 golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/config/root_dir_windows.go
+++ b/pkg/config/root_dir_windows.go
@@ -1,11 +1,12 @@
-//go:build !windows
-// +build !windows
+//go:build windows
+// +build windows
 
 package config
 
 import (
 	"path/filepath"
 
+	"github.com/adrg/xdg"
 	"github.com/suzuki-shunsuke/go-osenv/osenv"
 )
 
@@ -13,9 +14,9 @@ func GetRootDir(osEnv osenv.OSEnv) string {
 	if rootDir := osEnv.Getenv("AQUA_ROOT_DIR"); rootDir != "" {
 		return rootDir
 	}
-	xdgDataHome := osEnv.Getenv("XDG_DATA_HOME")
+	xdgDataHome := xdg.DataHome
 	if xdgDataHome == "" {
 		xdgDataHome = filepath.Join(osEnv.Getenv("HOME"), ".local", "share")
 	}
-	return filepath.Join(xdgDataHome, "aquaproj-aqua")
+	return filepath.Join(xdg.DataHome, "aquaproj-aqua")
 }


### PR DESCRIPTION
Close https://github.com/aquaproj/aqua/issues/887

Change the default path of AQUA_ROOT_DIR on Windows from `~/.local/share/aquaproj-aqua` to `~/AppData/Local/aquaproj-aqua`.