### PR TITLE
fix: improve a log creating a symbolic link

### DIFF
--- a/pkg/installpackage/link.go
+++ b/pkg/installpackage/link.go
@@ -29,8 +29,7 @@ func (inst *Installer) createLink(linkPath, linkDest string, logE *logrus.Entry)
 		}
 	}
 	logE.WithFields(logrus.Fields{
-		"link_file": linkPath,
-		"new":       linkDest,
+		"command": filepath.Base(linkPath),
 	}).Info("create a symbolic link")
 	if err := inst.linker.Symlink(linkDest, linkPath); err != nil {
 		return fmt.Errorf("create a symbolic link: %w", err)


### PR DESCRIPTION
Replace log fields `link_file` and `new` to `command`.

AS IS

```
$ aqua i
INFO[0000] create a symbolic link                        aqua_version= env=darwin/arm64 link_file=/Users/shunsukesuzuki/.local/share/aquaproj-aqua/bin/actionlint new=aqua-proxy program=aqua
```

```
$ aqua i
INFO[0000] create a symbolic link                        aqua_version= command=actionlint env=darwin/arm64 program=aqua
```