### PR TITLE
fix(generate): fix a panic

### DIFF
--- a/pkg/controller/generate/generate.go
+++ b/pkg/controller/generate/generate.go
@@ -192,10 +192,10 @@ func (ctrl *Controller) listPkgsWithoutFinder(ctx context.Context, logE *logrus.
 		pkgName = getGeneratePkg(pkgName)
 		key, version, _ := strings.Cut(pkgName, "@")
 		findingPkg, ok := m[key]
-		findingPkg.Version = version
 		if !ok {
 			return nil, logerr.WithFields(errUnknownPkg, logrus.Fields{"package_name": pkgName}) //nolint:wrapcheck
 		}
+		findingPkg.Version = version
 		outputPkg := ctrl.getOutputtedPkg(ctx, logE, param, findingPkg)
 		outputPkgs = append(outputPkgs, outputPkg)
 	}


### PR DESCRIPTION
Close #1388

This bug came from https://github.com/aquaproj/aqua/commit/0c87e2cc50a40a76d3177743e846cc782365409c .

Affected versions: [v1.23.0](https://github.com/aquaproj/aqua/releases/tag/v1.23.0)

Fixed.

```console
$ aqua g foo
FATA[0000] aqua failed                                   aqua_version= env=darwin/arm64 error="unknown package" package_name="standard,foo" program=aqua
```