### PR TITLE
fix(generate): improve newlines in the fuzzy finder's preview

### DIFF
--- a/pkg/controller/generate/finder.go
+++ b/pkg/controller/generate/finder.go
@@ -84,8 +84,8 @@ func getPreview(pkg *FindingPackage, i, w int) string {
 		formatDescription(pkg.PackageInfo.GetDescription(), w/2-8)) //nolint:gomnd
 }
 
-func formatDescription(desc string, w int) string {
-	descRune := []rune(desc)
+func formatLine(line string, w int) string {
+	descRune := []rune(line)
 	lenDescRune := len(descRune)
 	lineWidth := w - len([]rune("\n"))
 	numOfLines := (lenDescRune / lineWidth) + 1
@@ -99,4 +99,13 @@ func formatDescription(desc string, w int) string {
 		descArr[i] = string(descRune[start:end])
 	}
 	return strings.Join(descArr, "\n")
+}
+
+func formatDescription(desc string, w int) string {
+	lines := strings.Split(desc, "\n")
+	arr := make([]string, len(lines))
+	for i, line := range lines {
+		arr[i] = formatLine(line, w)
+	}
+	return strings.Join(arr, "\n")
 }


### PR DESCRIPTION
```console
aqua g -s cli/cli
```

## AS IS

<img width="730" alt="image" src="https://user-images.githubusercontent.com/13323303/176345530-b35229eb-b8ca-4e11-ad81-a7d39260dec4.png">

## TO BE

<img width="691" alt="image" src="https://user-images.githubusercontent.com/13323303/176345631-105df5f3-1bb4-4bcb-adf3-8abeb9dbe65d.png">