### PR TITLE
fix(generate-registry): fix replacements

### DIFF
--- a/pkg/controller/generate-registry/arch.go
+++ b/pkg/controller/generate-registry/arch.go
@@ -51,6 +51,6 @@ func (ctrl *Controller) setArch(assetName, lowAssetName string, assetInfo *Asset
 	}
 	if assetInfo.Arch == "" {
 		assetInfo.Arch = "amd64"
-		assetInfo.Score = -1
+		assetInfo.Score = -2 //nolint:gomnd
 	}
 }

--- a/pkg/controller/generate-registry/os.go
+++ b/pkg/controller/generate-registry/os.go
@@ -74,6 +74,10 @@ func (ctrl *Controller) setOS(assetName, lowAssetName string, assetInfo *AssetIn
 				assetInfo.Replacements[o.OS] = osName
 			}
 			assetInfo.Template = strings.Replace(assetInfo.Template, osName, "{{.OS}}", 1)
+			if osName == "unknown-linux-gnu" || osName == "pc-windows-gnu" {
+				// "unknown-linux-musl" and "pc-windows-msvc" take precedence over "unknown-linux-gnu" and "pc-windows-gnu".
+				assetInfo.Score = -1
+			}
 			break
 		}
 	}


### PR DESCRIPTION
"unknown-linux-musl" and "pc-windows-msvc" take precedence over "unknown-linux-gnu" and "pc-windows-gnu"