### PR TITLE
fix(generate): remove a newline

### DIFF
--- a/pkg/controller/generate/output/insert.go
+++ b/pkg/controller/generate/output/insert.go
@@ -29,7 +29,7 @@ func (out *Outputter) generateInsert(cfgFilePath string, pkgs []*aqua.Package) e
 	if err != nil {
 		return fmt.Errorf("get configuration file stat: %w", err)
 	}
-	if err := afero.WriteFile(out.fs, cfgFilePath, []byte(file.String()+"\n"), stat.Mode()); err != nil {
+	if err := afero.WriteFile(out.fs, cfgFilePath, []byte(file.String()), stat.Mode()); err != nil {
 		return fmt.Errorf("write the configuration file: %w", err)
 	}
 	return nil


### PR DESCRIPTION
https://github.com/aquaproj/aqua/blob/42caed5179f5aca04148dcb3b15c0ec30e641630/pkg/controller/generate/output/insert.go#L32

A newline is duplicated.

https://github.com/goccy/go-yaml/blob/6cdefc42e112ac71cbe316e1eed264ea62f58e25/ast/ast.go#L570

```go
// String all documents to text
func (f *File) String() string {
	docs := []string{}
	for _, doc := range f.Docs {
		docs = append(docs, doc.String())
	}
	if len(docs) > 0 {
		return strings.Join(docs, "\n") + "\n"
	} else {
		return ""
	}
}
```

:o: 1.10.0
:o: 1.20.0
:o: 1.25.0
:x: 1.25.2
:x: 1.26.0
:x: 1.30.3

In v1.25.2, goccy/go-yaml was updated from v1.9.6 to v1.9.8.
https://github.com/aquaproj/aqua/compare/v1.25.0...v1.25.2#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6

- https://github.com/aquaproj/aqua/pull/1429
- https://github.com/aquaproj/aqua/pull/1447

This bug was caused by this change. https://github.com/goccy/go-yaml/pull/329