### PR TITLE
feat: support verifying Registries' checksums

### DIFF
--- a/pkg/checksum/error.go
+++ b/pkg/checksum/error.go
@@ -1,0 +1,5 @@
+package checksum
+
+import "errors"
+
+var errInvalidChecksum = errors.New("checksum is invalid")

--- a/pkg/checksum/registry.go
+++ b/pkg/checksum/registry.go
@@ -1,0 +1,40 @@
+package checksum
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/aquaproj/aqua/pkg/config/aqua"
+	"github.com/sirupsen/logrus"
+	"github.com/suzuki-shunsuke/logrus-error/logerr"
+)
+
+func CheckRegistry(regist *aqua.Registry, checksums *Checksums, content []byte) error {
+	checksumID := path.Join("registries", "github_content", "github.com", regist.RepoOwner, regist.RepoName, regist.Ref, regist.Path)
+	chksum := checksums.Get(checksumID)
+	algorithm := "sha512"
+	if chksum != nil {
+		algorithm = chksum.Algorithm
+	}
+	chk, err := CalculateReader(strings.NewReader(string(content)), algorithm)
+	if err != nil {
+		return fmt.Errorf("calculate a checksum: %w", err)
+	}
+	if chksum == nil {
+		chksum = &Checksum{
+			ID:        checksumID,
+			Algorithm: "sha512",
+			Checksum:  chk,
+		}
+		checksums.Set(checksumID, chksum)
+		return nil
+	}
+	if chksum.Checksum != chk {
+		return logerr.WithFields(errInvalidChecksum, logrus.Fields{ //nolint:wrapcheck
+			"actual_checksum":   chk,
+			"expected_checksum": chksum.Checksum,
+		})
+	}
+	return nil
+}

--- a/pkg/controller/generate/generate.go
+++ b/pkg/controller/generate/generate.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/aquaproj/aqua/pkg/checksum"
 	"github.com/aquaproj/aqua/pkg/config"
 	reader "github.com/aquaproj/aqua/pkg/config-reader"
 	"github.com/aquaproj/aqua/pkg/config/aqua"
@@ -106,7 +107,24 @@ type FindingPackage struct {
 }
 
 func (ctrl *Controller) listPkgs(ctx context.Context, logE *logrus.Entry, param *config.Param, cfg *aqua.Config, cfgFilePath string, args ...string) ([]*aqua.Package, error) {
-	registryContents, err := ctrl.registryInstaller.InstallRegistries(ctx, logE, cfg, cfgFilePath)
+	var checksums *checksum.Checksums
+	if cfg.ChecksumEnabled() {
+		checksums = checksum.New()
+		checksumFilePath, err := checksum.GetChecksumFilePathFromConfigFilePath(ctrl.fs, cfgFilePath)
+		if err != nil {
+			return nil, err //nolint:wrapcheck
+		}
+		if err := checksums.ReadFile(ctrl.fs, checksumFilePath); err != nil {
+			return nil, fmt.Errorf("read a checksum JSON: %w", err)
+		}
+		defer func() {
+			if err := checksums.UpdateFile(ctrl.fs, checksumFilePath); err != nil {
+				logE.WithError(err).Error("update a checksum file")
+			}
+		}()
+	}
+
+	registryContents, err := ctrl.registryInstaller.InstallRegistries(ctx, logE, cfg, cfgFilePath, checksums)
 	if err != nil {
 		return nil, err //nolint:wrapcheck
 	}

--- a/pkg/controller/install/install.go
+++ b/pkg/controller/install/install.go
@@ -144,5 +144,6 @@ func (ctrl *Controller) install(ctx context.Context, logE *logrus.Entry, cfgFile
 		Tags:           ctrl.tags,
 		ExcludedTags:   ctrl.excludedTags,
 		PolicyConfigs:  policyConfigs,
+		Checksums:      checksums,
 	})
 }

--- a/pkg/controller/install/install.go
+++ b/pkg/controller/install/install.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/aquaproj/aqua/pkg/checksum"
 	"github.com/aquaproj/aqua/pkg/config"
 	finder "github.com/aquaproj/aqua/pkg/config-finder"
 	reader "github.com/aquaproj/aqua/pkg/config-reader"
@@ -113,7 +114,24 @@ func (ctrl *Controller) install(ctx context.Context, logE *logrus.Entry, cfgFile
 		return err //nolint:wrapcheck
 	}
 
