### PR TITLE
Support selecting a version interactively in `aqua g` command

### DIFF
--- a/pkg/cli/generate.go
+++ b/pkg/cli/generate.go
@@ -78,7 +78,12 @@ $ aqua list | aqua g -f - # Generate configuration to install all packages
 You can omit the registry name if it is "standard".
 
 echo "cli/cli" | aqua g -f -
-- name: cli/cli@v2.2.0`
+- name: cli/cli@v2.2.0
+
+You can select a version interactively with "-s" option.
+
+$ aqua g -s
+`
 
 func (runner *Runner) newGenerateCommand() *cli.Command {
 	return &cli.Command{

--- a/pkg/cli/generate.go
+++ b/pkg/cli/generate.go
@@ -97,6 +97,11 @@ func (runner *Runner) newGenerateCommand() *cli.Command {
 				Name:  "i",
 				Usage: `Insert packages to configuration file`,
 			},
+			&cli.BoolFlag{
+				Name:    "select-version",
+				Aliases: []string{"s"},
+				Usage:   `Select the installed version interactively`,
+			},
 		},
 	}
 }

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -44,6 +44,7 @@ func (runner *Runner) setParam(c *cli.Context, commandName string, param *config
 		param.Insert = c.Bool("i")
 	}
 	param.All = c.Bool("all")
+	param.SelectVersion = c.Bool("select-version")
 	param.File = c.String("f")
 	param.AQUAVersion = runner.LDFlags.Version
 	param.RootDir = config.GetRootDir(osenv.New())

