### PR TITLE
fix(update-checksum): fix a bug that registries' checksums are pruned by `-prune` option

### DIFF
--- a/pkg/checksum/registry.go
+++ b/pkg/checksum/registry.go
@@ -10,8 +10,12 @@ import (
 	"github.com/suzuki-shunsuke/logrus-error/logerr"
 )
 
+func RegistryID(regist *aqua.Registry) string {
+	return path.Join("registries", "github_content", "github.com", regist.RepoOwner, regist.RepoName, regist.Ref, regist.Path)
+}
+
 func CheckRegistry(regist *aqua.Registry, checksums *Checksums, content []byte) error {
-	checksumID := path.Join("registries", "github_content", "github.com", regist.RepoOwner, regist.RepoName, regist.Ref, regist.Path)
+	checksumID := RegistryID(regist)
 	chksum := checksums.Get(checksumID)
 	algorithm := "sha512"
 	if chksum != nil {

--- a/pkg/checksum/type.go
+++ b/pkg/checksum/type.go
@@ -28,7 +28,9 @@ func New() *Checksums {
 func (chksums *Checksums) Get(key string) *Checksum {
 	chksums.rwmutex.RLock()
 	chk := chksums.m[key]
-	chksums.newM[key] = chk
+	if chk != nil {
+		chksums.newM[key] = chk
+	}
 	chksums.rwmutex.RUnlock()
 	return chk
 }

--- a/pkg/controller/wire_gen.go
+++ b/pkg/controller/wire_gen.go
@@ -226,6 +226,6 @@ func InitializeUpdateChecksumCommandController(ctx context.Context, param *confi
 	slsaVerifierImpl := slsa.New(downloader, fs, executorImpl)
 	installerImpl := registry.New(param, gitHubContentFileDownloader, fs, rt, verifierImpl, slsaVerifierImpl)
 	checksumDownloaderImpl := download.NewChecksumDownloader(repositoriesService, rt, httpDownloader)
-	controller := updatechecksum.New(param, configFinder, configReaderImpl, installerImpl, fs, rt, checksumDownloaderImpl, downloader)
+	controller := updatechecksum.New(param, configFinder, configReaderImpl, installerImpl, fs, rt, checksumDownloaderImpl, downloader, gitHubContentFileDownloader)
 	return controller
 }

--- a/pkg/domain/github_content.go
+++ b/pkg/domain/github_content.go
@@ -2,7 +2,9 @@ package domain
 
 import (
 	"context"
+	"fmt"
 	"io"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 )
@@ -20,6 +22,40 @@ type GitHubContentFile struct {
 	String     string
 }
 
+func (file *GitHubContentFile) Reader() io.Reader {
+	if file.String != "" {
+		return strings.NewReader(file.String)
+	}
+	return file.ReadCloser
+}
+
+func (file *GitHubContentFile) Byte() ([]byte, error) {
+	if file.String != "" {
+		return []byte(file.String), nil
+	}
+	cnt, err := io.ReadAll(file.ReadCloser)
+	if err != nil {
+		return nil, fmt.Errorf("read the registry configuration file: %w", err)
+	}
+	return cnt, nil
+}
+
+func (file *GitHubContentFile) Close() error {
+	if file.ReadCloser != nil {
+		return file.ReadCloser.Close() //nolint:wrapcheck
+	}
+	return nil
+}
+
 type GitHubContentFileDownloader interface {
 	DownloadGitHubContentFile(ctx context.Context, logE *logrus.Entry, param *GitHubContentFileParam) (*GitHubContentFile, error)
+}
+
+type MockGitHubContentFileDownloader struct {
+	File *GitHubContentFile
+	Err  error
+}
+
+func (mock *MockGitHubContentFileDownloader) DownloadGitHubContentFile(ctx context.Context, logE *logrus.Entry, param *GitHubContentFileParam) (*GitHubContentFile, error) {
+	return mock.File, mock.Err
 }


### PR DESCRIPTION
Close #1521