### PR TITLE
feat(generate): support specifying version

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -28,7 +28,9 @@ jobs:
     - run: echo "x-motemen/ghq" | aqua g -f -
     - run: echo "local,aquaproj/aqua-installer" | aqua -c tests/aqua-global.yaml g -f -
     - run: aqua g x-motemen/ghq aquaproj/aqua-installer
-    - run: echo cli/cli | aqua g -f - x-motemen/ghq aquaproj/aqua-installer
+    - run: echo cli/cli | aqua g -f - x-motemen/ghq aquaproj/aqua-installer suzuki-shunsuke/tfcmt@v3.0.0
+    - name: Test -pin
+      run: aqua g cli/cli suzuki-shunsuke/tfcmt@v2.0.0
 
     - run: aqua list
     - run: aqua update-checksum

--- a/pkg/cli/generate.go
+++ b/pkg/cli/generate.go
@@ -54,11 +54,12 @@ $ aqua g -o aqua/pkgs.yaml
 
 You can pass packages with positional arguments.
 
-$ aqua g [<registry name>,<package name> ...]
+$ aqua g [<registry name>,<package name>[@<version>] ...]
 
-$ aqua g standard,cli/cli standard,junegunn/fzf
+$ aqua g standard,cli/cli standard,junegunn/fzf standard,suzuki-shunsuke/tfcmt@v3.0.0
 - name: cli/cli@v2.2.0
 - name: junegunn/fzf@0.28.0
+- name: suzuki-shunsuke/tfcmt@v3.0.0
 
 You can omit the registry name if it is "standard".
 
@@ -87,6 +88,12 @@ echo "cli/cli" | aqua g -f -
 You can select a version interactively with "-s" option.
 
 $ aqua g -s
+
+The option "-pin" is useful to prevent the package from being updated by Renovate.
+
+$ aqua g -pin cli/cli
+- name: cli/cli
+  version: v2.2.0
 `
 
 func (runner *Runner) newGenerateCommand() *cli.Command {
@@ -105,6 +112,10 @@ func (runner *Runner) newGenerateCommand() *cli.Command {
 			&cli.BoolFlag{
 				Name:  "i",
 				Usage: `Insert packages to configuration file`,
+			},
+			&cli.BoolFlag{
+				Name:  "pin",
+				Usage: `Pin version`,
 			},
 			&cli.StringFlag{
 				Name:  "o",

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -57,6 +57,7 @@ func (runner *Runner) setParam(c *cli.Context, commandName string, param *config
 	param.MaxParallelism = config.GetMaxParallelism(os.Getenv("AQUA_MAX_PARALLELISM"), logE)
 	param.GlobalConfigFilePaths = finder.ParseGlobalConfigFilePaths(os.Getenv("AQUA_GLOBAL_CONFIG"))
 	param.Deep = c.Bool("deep")
+	param.Pin = c.Bool("pin")
 	wd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("get the current directory: %w", err)

--- a/pkg/config/package.go
+++ b/pkg/config/package.go
@@ -181,6 +181,7 @@ type Param struct {
 	ProgressBar           bool
 	Deep                  bool
 	SkipLink              bool
+	Pin                   bool
 }
 
 func (cpkg *Package) RenderAsset(rt *runtime.Runtime) (string, error) {

--- a/pkg/controller/generate/generate.go
+++ b/pkg/controller/generate/generate.go
@@ -251,6 +251,9 @@ func (ctrl *Controller) getOutputtedPkg(ctx context.Context, logE *logrus.Entry,
 		outputPkg.Version = "[SET PACKAGE VERSION]"
 		return outputPkg
 	}
+	if param.Pin {
+		return outputPkg
+	}
 	pkgInfo := pkg.PackageInfo
 	if pkgInfo.HasRepo() {
 		repoOwner := pkgInfo.RepoOwner

--- a/pkg/controller/generate/read_pkg_file.go
+++ b/pkg/controller/generate/read_pkg_file.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/aquaproj/aqua/pkg/config"
 	"github.com/aquaproj/aqua/pkg/config/aqua"
@@ -27,10 +28,12 @@ func (ctrl *Controller) readGeneratedPkgsFromFile(ctx context.Context, logE *log
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		txt := getGeneratePkg(scanner.Text())
-		findingPkg, ok := m[txt]
+		key, version, _ := strings.Cut(txt, "@")
+		findingPkg, ok := m[key]
 		if !ok {
 			return nil, logerr.WithFields(errUnknownPkg, logrus.Fields{"package_name": txt}) //nolint:wrapcheck
 		}
+		findingPkg.Version = version
 		outputPkg := ctrl.getOutputtedPkg(ctx, logE, param, findingPkg)
 		outputPkgs = append(outputPkgs, outputPkg)
 	}


### PR DESCRIPTION
Close https://github.com/aquaproj/aqua/issues/1352

`aqua generate` supports specifying the package version. The package version is optional.

e.g.

```console
$ aqua g cli/cli
- name: cli/cli@v2.18.1

$ aqua g cli/cli@v2.0.0
- name: cli/cli@v2.0.0
```

The option `-pin` is added to `aqua generate` command.
This option is useful to prevent the package from being updated by Renovate.

```console
$ aqua g -pin cli/cli
- name: cli/cli
  version: v2.18.1

$ aqua g -pin cli/cli@v2.0.0
- name: cli/cli
  version: v2.0.0
```