### PR TITLE
feat: support a new field `private` for private packages and registries

### DIFF
--- a/pkg/config/aqua/registry.go
+++ b/pkg/config/aqua/registry.go
@@ -15,6 +15,7 @@ type Registry struct {
 	RepoName  string `yaml:"repo_name" json:"repo_name,omitempty"`
 	Ref       string `json:"ref,omitempty"`
 	Path      string `validate:"required" json:"path,omitempty"`
+	Private   bool   `json:"private,omitempty"`
 }
 
 const (

--- a/pkg/config/registry/package_info.go
+++ b/pkg/config/registry/package_info.go
@@ -79,6 +79,7 @@ func (pkgInfo *PackageInfo) Copy() *PackageInfo {
 		Checksum:           pkgInfo.Checksum,
 		Cosign:             pkgInfo.Cosign,
 		SLSAProvenance:     pkgInfo.SLSAProvenance,
+		Private:            pkgInfo.Private,
 	}
 	return pkg
 }

--- a/pkg/config/registry/package_info.go
+++ b/pkg/config/registry/package_info.go
@@ -47,6 +47,7 @@ type PackageInfo struct {
 	Checksum           *Checksum          `json:"checksum,omitempty"`
 	Cosign             *Cosign            `json:"cosign,omitempty"`
 	SLSAProvenance     *SLSAProvenance    `json:"slsa_provenance,omitempty" yaml:"slsa_provenance,omitempty"`
+	Private            bool               `json:"private,omitempty"`
 }
 
 func (pkgInfo *PackageInfo) Copy() *PackageInfo {

--- a/pkg/domain/github_content.go
+++ b/pkg/domain/github_content.go
@@ -12,6 +12,7 @@ type GitHubContentFileParam struct {
 	RepoName  string
 	Ref       string
 	Path      string
+	Private   bool
 }
 
 type GitHubContentFile struct {

--- a/pkg/domain/github_release.go
+++ b/pkg/domain/github_release.go
@@ -12,6 +12,7 @@ type DownloadGitHubReleaseParam struct {
 	RepoName  string
 	Version   string
 	Asset     string
+	Private   bool
 }
 
 type GitHubReleaseDownloader interface {

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -20,6 +20,7 @@ type File struct {
 	Asset     string
 	URL       string
 	Path      string
+	Private   bool
 }
 
 type Downloader struct {
@@ -67,6 +68,7 @@ func (downloader *Downloader) GetReadCloser(ctx context.Context, logE *logrus.En
 			RepoName:  file.RepoName,
 			Ref:       file.Version,
 			Path:      file.Path,
+			Private:   file.Private,
 		})
 		if err != nil {
 			return nil, 0, fmt.Errorf("download a package from GitHub Content: %w", err)

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -61,6 +61,7 @@ func (downloader *Downloader) GetReadCloser(ctx context.Context, logE *logrus.En
 			RepoName:  file.RepoName,
 			Version:   file.Version,
 			Asset:     file.Asset,
+			Private:   file.Private,
 		})
 	case config.PkgInfoTypeGitHubContent:
 		file, err := downloader.ghContent.DownloadGitHubContentFile(ctx, logE, &domain.GitHubContentFileParam{

--- a/pkg/download/github_content.go
+++ b/pkg/download/github_content.go
@@ -26,18 +26,20 @@ func NewGitHubContentFileDownloader(gh GitHubContentAPI, httpDL HTTPDownloader) 
 }
 
 func (dl *GitHubContentFileDownloader) DownloadGitHubContentFile(ctx context.Context, logE *logrus.Entry, param *domain.GitHubContentFileParam) (*domain.GitHubContentFile, error) {
-	// https://github.com/aquaproj/aqua/issues/391
-	body, _, err := dl.http.Download(ctx, fmt.Sprintf(
-		"https://raw.githubusercontent.com/%s/%s/%s/%s",
-		param.RepoOwner, param.RepoName, param.Ref, param.Path,
-	))
-	if err == nil {
-		return &domain.GitHubContentFile{
-			ReadCloser: body,
-		}, nil
-	}
-	if body != nil {
-		body.Close()
+	if !param.Private {
+		// https://github.com/aquaproj/aqua/issues/391
+		body, _, err := dl.http.Download(ctx, fmt.Sprintf(
+			"https://raw.githubusercontent.com/%s/%s/%s/%s",
+			param.RepoOwner, param.RepoName, param.Ref, param.Path,
+		))
+		if err == nil {
+			return &domain.GitHubContentFile{
+				ReadCloser: body,
+			}, nil
+		}
+		if body != nil {
+			body.Close()
+		}
 	}
 
 	file, _, _, err := dl.github.GetContents(ctx, param.RepoOwner, param.RepoName, param.Path, &github.RepositoryContentGetOptions{

--- a/pkg/download/util.go
+++ b/pkg/download/util.go
@@ -61,6 +61,7 @@ func ConvertPackageToFile(pkg *config.Package, assetName string, rt *runtime.Run
 		RepoOwner: pkgInfo.RepoOwner,
 		RepoName:  pkgInfo.RepoName,
 		Version:   pkg.Package.Version,
+		Private:   pkgInfo.Private,
 	}
 	switch pkgInfo.GetType() {
 	case config.PkgInfoTypeGitHubRelease:
@@ -94,6 +95,7 @@ func ConvertRegistryToFile(rgst *aqua.Registry) (*File, error) {
 		RepoOwner: rgst.RepoOwner,
 		RepoName:  rgst.RepoName,
 		Version:   rgst.Ref,
+		Private:   rgst.Private,
 	}
 	switch rgst.Type {
 	case config.PkgInfoTypeGitHubContent:


### PR DESCRIPTION
If `private` is true, aqua skips downloading assets via HTTP requests because requests always fail.

Close #1466
Close #1468