### PR TITLE
feat: show progress bars when tools are being installed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/ktr0731/go-fuzzyfinder v0.6.0
 	github.com/mattn/go-colorable v0.1.12
 	github.com/mholt/archiver/v3 v3.5.1
+	github.com/schollz/progressbar/v3 v3.8.6
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/afero v1.8.2
 	github.com/suzuki-shunsuke/flute v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -189,6 +189,7 @@ github.com/invopop/jsonschema v0.4.0 h1:Yuy/unfgCnfV5Wl7H0HgFufp/rlurqPOOuacqyBy
 github.com/invopop/jsonschema v0.4.0/go.mod h1:O9uiLokuu0+MGFlyiaqtWxwqJm41/+8Nj0lD7A36YH0=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213/go.mod h1:vNUNkEQ1e29fT/6vq2aBdFsgNPmy8qMdSay1npru+Sw=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.11.4 h1:kz40R/YWls3iqT9zX9AHN3WoVsrAWVyui5sxuLqiXqU=
@@ -227,6 +228,8 @@ github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mholt/archiver/v3 v3.5.1 h1:rDjOBX9JSF5BvoJGvjqK479aL70qh9DIpZCl+k7Clwo=
 github.com/mholt/archiver/v3 v3.5.1/go.mod h1:e3dqJ7H78uzsRSEACH1joayhuSyhnonssnDhppzS1L4=
+github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
+github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/reflectwalk v1.0.0 h1:9D+8oIskB4VJBN5SFlmc27fSlIBZaov1Wpk/IfikLNY=
@@ -257,6 +260,8 @@ github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6po
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sanity-io/litter v1.2.0/go.mod h1:JF6pZUFgu2Q0sBZ+HSV35P8TVPI1TTzEwyu9FXAw2W4=
+github.com/schollz/progressbar/v3 v3.8.6 h1:QruMUdzZ1TbEP++S1m73OqRJk20ON11m6Wqv4EoGg8c=
+github.com/schollz/progressbar/v3 v3.8.6/go.mod h1:W5IEwbJecncFGBvuEh4A7HT1nZZ6WNIL2i3qbnI0WKY=
 github.com/scylladb/go-set v1.0.2/go.mod h1:DkpGd78rljTxKAnTDPFqXSGxvETQnJyuSOQwsHycqfs=
 github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
@@ -323,8 +328,9 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3 h1:0es+/5331RGQPcXlMfP+WrnIIS6dNnNRe0WB02W0F4M=
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838 h1:71vQrMauZZhcTVK6KdYM+rklehEEwb3E+ZhaE5jrPrE=
+golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -456,6 +462,7 @@ golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b h1:2n253B2r0pYSmEV+UNCQoPfU/FiaizQEK5Gu4Bq4JE8=
 golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/pkg/download/download_github.go
+++ b/pkg/download/download_github.go
@@ -20,15 +20,15 @@ func getAssetIDFromAssets(assets []*github.ReleaseAsset, assetName string) (int6
 	return 0, fmt.Errorf("the asset isn't found: %s", assetName)
 }
 
