### PR TITLE
fix: skip installing cosign and verify with cosign in windows/arm64

### DIFF
--- a/pkg/installpackage/cosign.go
+++ b/pkg/installpackage/cosign.go
@@ -24,6 +24,11 @@ func (inst *Installer) InstallCosign(ctx context.Context, logE *logrus.Entry, ve
 			RepoOwner: "sigstore",
 			RepoName:  "cosign",
 			Asset:     &assetTemplate,
+			SupportedEnvs: []string{
+				"darwin",
+				"linux",
+				"amd64",
+			},
 			Checksum: &registry.Checksum{
 				Type:       "github_release",
 				Asset:      "cosign_checksums.txt",


### PR DESCRIPTION
Assets of Cosign for windows/arm64 aren't released.