### PR TITLE
fix: verify aqua-proxy's checksum

### DIFF
--- a/pkg/installpackage/proxy.go
+++ b/pkg/installpackage/proxy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/aquaproj/aqua/pkg/checksum"
 	"github.com/aquaproj/aqua/pkg/config"
 	"github.com/aquaproj/aqua/pkg/config/aqua"
 	"github.com/aquaproj/aqua/pkg/config/registry"
@@ -12,6 +13,17 @@ import (
 )
 
 const ProxyVersion = "v1.1.2" // renovate: depName=aquaproj/aqua-proxy
+
+func ProxyChecksums() map[string]string {
+	return map[string]string{
+		"darwin/amd64":  "9f7bfea8cfa38602194c6f92c1c4a0ad79fb54a1d7db08f446d3a78680bc8ea9",
+		"darwin/arm64":  "b88992bf317af50109c32533b05e0bf19e1fb71489f18bbfe3ad3d1d0acee74b",
+		"linux/amd64":   "902453d96fd1bd9a0053a86124663f49cf7ef50859b65aa8720dc868052a9762",
+		"linux/arm64":   "3a4b8bb0665d0dc7e347711946c691d4ba85af51608310db2894d98b2c85694e",
+		"windows/amd64": "7b9bec780b67b0f02face65f9bd63e69133b230a4af5bd71ff327dcb9bcbc57d",
+		"windows/arm64": "f6e37900b7d7c0b189844be4a7597fa24781e89665862fa7cdf3b8ed38eec4c6",
+	}
+}
 
 func (inst *InstallerImpl) InstallProxy(ctx context.Context, logE *logrus.Entry) error { //nolint:funlen
 	if isWindows(inst.runtime.GOOS) {
@@ -55,14 +67,19 @@ func (inst *InstallerImpl) InstallProxy(ctx context.Context, logE *logrus.Entry)
 	finfo, err := inst.fs.Stat(pkgPath)
 	if err != nil {
 		// file doesn't exist
+		chksum := ProxyChecksums()[inst.runtime.Env()]
 		if err := inst.downloadWithRetry(ctx, logE, &DownloadParam{
 			Package: pkg,
 			Dest:    pkgPath,
 			Asset:   assetName,
+			Checksum: &checksum.Checksum{
+				Algorithm: "sha256",
+				Checksum:  chksum,
+			},
 		}); err != nil {
 			return err
 		}
-	} else {
+	} else { //nolint:gocritic
 		if !finfo.IsDir() {
 			return fmt.Errorf("%s isn't a directory", pkgPath)
 		}

--- a/renovate.json5
+++ b/renovate.json5
@@ -32,7 +32,7 @@
       depNameTemplate: "aquaproj/aqua-proxy",
       datasourceTemplate: "github-releases",
       matchStrings: [
-        '"(?<currentValue>.*)", // renovate: depName=aquaproj/aqua-proxy',
+        '"(?<currentValue>.*)" // renovate: depName=aquaproj/aqua-proxy',
       ],
     },
     {


### PR DESCRIPTION
Verify checksums of [aqua-proxy](https://github.com/aquaproj/aqua-proxy) to prevent aqua-proxy from being tampered.
Checksums are hardcoded to aqua.

## Test

```
$ aqua i -l
INFO[0000] download and unarchive the package            aqua_version= env=darwin/arm64 package_name=aqua-proxy package_version=v1.1.3 program=aqua registry=
FATA[0002] aqua failed                                   actual_checksum=278120EFDA95AB505E43A2863393F254749D4229B4A49E5B3FB941245F6760A3 aqua_version= env=darwin/arm64 error="checksum is invalid" expected_checksum=B88992BF317AF50109C32533B05E0BF19E1FB71489F18BBFE3AD3D1D0ACEE74B program=aqua
```