-	registryContents, err := ctrl.registryInstaller.InstallRegistries(ctx, logE, cfg, cfgFilePath)
+	var checksums *checksum.Checksums
+	if cfg.ChecksumEnabled() {
+		checksums = checksum.New()
+		checksumFilePath, err := checksum.GetChecksumFilePathFromConfigFilePath(ctrl.fs, cfgFilePath)
+		if err != nil {
+			return err //nolint:wrapcheck
+		}
+		if err := checksums.ReadFile(ctrl.fs, checksumFilePath); err != nil {
+			return fmt.Errorf("read a checksum JSON: %w", err)
+		}
+		defer func() {
+			if err := checksums.UpdateFile(ctrl.fs, checksumFilePath); err != nil {
+				logE.WithError(err).Error("update a checksum file")
+			}
+		}()
+	}
+
+	registryContents, err := ctrl.registryInstaller.InstallRegistries(ctx, logE, cfg, cfgFilePath, checksums)
 	if err != nil {
 		return err //nolint:wrapcheck
 	}

--- a/pkg/controller/list/list.go
+++ b/pkg/controller/list/list.go
@@ -26,17 +26,18 @@ type Controller struct {
 	fs                afero.Fs
 }
 
-func NewController(configFinder ConfigFinder, configReader reader.ConfigReader, registInstaller registry.Installer, cosignInstaller domain.CosignInstaller) *Controller {
+func NewController(configFinder ConfigFinder, configReader reader.ConfigReader, registInstaller registry.Installer, cosignInstaller domain.CosignInstaller, fs afero.Fs) *Controller {
 	return &Controller{
 		stdout:            os.Stdout,
 		configFinder:      configFinder,
 		configReader:      configReader,
 		registryInstaller: registInstaller,
 		cosignInstaller:   cosignInstaller,
+		fs:                fs,
 	}
 }
 
-func (ctrl *Controller) List(ctx context.Context, param *config.Param, logE *logrus.Entry) error {
+func (ctrl *Controller) List(ctx context.Context, param *config.Param, logE *logrus.Entry) error { //nolint:cyclop
 	cfg := &aqua.Config{}
 	cfgFilePath, err := ctrl.configFinder.Find(param.PWD, param.ConfigFilePath, param.GlobalConfigFilePaths...)
 	if err != nil {

--- a/pkg/controller/list/list.go
+++ b/pkg/controller/list/list.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/aquaproj/aqua/pkg/checksum"
 	"github.com/aquaproj/aqua/pkg/config"
 	reader "github.com/aquaproj/aqua/pkg/config-reader"
 	"github.com/aquaproj/aqua/pkg/config/aqua"
@@ -13,6 +14,7 @@ import (
 	"github.com/aquaproj/aqua/pkg/domain"
 	registry "github.com/aquaproj/aqua/pkg/install-registry"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
 )
 
 type Controller struct {
@@ -21,6 +23,7 @@ type Controller struct {
 	configReader      reader.ConfigReader
 	registryInstaller registry.Installer
 	cosignInstaller   domain.CosignInstaller
+	fs                afero.Fs
 }
 
 func NewController(configFinder ConfigFinder, configReader reader.ConfigReader, registInstaller registry.Installer, cosignInstaller domain.CosignInstaller) *Controller {
@@ -48,7 +51,24 @@ func (ctrl *Controller) List(ctx context.Context, param *config.Param, logE *log
 		return fmt.Errorf("install Cosign: %w", err)
 	}
 
-	registryContents, err := ctrl.registryInstaller.InstallRegistries(ctx, logE, cfg, cfgFilePath)
+	var checksums *checksum.Checksums
+	if cfg.ChecksumEnabled() {
+		checksums = checksum.New()
+		checksumFilePath, err := checksum.GetChecksumFilePathFromConfigFilePath(ctrl.fs, cfgFilePath)
+		if err != nil {
+			return err //nolint:wrapcheck
+		}
+		if err := checksums.ReadFile(ctrl.fs, checksumFilePath); err != nil {
+			return fmt.Errorf("read a checksum JSON: %w", err)
+		}
+		defer func() {
+			if err := checksums.UpdateFile(ctrl.fs, checksumFilePath); err != nil {
+				logE.WithError(err).Error("update a checksum file")
+			}
+		}()
+	}
+
+	registryContents, err := ctrl.registryInstaller.InstallRegistries(ctx, logE, cfg, cfgFilePath, checksums)
 	if err != nil {
 		return err //nolint:wrapcheck
 	}

--- a/pkg/controller/list/list_test.go
+++ b/pkg/controller/list/list_test.go
@@ -66,7 +66,7 @@ packages:
 					t.Fatal(err)
 				}
 			}
-			ctrl := list.NewController(finder.NewConfigFinder(fs), reader.New(fs, d.param), registry.New(d.param, downloader, fs, rt, &cosign.MockVerifier{}, &slsa.MockVerifier{}), &domain.MockCosignInstaller{})
+			ctrl := list.NewController(finder.NewConfigFinder(fs), reader.New(fs, d.param), registry.New(d.param, downloader, fs, rt, &cosign.MockVerifier{}, &slsa.MockVerifier{}), &domain.MockCosignInstaller{}, fs)
 			if err := ctrl.List(ctx, d.param, logE); err != nil {
 				if d.isErr {
 					return

--- a/pkg/controller/updatechecksum/update.go
+++ b/pkg/controller/updatechecksum/update.go
@@ -91,11 +91,6 @@ func (ctrl *Controller) updateChecksum(ctx context.Context, logE *logrus.Entry, 
 		return err //nolint:wrapcheck
 	}
 
-	registryContents, err := ctrl.registryInstaller.InstallRegistries(ctx, logE, cfg, cfgFilePath)
-	if err != nil {
-		return err //nolint:wrapcheck
-	}
-
 	checksums := checksum.New()
 	checksumFilePath, err := checksum.GetChecksumFilePathFromConfigFilePath(ctrl.fs, cfgFilePath)
 	if err != nil {
@@ -103,6 +98,11 @@ func (ctrl *Controller) updateChecksum(ctx context.Context, logE *logrus.Entry, 
 	}
 	if err := checksums.ReadFile(ctrl.fs, checksumFilePath); err != nil {
 		return fmt.Errorf("read a checksum JSON: %w", err)
+	}
+
+	registryContents, err := ctrl.registryInstaller.InstallRegistries(ctx, logE, cfg, cfgFilePath, checksums)
+	if err != nil {
+		return err //nolint:wrapcheck
 	}
 	pkgs, _ := config.ListPackagesNotOverride(logE, cfg, registryContents)
 	failed := false

--- a/pkg/controller/wire_gen.go
+++ b/pkg/controller/wire_gen.go
@@ -60,7 +60,7 @@ func InitializeListCommandController(ctx context.Context, param *config.Param, h
 	unarchiver := unarchive.New()
 	checkerImpl := policy.NewChecker()
 	installpackageCosign := installpackage.NewCosign(param, downloader, fs, linker, executor, checksumDownloaderImpl, calculator, unarchiver, checkerImpl, verifierImpl, slsaVerifierImpl)
-	controller := list.NewController(configFinder, configReaderImpl, installerImpl, installpackageCosign)
+	controller := list.NewController(configFinder, configReaderImpl, installerImpl, installpackageCosign, fs)
 	return controller
 }
 

--- a/pkg/install-registry/install_test.go
+++ b/pkg/install-registry/install_test.go
@@ -178,7 +178,7 @@ func TestInstaller_InstallRegistries(t *testing.T) { //nolint:funlen
 				}
 			}
 			inst := registry.New(d.param, d.downloader, fs, rt, &cosign.MockVerifier{}, &slsa.MockVerifier{})
-			registries, err := inst.InstallRegistries(ctx, logE, d.cfg, d.cfgFilePath)
+			registries, err := inst.InstallRegistries(ctx, logE, d.cfg, d.cfgFilePath, nil)
 			if err != nil {
 				if d.isErr {
 					return


### PR DESCRIPTION
Close #1491

aqua.yaml

```yaml
checksum:
  enabled: true
```

aqua-checksums.json

```json
{
  "checksums": [
    {
      "id": "registries/github_content/github.com/aquaproj/aqua-registry/v3.114.0/registry.yaml",
      "checksum": "b5b922c4d64609e536daffec6e480d0fed3ee56b16320a10c38ae12df7f045e8b20a0c05ec66eb28146cee42559e5e6c4e4bc49ce89ffe48a5640999cc6248bd",
      "algorithm": "sha512"
    }
  ]
}
```

If the checksum is invalid, the installation of registries would fail.

```
ERRO[0000] install the registry                          actual_checksum=b5b922c4d64609e536daffec6e480d0fed3ee56b16320a10c38ae12df7f045e8b20a0c05ec66eb28146cee42559e5e6c4e4bc49ce89ffe48a5640999cc6248be aqua_version= env=darwin/arm64 error="check a registry's checksum: checksum is invalid" exe_name=starship expected_checksum=b5b922c4d64609e536daffec6e480d0fed3ee56b16320a10c38ae12df7f045e8b20a0c05ec66eb28146cee42559e5e6c4e4bc49ce89ffe48a5640999cc6248bd program=aqua registry_name=standard
FATA[0000] aqua failed                                   aqua_version= env=darwin/arm64 error="it failed to install some registries" exe_name=starship program=aqua
```