--- a/pkg/config/package.go
+++ b/pkg/config/package.go
@@ -160,19 +160,20 @@ const (
 )
 
 type Param struct {
+	GlobalConfigFilePaths []string
 	ConfigFilePath        string
 	LogLevel              string
+	File                  string
+	AQUAVersion           string
+	RootDir               string
+	PWD                   string
+	InsertFile            string
+	MaxParallelism        int
 	OnlyLink              bool
 	IsTest                bool
 	All                   bool
 	Insert                bool
-	File                  string
-	GlobalConfigFilePaths []string
-	AQUAVersion           string
-	RootDir               string
-	MaxParallelism        int
-	PWD                   string
-	InsertFile            string
+	SelectVersion         bool
 }
 
 func (cpkg *Package) RenderAsset(rt *runtime.Runtime) (string, error) {

--- a/pkg/config/registry/package_info.go
+++ b/pkg/config/registry/package_info.go
@@ -199,7 +199,7 @@ type VersionOverride struct {
 	SupportedEnvs      SupportedEnvs     `yaml:"supported_envs,omitempty" json:"supported_envs,omitempty"`
 	VersionConstraints string            `yaml:"version_constraint,omitempty" json:"version_constraint,omitempty"`
 	VersionFilter      *string           `yaml:"version_filter,omitempty" json:"version_filter,omitempty"`
-	VersionSource      string            `json:"version_source,omitempty" yaml:"version_source"`
+	VersionSource      string            `json:"version_source,omitempty" yaml:"version_source,omitempty"`
 	Rosetta2           *bool             `yaml:",omitempty" json:"rosetta2,omitempty"`
 	CompleteWindowsExt *bool             `json:"complete_windows_ext,omitempty" yaml:"complete_windows_ext,omitempty"`
 	WindowsExt         string            `json:"windows_ext,omitempty" yaml:"windows_ext,omitempty"`

--- a/pkg/controller/generate/generate_test.go
+++ b/pkg/controller/generate/generate_test.go
@@ -25,17 +25,19 @@ func stringP(s string) *string {
 func Test_controller_Generate(t *testing.T) { //nolint:funlen
 	t.Parallel()
 	data := []struct {
-		name           string
-		files          map[string]string
-		links          map[string]string
-		args           []string
-		env            map[string]string
-		param          *config.Param
-		rt             *runtime.Runtime
-		isErr          bool
-		idxs           []int
-		fuzzyFinderErr error
-		releases       []*github.RepositoryRelease
+		name               string
+		files              map[string]string
+		links              map[string]string
+		args               []string
+		env                map[string]string
+		param              *config.Param
+		rt                 *runtime.Runtime
+		isErr              bool
+		idxs               []int
+		idx                int
+		fuzzyFinderErr     error
+		versionSelectorErr error
+		releases           []*github.RepositoryRelease
 	}{
 		{
 			name: "normal",
@@ -239,7 +241,8 @@ packages:
 			registryInstaller := registry.New(d.param, downloader, fs)
 			configReader := reader.New(fs)
 			fuzzyFinder := generate.NewMockFuzzyFinder(d.idxs, d.fuzzyFinderErr)
-			ctrl := generate.New(configFinder, configReader, registryInstaller, gh, fs, fuzzyFinder)
+			versionSelector := generate.NewMockVersionSelector(d.idx, d.versionSelectorErr)
+			ctrl := generate.New(configFinder, configReader, registryInstaller, gh, fs, fuzzyFinder, versionSelector)
 			if err := ctrl.Generate(ctx, logE, d.param, d.args...); err != nil {
 				if d.isErr {
 					return

--- a/pkg/controller/generate/version_selector.go
+++ b/pkg/controller/generate/version_selector.go
@@ -59,9 +59,18 @@ func getVersionPreview(version *Version, i, w int) string {
 	if i < 0 {
 		return ""
 	}
-	return fmt.Sprintf("%s (%s)\n\n%s\n%s",
-		version.Version,
-		version.Name,
-		version.URL,
-		formatDescription(version.Description, w/2-8)) //nolint:gomnd
+	s := version.Version
+	if version.Name != version.Version {
+		s += fmt.Sprintf(" (%s)", version.Name)
+	}
+	if version.URL != "" || version.Description != "" {
+		s += "\n"
+	}
+	if version.URL != "" {
+		s += fmt.Sprintf("\n%s", version.URL)
+	}
+	if version.URL != "" {
+		s += fmt.Sprintf("\n%s", formatDescription(version.Description, w/2-8)) //nolint:gomnd
+	}
+	return s
 }

--- a/pkg/controller/generate/version_selector.go
+++ b/pkg/controller/generate/version_selector.go
@@ -1,0 +1,67 @@
+package generate
+
+import (
+	"fmt"
+
+	"github.com/ktr0731/go-fuzzyfinder"
+)
+
+type Version struct {
+	Name        string
+	Version     string
+	Description string
+	URL         string
+}
+
+type VersionSelector interface {
+	Find(versions []*Version) (int, error)
+}
+
+type versionSelector struct{}
+
+func NewVersionSelector() VersionSelector {
+	return &versionSelector{}
+}
+
+func NewMockVersionSelector(idx int, err error) VersionSelector {
+	return &mockVersionSelector{
+		idx: idx,
+		err: err,
+	}
+}
+
+type mockVersionSelector struct {
+	idx int
+	err error
+}
+
+func (selector *mockVersionSelector) Find(versions []*Version) (int, error) {
+	return selector.idx, selector.err
+}
+
+func (selector *versionSelector) Find(versions []*Version) (int, error) {
+	return fuzzyfinder.Find(versions, func(i int) string { //nolint:wrapcheck
+		return getVersionItem(versions[i])
+	},
+		fuzzyfinder.WithPreviewWindow(func(i, w, h int) string {
+			if i < 0 {
+				return "No package matches"
+			}
+			return getVersionPreview(versions[i], i, w)
+		}))
+}
+
+func getVersionItem(version *Version) string {
+	return version.Version
+}
+
+func getVersionPreview(version *Version, i, w int) string {
+	if i < 0 {
+		return ""
+	}
+	return fmt.Sprintf("%s (%s)\n\n%s\n%s",
+		version.Version,
+		version.Name,
+		version.URL,
+		formatDescription(version.Description, w/2-8)) //nolint:gomnd
+}

--- a/pkg/controller/generate/version_selector_internal_test.go
+++ b/pkg/controller/generate/version_selector_internal_test.go
@@ -1,0 +1,52 @@
+package generate
+
+import (
+	"testing"
+)
+
+func Test_getVersionPreview(t *testing.T) {
+	t.Parallel()
+	data := []struct {
+		name    string
+		version *Version
+		i       int
+		w       int
+		exp     string
+	}{
+		{
+			name: "tag",
+			version: &Version{
+				Version: "v1.0.0",
+				Name:    "v1.0.0",
+			},
+			w:   100,
+			exp: `v1.0.0`,
+		},
+		{
+			name: "release",
+			version: &Version{
+				Version: "v1.0.0",
+				Name:    "Major",
+				URL:     "https://github.com/suzuki-shunsuke/tfcmt/releases/v1.0.0",
+				Description: `foo
+bar`,
+			},
+			w: 100,
+			exp: `v1.0.0 (Major)
+
+https://github.com/suzuki-shunsuke/tfcmt/releases/v1.0.0
+foo
+bar`,
+		},
+	}
+	for _, d := range data {
+		d := d
+		t.Run(d.name, func(t *testing.T) {
+			t.Parallel()
+			s := getVersionPreview(d.version, d.i, d.w)
+			if s != d.exp {
+				t.Fatalf("wanted %s, got %s", d.exp, s)
+			}
+		})
+	}
+}

--- a/pkg/controller/wire.go
+++ b/pkg/controller/wire.go
@@ -30,36 +30,147 @@ import (
 )
 
 func InitializeListCommandController(ctx context.Context, param *config.Param, httpClient *http.Client) *list.Controller {
-	wire.Build(list.NewController, finder.NewConfigFinder, github.New, registry.New, download.NewRegistryDownloader, reader.New, afero.NewOsFs, download.NewHTTPDownloader)
+	wire.Build(
+		list.NewController,
+		wire.NewSet(
+			finder.NewConfigFinder,
+			wire.Bind(new(list.ConfigFinder), new(*finder.ConfigFinder)),
+		),
+		wire.NewSet(
+			github.New,
+			wire.Bind(new(download.RepositoryService), new(*github.RepositoriesService)),
+		),
+		registry.New,
+		download.NewRegistryDownloader,
+		reader.New,
+		afero.NewOsFs,
+		download.NewHTTPDownloader,
+	)
 	return &list.Controller{}
 }
 
 func InitializeGenerateRegistryCommandController(ctx context.Context, param *config.Param, httpClient *http.Client) *genrgst.Controller {
-	wire.Build(genrgst.NewController, github.New, afero.NewOsFs)
+	wire.Build(
+		genrgst.NewController,
+		wire.NewSet(
+			github.New,
+			wire.Bind(new(genrgst.RepositoryService), new(*github.RepositoriesService)),
+		),
+		afero.NewOsFs,
+	)
 	return &genrgst.Controller{}
 }
 
 func InitializeInitCommandController(ctx context.Context, param *config.Param) *initcmd.Controller {
-	wire.Build(initcmd.New, github.New, afero.NewOsFs)
+	wire.Build(
+		initcmd.New,
+		wire.NewSet(
+			github.New,
+			wire.Bind(new(initcmd.RepositoryService), new(*github.RepositoriesService)),
+		),
+		afero.NewOsFs,
+	)
 	return &initcmd.Controller{}
 }
 
 func InitializeGenerateCommandController(ctx context.Context, param *config.Param, httpClient *http.Client) *generate.Controller {
-	wire.Build(generate.New, finder.NewConfigFinder, github.New, registry.New, download.NewRegistryDownloader, reader.New, afero.NewOsFs, generate.NewFuzzyFinder, download.NewHTTPDownloader)
+	wire.Build(
+		generate.New,
+		wire.NewSet(
+			finder.NewConfigFinder,
+			wire.Bind(new(generate.ConfigFinder), new(*finder.ConfigFinder)),
+		),
+		wire.NewSet(
+			github.New,
+			wire.Bind(new(generate.RepositoryService), new(*github.RepositoriesService)),
+			wire.Bind(new(download.RepositoryService), new(*github.RepositoriesService)),
+		),
+		registry.New,
+		download.NewRegistryDownloader,
+		reader.New,
+		afero.NewOsFs,
+		generate.NewFuzzyFinder,
+		generate.NewVersionSelector,
+		download.NewHTTPDownloader,
+	)
 	return &generate.Controller{}
 }
 
 func InitializeInstallCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *install.Controller {
-	wire.Build(install.New, finder.NewConfigFinder, github.New, registry.New, download.NewRegistryDownloader, reader.New, installpackage.New, download.NewPackageDownloader, afero.NewOsFs, link.New, download.NewHTTPDownloader, exec.New)
+	wire.Build(
+		install.New,
+		wire.NewSet(
+			finder.NewConfigFinder,
+			wire.Bind(new(install.ConfigFinder), new(*finder.ConfigFinder)),
+		),
+		wire.NewSet(
+			github.New,
+			wire.Bind(new(download.RepositoryService), new(*github.RepositoriesService)),
+		),
+		registry.New,
+		download.NewRegistryDownloader,
+		reader.New,
+		installpackage.New,
+		download.NewPackageDownloader,
+		afero.NewOsFs,
+		link.New,
+		download.NewHTTPDownloader,
+		wire.NewSet(
+			exec.New,
+			wire.Bind(new(installpackage.Executor), new(*exec.Executor)),
+		),
+	)
 	return &install.Controller{}
 }
 
 func InitializeWhichCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) which.Controller {
-	wire.Build(which.New, finder.NewConfigFinder, github.New, registry.New, download.NewRegistryDownloader, reader.New, osenv.New, afero.NewOsFs, download.NewHTTPDownloader, link.New)
+	wire.Build(
+		which.New,
+		wire.NewSet(
+			finder.NewConfigFinder,
+			wire.Bind(new(which.ConfigFinder), new(*finder.ConfigFinder)),
+		),
+		wire.NewSet(
+			github.New,
+			wire.Bind(new(download.RepositoryService), new(*github.RepositoriesService)),
+		),
+		registry.New,
+		download.NewRegistryDownloader,
+		reader.New,
+		osenv.New,
+		afero.NewOsFs,
+		download.NewHTTPDownloader,
+		link.New,
+	)
 	return nil
 }
 
 func InitializeExecCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *cexec.Controller {
-	wire.Build(cexec.New, finder.NewConfigFinder, download.NewPackageDownloader, installpackage.New, github.New, registry.New, download.NewRegistryDownloader, reader.New, which.New, exec.New, osenv.New, afero.NewOsFs, link.New, download.NewHTTPDownloader)
+	wire.Build(
+		cexec.New,
+		wire.NewSet(
+			finder.NewConfigFinder,
+			wire.Bind(new(which.ConfigFinder), new(*finder.ConfigFinder)),
+		),
+		download.NewPackageDownloader,
+		installpackage.New,
+		wire.NewSet(
+			github.New,
+			wire.Bind(new(download.RepositoryService), new(*github.RepositoriesService)),
+		),
+		registry.New,
+		download.NewRegistryDownloader,
+		reader.New,
+		which.New,
+		wire.NewSet(
+			exec.New,
+			wire.Bind(new(installpackage.Executor), new(*exec.Executor)),
+			wire.Bind(new(cexec.Executor), new(*exec.Executor)),
+		),
+		osenv.New,
+		afero.NewOsFs,
+		link.New,
+		download.NewHTTPDownloader,
+	)
 	return &cexec.Controller{}
 }

--- a/pkg/controller/wire_gen.go
+++ b/pkg/controller/wire_gen.go
@@ -36,9 +36,9 @@ func InitializeListCommandController(ctx context.Context, param *config.Param, h
 	fs := afero.NewOsFs()
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs)
-	repositoryService := github.New(ctx)
+	repositoriesService := github.New(ctx)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
-	registryDownloader := download.NewRegistryDownloader(repositoryService, httpDownloader)
+	registryDownloader := download.NewRegistryDownloader(repositoriesService, httpDownloader)
 	installer := registry.New(param, registryDownloader, fs)
 	controller := list.NewController(configFinder, configReader, installer)
 	return controller
@@ -46,15 +46,15 @@ func InitializeListCommandController(ctx context.Context, param *config.Param, h
 
 func InitializeGenerateRegistryCommandController(ctx context.Context, param *config.Param, httpClient *http.Client) *genrgst.Controller {
 	fs := afero.NewOsFs()
-	repositoryService := github.New(ctx)
-	controller := genrgst.NewController(fs, repositoryService)
+	repositoriesService := github.New(ctx)
+	controller := genrgst.NewController(fs, repositoriesService)
 	return controller
 }
 
 func InitializeInitCommandController(ctx context.Context, param *config.Param) *initcmd.Controller {
-	repositoryService := github.New(ctx)
+	repositoriesService := github.New(ctx)
 	fs := afero.NewOsFs()
-	controller := initcmd.New(repositoryService, fs)
+	controller := initcmd.New(repositoriesService, fs)
 	return controller
 }
 
@@ -62,12 +62,13 @@ func InitializeGenerateCommandController(ctx context.Context, param *config.Para
 	fs := afero.NewOsFs()
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs)
-	repositoryService := github.New(ctx)
+	repositoriesService := github.New(ctx)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
-	registryDownloader := download.NewRegistryDownloader(repositoryService, httpDownloader)
+	registryDownloader := download.NewRegistryDownloader(repositoriesService, httpDownloader)
 	installer := registry.New(param, registryDownloader, fs)
 	fuzzyFinder := generate.NewFuzzyFinder()
-	controller := generate.New(configFinder, configReader, installer, repositoryService, fs, fuzzyFinder)
+	versionSelector := generate.NewVersionSelector()
+	controller := generate.New(configFinder, configReader, installer, repositoriesService, fs, fuzzyFinder, versionSelector)
 	return controller
 }
 
@@ -75,11 +76,11 @@ func InitializeInstallCommandController(ctx context.Context, param *config.Param
 	fs := afero.NewOsFs()
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs)
-	repositoryService := github.New(ctx)
+	repositoriesService := github.New(ctx)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
-	registryDownloader := download.NewRegistryDownloader(repositoryService, httpDownloader)
+	registryDownloader := download.NewRegistryDownloader(repositoriesService, httpDownloader)
 	installer := registry.New(param, registryDownloader, fs)
-	packageDownloader := download.NewPackageDownloader(repositoryService, rt, httpDownloader)
+	packageDownloader := download.NewPackageDownloader(repositoriesService, rt, httpDownloader)
 	linker := link.New()
 	executor := exec.New()
 	installpackageInstaller := installpackage.New(param, packageDownloader, rt, fs, linker, executor)
@@ -91,9 +92,9 @@ func InitializeWhichCommandController(ctx context.Context, param *config.Param, 
 	fs := afero.NewOsFs()
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs)
-	repositoryService := github.New(ctx)
+	repositoriesService := github.New(ctx)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
-	registryDownloader := download.NewRegistryDownloader(repositoryService, httpDownloader)
+	registryDownloader := download.NewRegistryDownloader(repositoriesService, httpDownloader)
 	installer := registry.New(param, registryDownloader, fs)
 	osEnv := osenv.New()
 	linker := link.New()
@@ -102,16 +103,16 @@ func InitializeWhichCommandController(ctx context.Context, param *config.Param, 
 }
 
 func InitializeExecCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *exec2.Controller {
-	repositoryService := github.New(ctx)
+	repositoriesService := github.New(ctx)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
-	packageDownloader := download.NewPackageDownloader(repositoryService, rt, httpDownloader)
+	packageDownloader := download.NewPackageDownloader(repositoriesService, rt, httpDownloader)
 	fs := afero.NewOsFs()
 	linker := link.New()
 	executor := exec.New()
 	installer := installpackage.New(param, packageDownloader, rt, fs, linker, executor)
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs)
-	registryDownloader := download.NewRegistryDownloader(repositoryService, httpDownloader)
+	registryDownloader := download.NewRegistryDownloader(repositoriesService, httpDownloader)
 	registryInstaller := registry.New(param, registryDownloader, fs)
 	osEnv := osenv.New()
 	controller := which.New(param, configFinder, configReader, registryInstaller, rt, osEnv, fs, linker)

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -13,6 +13,7 @@ type (
 	ReleaseAsset                = github.ReleaseAsset
 	ListOptions                 = github.ListOptions
 	RepositoryRelease           = github.RepositoryRelease
+	RepositoriesService         = github.RepositoriesService
 	Repository                  = github.Repository
 	RepositoryContentGetOptions = github.RepositoryContentGetOptions
 	RepositoryContent           = github.RepositoryContent


### PR DESCRIPTION
Close #955

## Example

```console
$ aqua g -s cli/cli
```

You can select a version with a fuzzy finder.

<img width="1405" alt="image" src="https://user-images.githubusercontent.com/13323303/176344049-a2dd8ca5-d90d-4bc5-90c2-5b44c85119f3.png">