### PR TITLE
fix: disable the progress bar by default

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -43,6 +43,8 @@ jobs:
       working-directory: tests
     - run: kind version
     - run: restic version
+      env:
+        AQUA_PROGRESS_BAR: "true"
     - run: migrate -version
     - run: ghq -version
     - run: gh version
@@ -123,6 +125,8 @@ jobs:
       working-directory: tests
     - run: kind version
     - run: restic version
+      env:
+        AQUA_PROGRESS_BAR: "true"
     - run: migrate -version
     - run: ghq -version
     - run: gh version
@@ -187,6 +191,8 @@ jobs:
       working-directory: tests
     - run: kind version
     - run: restic version
+      env:
+        AQUA_PROGRESS_BAR: "true"
     - run: migrate -version
     - run: ghq -version
     - run: gh version

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -57,6 +57,7 @@ func (runner *Runner) setParam(c *cli.Context, commandName string, param *config
 		return fmt.Errorf("get the current directory: %w", err)
 	}
 	param.PWD = wd
+	param.NoProgressBar = os.Getenv("AQUA_NO_PROGRESS_BAR") == "true"
 	return nil
 }
 

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -57,7 +57,7 @@ func (runner *Runner) setParam(c *cli.Context, commandName string, param *config
 		return fmt.Errorf("get the current directory: %w", err)
 	}
 	param.PWD = wd
-	param.NoProgressBar = os.Getenv("AQUA_NO_PROGRESS_BAR") == "true"
+	param.ProgressBar = os.Getenv("AQUA_PROGRESS_BAR") == "true"
 	return nil
 }
 

--- a/pkg/config/package.go
+++ b/pkg/config/package.go
@@ -174,7 +174,7 @@ type Param struct {
 	All                   bool
 	Insert                bool
 	SelectVersion         bool
-	NoProgressBar         bool
+	ProgressBar           bool
 }
 
 func (cpkg *Package) RenderAsset(rt *runtime.Runtime) (string, error) {

--- a/pkg/config/package.go
+++ b/pkg/config/package.go
@@ -174,6 +174,7 @@ type Param struct {
 	All                   bool
 	Insert                bool
 	SelectVersion         bool
+	NoProgressBar         bool
 }
 
 func (cpkg *Package) RenderAsset(rt *runtime.Runtime) (string, error) {

--- a/pkg/installpackage/download.go
+++ b/pkg/installpackage/download.go
@@ -32,7 +32,7 @@ func (inst *installer) download(ctx context.Context, pkg *config.Package, dest, 
 	}
 
 	var pOpts *unarchive.ProgressBarOpts
-	if !inst.noProgressBar {
+	if inst.progressBar {
 		pOpts = &unarchive.ProgressBarOpts{
 			ContentLength: cl,
 			Description:   fmt.Sprintf("Downloading %s %s", pkg.Package.Name, pkg.Package.Version),

--- a/pkg/installpackage/download.go
+++ b/pkg/installpackage/download.go
@@ -31,14 +31,19 @@ func (inst *installer) download(ctx context.Context, pkg *config.Package, dest, 
 		return err //nolint:wrapcheck
 	}
 
+	var pOpts *unarchive.ProgressBarOpts
+	if !inst.noProgressBar {
+		pOpts = &unarchive.ProgressBarOpts{
+			ContentLength: cl,
+			Description:   fmt.Sprintf("Downloading %s %s", pkg.Package.Name, pkg.Package.Version),
+		}
+	}
+
 	return unarchive.Unarchive(&unarchive.File{ //nolint:wrapcheck
 		Body:     body,
 		Filename: assetName,
 		Type:     pkgInfo.GetFormat(),
-	}, dest, logE, inst.fs, &unarchive.ProgressBarOpts{
-		ContentLength: cl,
-		Description:   fmt.Sprintf("Downloading %s %s", pkg.Package.Name, pkg.Package.Version),
-	})
+	}, dest, logE, inst.fs, pOpts)
 }
 
 func (inst *installer) downloadGoInstall(ctx context.Context, pkg *config.Package, dest string, logE *logrus.Entry) error {

--- a/pkg/installpackage/installer.go
+++ b/pkg/installpackage/installer.go
@@ -24,6 +24,7 @@ const proxyName = "aqua-proxy"
 type installer struct {
 	rootDir           string
 	maxParallelism    int
+	noProgressBar     bool
 	packageDownloader download.PackageDownloader
 	runtime           *runtime.Runtime
 	fs                afero.Fs

--- a/pkg/installpackage/installer.go
+++ b/pkg/installpackage/installer.go
@@ -24,7 +24,7 @@ const proxyName = "aqua-proxy"
 type installer struct {
 	rootDir           string
 	maxParallelism    int
-	noProgressBar     bool
+	progressBar       bool
 	packageDownloader download.PackageDownloader
 	runtime           *runtime.Runtime
 	fs                afero.Fs

--- a/pkg/installpackage/public.go
+++ b/pkg/installpackage/public.go
@@ -33,5 +33,6 @@ func New(param *config.Param, downloader download.PackageDownloader, rt *runtime
 		fs:                fs,
 		linker:            linker,
 		executor:          executor,
+		noProgressBar:     param.NoProgressBar,
 	}
 }

--- a/pkg/installpackage/public.go
+++ b/pkg/installpackage/public.go
@@ -33,6 +33,6 @@ func New(param *config.Param, downloader download.PackageDownloader, rt *runtime
 		fs:                fs,
 		linker:            linker,
 		executor:          executor,
-		noProgressBar:     param.NoProgressBar,
+		progressBar:       param.ProgressBar,
 	}
 }


### PR DESCRIPTION
Close #976

The progress bar is disabled by default, but you can enable it by setting the environment variable `AQUA_PROGRESS_BAR` to `true`.

```console
$ export AQUA_PROGRESS_BAR=true
```