### PR TITLE
fix: change the structure of aqua-checksums.json

### DIFF
--- a/pkg/checksum/type.go
+++ b/pkg/checksum/type.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"sort"
 	"sync"
 
 	"github.com/spf13/afero"
@@ -84,6 +85,9 @@ func (chksums *Checksums) UpdateFile(fs afero.Fs, p string) error {
 	for _, chk := range chksums.m {
 		arr = append(arr, chk)
 	}
+	sort.Slice(arr, func(i, j int) bool {
+		return arr[i].ID < arr[j].ID
+	})
 	chkJSON := &checksumsJSON{
 		Checksums: arr,
 	}

--- a/pkg/controller/updatechecksum/update.go
+++ b/pkg/controller/updatechecksum/update.go
@@ -153,7 +153,7 @@ func (ctrl *Controller) getChecksums(ctx context.Context, logE *logrus.Entry, ch
 			return fmt.Errorf("get a checksum id: %w", err)
 		}
 
-		if a := checksums.Get(checksumID); a != "" {
+		if a := checksums.Get(checksumID); a != nil {
 			continue
 		}
 
@@ -184,7 +184,11 @@ func (ctrl *Controller) getChecksums(ctx context.Context, logE *logrus.Entry, ch
 				"checksum_id": checksumID,
 				"checksum":    checksumFile,
 			}).Debug("set a checksum")
-			checksums.Set(checksumID, checksumFile)
+			checksums.Set(checksumID, &checksum.Checksum{
+				ID:        checksumID,
+				Checksum:  checksumFile,
+				Algorithm: pkgInfo.Checksum.GetAlgorithm(),
+			})
 			continue
 		}
 		m, err := ctrl.parser.ParseChecksumFile(checksumFile, pkg)
@@ -200,7 +204,11 @@ func (ctrl *Controller) getChecksums(ctx context.Context, logE *logrus.Entry, ch
 				"checksum_id": checksumID,
 				"checksum":    chksum,
 			}).Debug("set a checksum")
-			checksums.Set(checksumID, chksum)
+			checksums.Set(checksumID, &checksum.Checksum{
+				ID:        checksumID,
+				Checksum:  chksum,
+				Algorithm: pkgInfo.Checksum.GetAlgorithm(),
+			})
 		}
 	}
 	return nil


### PR DESCRIPTION
AS IS

```json
{
  "checksums": {
    "github_archive/github.com/b3nj5m1n/xdg-ninja/v0.2.0.1": "f4f9ab4500e7cf865ff8b68c343537e27b9ff1e6068cb1387e516e608f77cec8"
  }
}
```

TO BE

```json
{
  "checksums": [
    {
      "id": "github_archive/github.com/b3nj5m1n/xdg-ninja/v0.2.0.1",
      "checksum": "f4f9ab4500e7cf865ff8b68c343537e27b9ff1e6068cb1387e516e608f77cec8",
      "algorithm": "sha256"
    }
  ]
}
```

## WHY

The current format doesn't have the checksum algorithm.
The current default checksum algorithm is `sha512`, but when this will be changed, the configuration file will be broken.
To solve the problem, the new format has the checksum algorithm.
Additionally, the value is not a atring but a object, so we can add new fields in future keeping the compatibility.