### PR TITLE
ci: stop slsa-github-generator pinning because slsa-github-generator doesn't support pinning

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,7 +64,10 @@ jobs:
       actions: read # Needed for detection of GitHub Actions environment.
       id-token: write # Needed for provenance signing and ID
       contents: write # Needed for release uploads
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@68bad40844440577b33778c9f29077a3388838e9 # v1.4.0
+    # slsa-framework/slsa-github-generator doesn't support pinning version
+    # > Invalid ref: 68bad40844440577b33778c9f29077a3388838e9. Expected ref of the form refs/tags/vX.Y.Z
+    # https://github.com/slsa-framework/slsa-github-generator/issues/722
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.4.0
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"
       # Upload provenance to a new release

--- a/renovate.json5
+++ b/renovate.json5
@@ -8,6 +8,24 @@
     "github>aquaproj/aqua-renovate-config:file#1.5.0(aqua/.*\\.ya?ml)",
   ],
   ignorePaths: [],
+  packageRules: [
+    {
+      matchUpdateTypes: ["digest"],
+      enabled: false,
+    },
+    {
+      // slsa-framework/slsa-github-generator doesn't support pinning version
+      // > Invalid ref: 68bad40844440577b33778c9f29077a3388838e9. Expected ref of the form refs/tags/vX.Y.Z
+      // https://github.com/slsa-framework/slsa-github-generator/issues/722
+      matchDepTypes: [
+        "action",
+      ],
+      matchPackageNames: [
+        "slsa-framework/slsa-github-generator",
+      ],
+      pinDigests: false,
+    },
+  ],
   regexManagers: [
     {
       fileMatch: [".*\\.go"],


### PR DESCRIPTION
> Invalid ref: 68bad40844440577b33778c9f29077a3388838e9. Expected ref of the form refs/tags/vX.Y.Z

- https://github.com/slsa-framework/slsa-github-generator/issues/722