### PR TITLE
feat(cp): support copying all packages

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -93,6 +93,10 @@ jobs:
       run: dist/actionlint -version
     - name: test aqua cp
       run: dist/golangci-lint version
+    - name: test aqua cp
+      run: aqua cp
+    - name: test aqua cp -a
+      run: aqua cp -a
 
     # Test if global configuration files are read in `aqua list` and `aqua g`
     - run: aqua g suzuki-shunsuke/cmdx

--- a/pkg/cli/cp.go
+++ b/pkg/cli/cp.go
@@ -36,6 +36,14 @@ gh
 You can specify the target directory by -o option.
 
 $ aqua cp -o ~/bin terraform hugo
+
+If you don't specify commands, all commands are copied.
+
+$ aqua cp
+
+You can also copy global configuration files' commands with "-a" option.
+
+$ aqua cp -a
 `,
 		Action: runner.cpAction,
 	}

--- a/pkg/cli/cp.go
+++ b/pkg/cli/cp.go
@@ -20,6 +20,11 @@ func (runner *Runner) newCpCommand() *cli.Command {
 				Value: "dist",
 				Usage: "destination directory",
 			},
+			&cli.BoolFlag{
+				Name:    "all",
+				Aliases: []string{"a"},
+				Usage:   "install all aqua configuration packages",
+			},
 		},
 		Description: `Copy executable files in a directory.
 