-func (downloader *pkgDownloader) downloadFromGitHubRelease(ctx context.Context, owner, repoName, version, assetName string, logE *logrus.Entry) (io.ReadCloser, error) {
+func (downloader *pkgDownloader) downloadFromGitHubRelease(ctx context.Context, owner, repoName, version, assetName string, logE *logrus.Entry) (io.ReadCloser, int64, error) {
 	// I have tested if downloading assets from public repository's GitHub Releases anonymously is rate limited.
 	// As a result of test, it seems not to be limited.
 	// So at first aqua tries to download assets without GitHub API.
 	// And if it failed, aqua tries again with GitHub API.
 	// It avoids the rate limit of the access token.
-	b, err := downloader.http.Download(ctx, "https://github.com/"+owner+"/"+repoName+"/releases/download/"+version+"/"+assetName)
+	b, length, err := downloader.http.Download(ctx, "https://github.com/"+owner+"/"+repoName+"/releases/download/"+version+"/"+assetName)
 	if err == nil {
-		return b, nil
+		return b, length, nil
 	}
 	if b != nil {
 		b.Close()
@@ -41,37 +41,38 @@ func (downloader *pkgDownloader) downloadFromGitHubRelease(ctx context.Context, 
 	}).Debug("failed to download an asset from GitHub Release without GitHub API. Try again with GitHub API")
 
 	if downloader.github == nil {
-		return nil, errGitHubTokenIsRequired
+		return nil, 0, errGitHubTokenIsRequired
 	}
 
 	release, _, err := downloader.github.GetReleaseByTag(ctx, owner, repoName, version)
 	if err != nil {
-		return nil, fmt.Errorf("get the GitHub Release by Tag: %w", err)
+		return nil, 0, fmt.Errorf("get the GitHub Release by Tag: %w", err)
 	}
 	assetID, err := getAssetIDFromAssets(release.Assets, assetName)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	body, redirectURL, err := downloader.github.DownloadReleaseAsset(ctx, owner, repoName, assetID, http.DefaultClient)
 	if err != nil {
-		return nil, fmt.Errorf("download the release asset (asset id: %d): %w", assetID, err)
+		return nil, 0, fmt.Errorf("download the release asset (asset id: %d): %w", assetID, err)
 	}
 	if body != nil {
-		return body, nil
+		// DownloadReleaseAsset doesn't return a http.Response, so the content length is zero.
+		return body, 0, nil
 	}
-	b, err = downloader.http.Download(ctx, redirectURL)
+	b, length, err = downloader.http.Download(ctx, redirectURL)
 	if err != nil {
 		if b != nil {
 			b.Close()
 		}
-		return nil, fmt.Errorf("download asset from redirect URL: %w", err)
+		return nil, 0, fmt.Errorf("download asset from redirect URL: %w", err)
 	}
-	return b, nil
+	return b, length, nil
 }
 
 func (downloader *pkgDownloader) downloadGitHubContent(ctx context.Context, owner, repoName, version, assetName string) (io.ReadCloser, error) {
 	// https://github.com/aquaproj/aqua/issues/391
-	body, err := downloader.http.Download(ctx, "https://raw.githubusercontent.com/"+owner+"/"+repoName+"/"+version+"/"+assetName)
+	body, _, err := downloader.http.Download(ctx, "https://raw.githubusercontent.com/"+owner+"/"+repoName+"/"+version+"/"+assetName)
 	if err == nil {
 		return body, nil
 	}

--- a/pkg/download/download_test.go
+++ b/pkg/download/download_test.go
@@ -375,7 +375,7 @@ func Test_pkgDownloader_GetReadCloser(t *testing.T) { //nolint:funlen,maintidx
 		t.Run(d.name, func(t *testing.T) {
 			t.Parallel()
 			downloader := download.NewPackageDownloader(d.github, d.rt, download.NewHTTPDownloader(d.httpClient))
-			file, err := downloader.GetReadCloser(ctx, d.pkg, d.assetName, logE)
+			file, _, err := downloader.GetReadCloser(ctx, d.pkg, d.assetName, logE)
 			if err != nil {
 				if d.isErr {
 					return

--- a/pkg/download/download_url.go
+++ b/pkg/download/download_url.go
@@ -8,7 +8,7 @@ import (
 )
 
 type HTTPDownloader interface {
-	Download(ctx context.Context, u string) (io.ReadCloser, error)
+	Download(ctx context.Context, u string) (io.ReadCloser, int64, error)
 }
 
 func NewHTTPDownloader(httpClient *http.Client) HTTPDownloader {
@@ -21,17 +21,17 @@ type httpDownloader struct {
 	client *http.Client
 }
 
-func (downloader *httpDownloader) Download(ctx context.Context, u string) (io.ReadCloser, error) {
+func (downloader *httpDownloader) Download(ctx context.Context, u string) (io.ReadCloser, int64, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
-		return nil, fmt.Errorf("create a http request: %w", err)
+		return nil, 0, fmt.Errorf("create a http request: %w", err)
 	}
 	resp, err := downloader.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("send http request: %w", err)
+		return nil, 0, fmt.Errorf("send http request: %w", err)
 	}
 	if resp.StatusCode >= 400 { //nolint:gomnd
-		return resp.Body, errInvalidHTTPStatusCode
+		return resp.Body, 0, errInvalidHTTPStatusCode
 	}
-	return resp.Body, nil
+	return resp.Body, resp.ContentLength, nil
 }

--- a/pkg/download/download_url_internal_test.go
+++ b/pkg/download/download_url_internal_test.go
@@ -54,7 +54,7 @@ func Test_fromURL(t *testing.T) { //nolint:funlen
 		t.Run(d.title, func(t *testing.T) {
 			t.Parallel()
 			httpDownloader := NewHTTPDownloader(d.httpClient)
-			readCloser, err := httpDownloader.Download(ctx, d.url)
+			readCloser, _, err := httpDownloader.Download(ctx, d.url)
 			if readCloser != nil {
 				defer readCloser.Close()
 			}

--- a/pkg/download/public.go
+++ b/pkg/download/public.go
@@ -10,7 +10,7 @@ import (
 )
 
 type PackageDownloader interface {
-	GetReadCloser(ctx context.Context, pkg *config.Package, assetName string, logE *logrus.Entry) (io.ReadCloser, error)
+	GetReadCloser(ctx context.Context, pkg *config.Package, assetName string, logE *logrus.Entry) (io.ReadCloser, int64, error)
 }
 
 func NewPackageDownloader(gh RepositoriesService, rt *runtime.Runtime, httpDownloader HTTPDownloader) PackageDownloader {

--- a/pkg/download/registry.go
+++ b/pkg/download/registry.go
@@ -17,7 +17,7 @@ type registryDownloader struct {
 
 func (downloader *registryDownloader) GetGitHubContentFile(ctx context.Context, repoOwner, repoName, ref, path string, logE *logrus.Entry) ([]byte, error) {
 	// https://github.com/aquaproj/aqua/issues/391
-	body, err := downloader.http.Download(ctx, "https://raw.githubusercontent.com/"+repoOwner+"/"+repoName+"/"+ref+"/"+path)
+	body, _, err := downloader.http.Download(ctx, "https://raw.githubusercontent.com/"+repoOwner+"/"+repoName+"/"+ref+"/"+path)
 	if body != nil {
 		defer body.Close()
 	}

--- a/pkg/installpackage/download.go
+++ b/pkg/installpackage/download.go
@@ -23,7 +23,7 @@ func (inst *installer) download(ctx context.Context, pkg *config.Package, dest, 
 
 	logE.Info("download and unarchive the package")
 
-	body, err := inst.packageDownloader.GetReadCloser(ctx, pkg, assetName, logE)
+	body, cl, err := inst.packageDownloader.GetReadCloser(ctx, pkg, assetName, logE)
 	if body != nil {
 		defer body.Close()
 	}
@@ -35,7 +35,10 @@ func (inst *installer) download(ctx context.Context, pkg *config.Package, dest, 
 		Body:     body,
 		Filename: assetName,
 		Type:     pkgInfo.GetFormat(),
-	}, dest, logE, inst.fs)
+	}, dest, logE, inst.fs, &unarchive.ProgressBarOpts{
+		ContentLength: cl,
+		Description:   fmt.Sprintf("Downloading %s %s", pkg.Package.Name, pkg.Package.Version),
+	})
 }
 
 func (inst *installer) downloadGoInstall(ctx context.Context, pkg *config.Package, dest string, logE *logrus.Entry) error {

--- a/pkg/unarchive/decompressor.go
+++ b/pkg/unarchive/decompressor.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/mholt/archiver/v3"
+	"github.com/schollz/progressbar/v3"
 	"github.com/spf13/afero"
 )
 
@@ -15,7 +16,7 @@ type Decompressor struct {
 	dest         string
 }
 
-func (decompressor *Decompressor) Unarchive(fs afero.Fs, body io.Reader) error {
+func (decompressor *Decompressor) Unarchive(fs afero.Fs, body io.Reader, prgOpts *ProgressBarOpts) error {
 	dest := decompressor.dest
 	if err := fs.MkdirAll(filepath.Dir(dest), dirPermission); err != nil {
 		return fmt.Errorf("create a directory (%s): %w", dest, err)
@@ -25,5 +26,15 @@ func (decompressor *Decompressor) Unarchive(fs afero.Fs, body io.Reader) error {
 		return fmt.Errorf("open the file (%s): %w", dest, err)
 	}
 	defer f.Close()
-	return decompressor.decompressor.Decompress(body, f) //nolint:wrapcheck
+
+	var m io.Writer = f
+	if prgOpts != nil {
+		bar := progressbar.DefaultBytes(
+			prgOpts.ContentLength,
+			prgOpts.Description,
+		)
+		m = io.MultiWriter(f, bar)
+	}
+
+	return decompressor.decompressor.Decompress(body, m) //nolint:wrapcheck
 }

--- a/pkg/unarchive/unarchive.go
+++ b/pkg/unarchive/unarchive.go
@@ -14,8 +14,13 @@ import (
 
 var errUnsupportedFileFormat = errors.New("unsupported file format")
 
+type ProgressBarOpts struct {
+	ContentLength int64
+	Description   string
+}
+
 type Unarchiver interface {
-	Unarchive(fs afero.Fs, body io.Reader) error
+	Unarchive(fs afero.Fs, body io.Reader, prgOpts *ProgressBarOpts) error
 }
 
 type File struct {
@@ -24,13 +29,13 @@ type File struct {
 	Type     string
 }
 
-func Unarchive(src *File, dest string, logE *logrus.Entry, fs afero.Fs) error {
+func Unarchive(src *File, dest string, logE *logrus.Entry, fs afero.Fs, prgOpts *ProgressBarOpts) error {
 	arc, err := getUnarchiver(src, dest)
 	if err != nil {
 		return fmt.Errorf("get the unarchiver or decompressor by the file extension: %w", err)
 	}
 
-	return arc.Unarchive(fs, src.Body) //nolint:wrapcheck
+	return arc.Unarchive(fs, src.Body, prgOpts) //nolint:wrapcheck
 }
 
 func IsUnarchived(archiveType, assetName string) bool {

--- a/pkg/unarchive/unarchive_test.go
+++ b/pkg/unarchive/unarchive_test.go
@@ -61,9 +61,9 @@ func TestIsUnarchived(t *testing.T) {
 	}
 }
 
-func getReadCloser(ctx context.Context, downloader download.HTTPDownloader, body, url string) (io.ReadCloser, error) {
+func getReadCloser(ctx context.Context, downloader download.HTTPDownloader, body, url string) (io.ReadCloser, int64, error) {
 	if body != "" {
-		return io.NopCloser(strings.NewReader(body)), nil
+		return io.NopCloser(strings.NewReader(body)), 0, nil
 	}
 	return downloader.Download(ctx, url) //nolint:wrapcheck
 }
@@ -107,7 +107,7 @@ func TestUnarchive(t *testing.T) {
 		t.Run(d.title, func(t *testing.T) {
 			t.Parallel()
 			fs := afero.NewOsFs()
-			body, err := getReadCloser(ctx, httpDownloader, d.body, d.url)
+			body, _, err := getReadCloser(ctx, httpDownloader, d.body, d.url)
 			if body != nil {
 				defer body.Close()
 			}
@@ -115,7 +115,7 @@ func TestUnarchive(t *testing.T) {
 				t.Fatal(err)
 			}
 			d.src.Body = body
-			if err := unarchive.Unarchive(d.src, t.TempDir(), logE, fs); err != nil {
+			if err := unarchive.Unarchive(d.src, t.TempDir(), logE, fs, nil); err != nil {
 				if d.isErr {
 					return
 				}


### PR DESCRIPTION
Close #956

Powered by [github.com/schollz/progressbar/v3](https://pkg.go.dev/github.com/schollz/progressbar/v3).

## Example

```console
$ aqua i
INFO[0000] download and unarchive the package            aqua_version= env=darwin/arm64 package_name=aqua-proxy package_version=v1.1.2 program=aqua registry=
Downloading aqua-proxy v1.1.2 100% |██████████████████████████████████████████████████████████████████████████████████████████████████████████| (668/668 kB, 11.270 MB/s)
INFO[0000] create a symbolic link                        aqua_version= env=darwin/arm64 link_file=/Users/shunsukesuzuki/Documents/test/aqua/progress/aquaproj-aqua/bin/aqua-proxy new=../pkgs/github_release/github.com/aquaproj/aqua-proxy/v1.1.2/aqua-proxy_darwin_arm64.tar.gz/aqua-proxy package_name=aqua-proxy package_version=v1.1.2 program=aqua registry=
INFO[0000] create a symbolic link                        aqua_version= env=darwin/arm64 link_file=/Users/shunsukesuzuki/Documents/test/aqua/progress/aquaproj-aqua/bin/aqua-installer new=aqua-proxy package_name=aquaproj/aqua-installer package_version=v1.0.0 program=aqua registry=standard registry_ref=v3.4.0
INFO[0000] create a symbolic link                        aqua_version= env=darwin/arm64 link_file=/Users/shunsukesuzuki/Documents/test/aqua/progress/aquaproj-aqua/bin/tokei new=aqua-proxy package_name=XAMPPRocky/tokei package_version=v12.1.2 program=aqua registry=standard registry_ref=v3.4.0
INFO[0000] create a symbolic link                        aqua_version= env=darwin/arm64 link_file=/Users/shunsukesuzuki/Documents/test/aqua/progress/aquaproj-aqua/bin/terraform new=aqua-proxy package_name=hashicorp/terraform package_version=v1.2.3 program=aqua registry=standard registry_ref=v3.4.0
INFO[0000] create a symbolic link                        aqua_version= env=darwin/arm64 link_file=/Users/shunsukesuzuki/Documents/test/aqua/progress/aquaproj-aqua/bin/tfcmt new=aqua-proxy package_name=suzuki-shunsuke/tfcmt package_version=v3.2.5 program=aqua registry=standard registry_ref=v3.4.0
INFO[0000] download and unarchive the package            aqua_version= env=darwin/arm64 package_name=suzuki-shunsuke/tfcmt package_version=v3.2.5 program=aqua registry=standard
INFO[0000] download and unarchive the package            aqua_version= env=darwin/arm64 package_name=XAMPPRocky/tokei package_version=v12.1.2 program=aqua registry=standard
INFO[0000] download and unarchive the package            aqua_version= env=darwin/arm64 package_name=aquaproj/aqua-installer package_version=v1.0.0 program=aqua registry=standard
INFO[0000] download and unarchive the package            aqua_version= env=darwin/arm64 package_name=hashicorp/terraform package_version=v1.2.3 program=aqua registry=standard
Downloading aquaproj/aqua-installer v1.0.0   0% |                                                                                                            | ( 0/ 0B, ) [0s:0s]
Downloading XAMPPRocky/tokei v12.1.2 100% |████████████████████████████████████████████████████████████████████████████████████████████████████| (1.5/1.5 MB, 7.936 MB/s)        
Downloading hashicorp/terraform v1.2.3 100% |███████████████████████████████████████████████████████████████████████████████████████████████████| (19/19 MB, 23.924 MB/s)        
Downloading suzuki-shunsuke/tfcmt v3.2.5 100% |████████████████████████████████████████████████████████████████████████████████████████████████| (3.7/3.7 MB, 2.076 MB/s)        

```

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/13323303/176355187-42bffdf9-5871-4be0-ad0a-624f53ab47ac.png">

## Known Issue

[DownloadReleaseAsset](https://pkg.go.dev/github.com/google/go-github/v45/github#RepositoriesService.DownloadReleaseAsset) doesn't return http.Response, so we can't get the content length.