### PR TITLE
ci: remove flaky test

### DIFF
--- a/tests/cosign/aqua.yaml
+++ b/tests/cosign/aqua.yaml
@@ -14,6 +14,10 @@ packages:
   - name: terraform-linters/tflint
     version: v0.44.1
     registry: local
-  - name: aquaproj/aqua-installer
-    version: v1.1.3-3
-    registry: local
+  # Comment out flaky test
+  # Verification with Cosign frequently failed.
+  # > Error: verifying blob [/tmp/482325480]: getting Fulcio roots: error getting targets: error getting target fulcio.crt.pem by usage: open /home/runner/.sigstore/root/targets/fulcio.crt.pem: no such file or directory
+  # > main.go:62: error during command execution: verifying blob [/tmp/482325480]: getting Fulcio roots: error getting targets: error getting target fulcio.crt.pem by usage: open /home/runner/.sigstore/root/targets/fulcio.crt.pem: no such file or directory
+  # - name: aquaproj/aqua-installer
+  #   version: v1.1.3-3
+  #   registry: local


### PR DESCRIPTION
Verification with Cosign frequently failed.

```
Error: verifying blob [/tmp/482325480]: getting Fulcio roots: error getting targets: error getting target fulcio.crt.pem by usage: open /home/runner/.sigstore/root/targets/fulcio.crt.pem: no such file or directory
main.go:62: error during command execution: verifying blob [/tmp/482325480]: getting Fulcio roots: error getting targets: error getting target fulcio.crt.pem by usage: open /home/runner/.sigstore/root/targets/fulcio.crt.pem: no such file or directory
```