--- a/pkg/cli/cp.go
+++ b/pkg/cli/cp.go
@@ -66,6 +66,7 @@ func (runner *Runner) cpAction(c *cli.Context) error {
 	if err := runner.setParam(c, "cp", param); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
+	param.IsTest = true
 	ctrl := controller.InitializeCopyCommandController(c.Context, param, http.DefaultClient, runner.Runtime)
 	if err := ctrl.Copy(c.Context, runner.LogE, param); err != nil {
 		return err //nolint:wrapcheck

--- a/pkg/controller/install/install.go
+++ b/pkg/controller/install/install.go
@@ -46,19 +46,20 @@ func New(param *config.Param, configFinder ConfigFinder, configReader domain.Con
 }
 
 func (ctrl *Controller) Install(ctx context.Context, logE *logrus.Entry, param *config.Param) error {
-	rootBin := filepath.Join(ctrl.rootDir, "bin")
-
-	if err := ctrl.fs.MkdirAll(rootBin, dirPermission); err != nil {
-		return fmt.Errorf("create the directory: %w", err)
-	}
-	if ctrl.runtime.GOOS == "windows" {
-		if err := ctrl.fs.MkdirAll(filepath.Join(ctrl.rootDir, "bat"), dirPermission); err != nil {
+	if param.Dest != "" { //nolint:nestif
+		rootBin := filepath.Join(ctrl.rootDir, "bin")
+		if err := ctrl.fs.MkdirAll(rootBin, dirPermission); err != nil {
 			return fmt.Errorf("create the directory: %w", err)
 		}
-	}
+		if ctrl.runtime.GOOS == "windows" {
+			if err := ctrl.fs.MkdirAll(filepath.Join(ctrl.rootDir, "bat"), dirPermission); err != nil {
+				return fmt.Errorf("create the directory: %w", err)
+			}
+		}
 
-	if err := ctrl.packageInstaller.InstallProxy(ctx, logE); err != nil {
-		return err //nolint:wrapcheck
+		if err := ctrl.packageInstaller.InstallProxy(ctx, logE); err != nil {
+			return err //nolint:wrapcheck
+		}
 	}
 
 	for _, cfgFilePath := range ctrl.configFinder.Finds(param.PWD, param.ConfigFilePath) {

--- a/pkg/controller/install/install.go
+++ b/pkg/controller/install/install.go
@@ -46,7 +46,7 @@ func New(param *config.Param, configFinder ConfigFinder, configReader domain.Con
 }
 
 func (ctrl *Controller) Install(ctx context.Context, logE *logrus.Entry, param *config.Param) error {
-	if param.Dest != "" { //nolint:nestif
+	if param.Dest == "" { //nolint:nestif
 		rootBin := filepath.Join(ctrl.rootDir, "bin")
 		if err := ctrl.fs.MkdirAll(rootBin, dirPermission); err != nil {
 			return fmt.Errorf("create the directory: %w", err)

--- a/pkg/controller/wire.go
+++ b/pkg/controller/wire.go
@@ -253,6 +253,11 @@ func InitializeCopyCommandController(ctx context.Context, param *config.Param, h
 		wire.NewSet(
 			finder.NewConfigFinder,
 			wire.Bind(new(which.ConfigFinder), new(*finder.ConfigFinder)),
+			wire.Bind(new(install.ConfigFinder), new(*finder.ConfigFinder)),
+		),
+		wire.NewSet(
+			install.New,
+			wire.Bind(new(cp.Installer), new(*install.Controller)),
 		),
 		wire.NewSet(
 			download.NewPackageDownloader,

--- a/pkg/controller/wire_gen.go
+++ b/pkg/controller/wire_gen.go
@@ -139,7 +139,8 @@ func InitializeCopyCommandController(ctx context.Context, param *config.Param, h
 	registryInstaller := registry.New(param, gitHubContentFileDownloader, fs)
 	osEnv := osenv.New()
 	controller := which.New(param, configFinder, configReader, registryInstaller, rt, osEnv, fs, linker)
-	cpController := cp.New(param, installer, fs, rt, controller)
+	installController := install.New(param, configFinder, configReader, registryInstaller, installer, fs, rt)
+	cpController := cp.New(param, installer, fs, rt, controller, installController)
 	return cpController
 }
 

--- a/pkg/domain/package_installer.go
+++ b/pkg/domain/package_installer.go
@@ -20,4 +20,5 @@ type ParamInstallPackages struct {
 	ConfigFilePath string
 	Config         *aqua.Config
 	Registries     map[string]*registry.Config
+	SkipLink       bool
 }

--- a/pkg/installpackage/installer.go
+++ b/pkg/installpackage/installer.go
@@ -240,6 +240,7 @@ func (inst *Installer) checkAndCopyFile(ctx context.Context, pkg *config.Package
 	if inst.copyDir == "" {
 		return nil
 	}
+	logE.Info("copying an executable file")
 	if err := inst.copy(filepath.Join(inst.copyDir, file.Name), exePath); err != nil {
 		return err
 	}

--- a/pkg/installpackage/installer.go
+++ b/pkg/installpackage/installer.go
@@ -3,6 +3,8 @@ package installpackage
 import (
 	"context"
 	"fmt"
+	"io"
+	"os"
 	"path/filepath"
 	"sync"
 
@@ -33,6 +35,7 @@ type Installer struct {
 	progressBar        bool
 	onlyLink           bool
 	isTest             bool
+	copyDir            string
 }
 
 func isWindows(goos string) bool {
@@ -153,7 +156,9 @@ func (inst *Installer) InstallPackage(ctx context.Context, logE *logrus.Entry, p
 	}
 
 	for _, file := range pkgInfo.GetFiles() {
-		if err := inst.checkFileSrc(ctx, pkg, file, logE); err != nil {
+		file := file
+		logE := logE.WithField("file_name", file.Name)
+		if err := inst.checkAndCopyFile(ctx, pkg, file, logE); err != nil {
 			if inst.isTest {
 				return fmt.Errorf("check file_src is correct: %w", err)
 			}
@@ -195,7 +200,7 @@ type DownloadParam struct {
 	Asset     string
 }
 
-func (inst *Installer) checkFileSrcGo(ctx context.Context, pkg *config.Package, file *registry.File, logE *logrus.Entry) error {
+func (inst *Installer) checkFileSrcGo(ctx context.Context, pkg *config.Package, file *registry.File, logE *logrus.Entry) (string, error) {
 	pkgInfo := pkg.PackageInfo
 	exePath := filepath.Join(inst.rootDir, "pkgs", pkgInfo.GetType(), "github.com", pkgInfo.RepoOwner, pkgInfo.RepoName, pkg.Package.Version, "bin", file.Name)
 	if isWindows(inst.runtime.GOOS) {
@@ -203,11 +208,11 @@ func (inst *Installer) checkFileSrcGo(ctx context.Context, pkg *config.Package, 
 	}
 	dir, err := pkg.RenderDir(file, inst.runtime)
 	if err != nil {
-		return fmt.Errorf("render file dir: %w", err)
+		return "", fmt.Errorf("render file dir: %w", err)
 	}
 	exeDir := filepath.Join(inst.rootDir, "pkgs", pkgInfo.GetType(), "github.com", pkgInfo.RepoOwner, pkgInfo.RepoName, pkg.Package.Version, "src", dir)
 	if _, err := inst.fs.Stat(exePath); err == nil {
-		return nil
+		return exePath, nil
 	}
 	src := file.Src
 	if src == "" {
@@ -219,46 +224,82 @@ func (inst *Installer) checkFileSrcGo(ctx context.Context, pkg *config.Package, 
 		"go_build_dir": exeDir,
 	}).Info("building Go tool")
 	if _, err := inst.executor.GoBuild(ctx, exePath, src, exeDir); err != nil {
-		return fmt.Errorf("build Go tool: %w", err)
+		return "", fmt.Errorf("build Go tool: %w", err)
 	}
+	return exePath, nil
+}
+
+func (inst *Installer) checkAndCopyFile(ctx context.Context, pkg *config.Package, file *registry.File, logE *logrus.Entry) error {
+	exePath, err := inst.checkFileSrc(ctx, pkg, file, logE)
+	if err != nil {
+		if inst.isTest {
+			return fmt.Errorf("check file_src is correct: %w", err)
+		}
+		logerr.WithError(logE, err).Warn("check file_src is correct")
+	}
+	if inst.copyDir == "" {
+		return nil
+	}
+	if err := inst.copy(filepath.Join(inst.copyDir, file.Name), exePath); err != nil {
+		return err
+	}
+
 	return nil
 }
 
-func (inst *Installer) checkFileSrc(ctx context.Context, pkg *config.Package, file *registry.File, logE *logrus.Entry) error {
-	fields := logrus.Fields{
-		"file_name": file.Name,
-	}
-	logE = logE.WithFields(fields)
-
+func (inst *Installer) checkFileSrc(ctx context.Context, pkg *config.Package, file *registry.File, logE *logrus.Entry) (string, error) {
 	if pkg.PackageInfo.Type == "go" {
 		return inst.checkFileSrcGo(ctx, pkg, file, logE)
 	}
 
 	pkgPath, err := pkg.GetPkgPath(inst.rootDir, inst.runtime)
 	if err != nil {
-		return fmt.Errorf("get the package install path: %w", err)
+		return "", fmt.Errorf("get the package install path: %w", err)
 	}
 
 	fileSrc, err := pkg.RenameFile(logE, inst.fs, pkgPath, file, inst.runtime)
 	if err != nil {
-		return fmt.Errorf("get file_src: %w", err)
+		return "", fmt.Errorf("get file_src: %w", err)
 	}
 
 	exePath := filepath.Join(pkgPath, fileSrc)
 	finfo, err := inst.fs.Stat(exePath)
 	if err != nil {
-		return fmt.Errorf("exe_path isn't found: %w", logerr.WithFields(err, fields))
+		return "", fmt.Errorf("exe_path isn't found: %w", logerr.WithFields(err, logE.Data))
 	}
 	if finfo.IsDir() {
-		return logerr.WithFields(errExePathIsDirectory, fields) //nolint:wrapcheck
+		return "", logerr.WithFields(errExePathIsDirectory, logE.Data) //nolint:wrapcheck
 	}
 
 	logE.Debug("check the permission")
 	if mode := finfo.Mode().Perm(); !util.IsOwnerExecutable(mode) {
 		logE.Debug("add the permission to execute the command")
 		if err := inst.fs.Chmod(exePath, util.AllowOwnerExec(mode)); err != nil {
-			return logerr.WithFields(errChmod, fields) //nolint:wrapcheck
+			return "", logerr.WithFields(errChmod, logE.Data) //nolint:wrapcheck
 		}
 	}
+
+	return exePath, nil
+}
+
+const (
+	filePermission os.FileMode = 0o755
+)
+
+func (inst *Installer) copy(dest, src string) error {
+	dst, err := inst.fs.OpenFile(dest, os.O_RDWR|os.O_CREATE|os.O_TRUNC, filePermission) //nolint:nosnakecase
+	if err != nil {
+		return fmt.Errorf("create a file: %w", err)
+	}
+	defer dst.Close()
+	srcFile, err := inst.fs.Open(src)
+	if err != nil {
+		return fmt.Errorf("open a file: %w", err)
+	}
+	defer srcFile.Close()
+	if _, err := io.Copy(dst, srcFile); err != nil {
+		return fmt.Errorf("copy a file: %w", err)
+	}
+
 	return nil
 }

--- a/pkg/installpackage/public.go
+++ b/pkg/installpackage/public.go
@@ -30,5 +30,6 @@ func New(param *config.Param, downloader domain.PackageDownloader, rt *runtime.R
 		progressBar:        param.ProgressBar,
 		isTest:             param.IsTest,
 		onlyLink:           param.OnlyLink,
+		copyDir:            param.Dest,
 	}
 }


### PR DESCRIPTION
Close #1173

## Example

```console
$ aqua cp
INFO[0000] copying an executable file                    aqua_version= env=darwin/arm64 file_name=cmdx package_name=suzuki-shunsuke/cmdx package_version=v1.6.1 program=aqua registry=standard
INFO[0000] copying an executable file                    aqua_version= env=darwin/arm64 file_name=actionlint package_name=rhysd/actionlint package_version=v1.6.20 program=aqua registry=standard
INFO[0000] copying an executable file                    aqua_version= env=darwin/arm64 file_name=reviewdog package_name=reviewdog/reviewdog package_version=v0.14.1 program=aqua registry=standard
INFO[0000] copying an executable file                    aqua_version= env=darwin/arm64 file_name=golangci-lint package_name=golangci/golangci-lint package_version=v1.49.0 program=aqua registry=standard
```