### PR TITLE
fix: typo in output

### DIFF
--- a/pkg/controller/generate/generate.go
+++ b/pkg/controller/generate/generate.go
@@ -132,7 +132,7 @@ func excludeDuplicatedPkgs(logE *logrus.Entry, cfg *aqua.Config, pkgs []*aqua.Pa
 				"package_name":     pkg.Name,
 				"package_version":  pkg.Version,
 				"package_registry": registry,
-			}).Warn("skip adding a dupliated package")
+			}).Warn("skip adding a duplicate package")
 			continue
 		}
 		m[keyV] = pkg


### PR DESCRIPTION
Fix typo in `aqua generate` output

Signed-off-by: Noel Georgi <git@frezbo.dev>