### PR TITLE
fix(generate): suppress outputting an empty array

### DIFF
--- a/pkg/controller/generate/generate.go
+++ b/pkg/controller/generate/generate.go
@@ -78,7 +78,7 @@ func (ctrl *Controller) Generate(ctx context.Context, logE *logrus.Entry, param 
 		return err
 	}
 	list = excludeDuplicatedPkgs(logE, cfg, list)
-	if list == nil {
+	if len(list) == 0 {
 		return nil
 	}
 	if !param.Insert && param.Dest == "" {


### PR DESCRIPTION
```console
$ aqua g
[]
```