### PR TITLE
feat: support setting log coloring

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -35,6 +35,8 @@ jobs:
       working-directory: tests
     - run: aqua i --test
       working-directory: tests
+      env:
+        AQUA_LOG_COLOR: always
     - run: aqua which golangci-lint
       working-directory: tests
     - run: aqua which go

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -46,10 +46,12 @@ func (runner *Runner) setParam(c *cli.Context, commandName string, param *config
 	param.All = c.Bool("all")
 	param.SelectVersion = c.Bool("select-version")
 	param.File = c.String("f")
+	param.LogColor = os.Getenv("AQUA_LOG_COLOR")
 	param.AQUAVersion = runner.LDFlags.Version
 	param.RootDir = config.GetRootDir(osenv.New())
 	logE := runner.LogE
 	log.SetLevel(param.LogLevel, logE)
+	log.SetColor(param.LogColor, logE)
 	param.MaxParallelism = config.GetMaxParallelism(os.Getenv("AQUA_MAX_PARALLELISM"), logE)
 	param.GlobalConfigFilePaths = finder.ParseGlobalConfigFilePaths(os.Getenv("AQUA_GLOBAL_CONFIG"))
 	wd, err := os.Getwd()

--- a/pkg/config/package.go
+++ b/pkg/config/package.go
@@ -168,6 +168,7 @@ type Param struct {
 	RootDir               string
 	PWD                   string
 	InsertFile            string
+	LogColor              string
 	MaxParallelism        int
 	OnlyLink              bool
 	IsTest                bool

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -24,3 +24,21 @@ func SetLevel(level string, logE *logrus.Entry) {
 	}
 	logrus.SetLevel(lvl)
 }
+
+func SetColor(color string, logE *logrus.Entry) {
+	switch color {
+	case "", "auto":
+		return
+	case "always":
+		logrus.SetFormatter(&logrus.TextFormatter{
+			ForceColors: true,
+		})
+	case "never":
+		logrus.SetFormatter(&logrus.TextFormatter{
+			DisableColors: true,
+		})
+	default:
+		logE.WithField("log_color", color).Error("log_color is invalid")
+		return
+	}
+}


### PR DESCRIPTION
Close #982

Support setting the log coloring by the environment variable `AQUA_LOG_COLOR`.

```console
$ export AQUA_LOG_COLOR=always|auto|never
```