### PR TITLE
fix: lock installing cosign

### DIFF
--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -67,7 +67,6 @@ func (verifier *VerifierImpl) Verify(ctx context.Context, logE *logrus.Entry, rt
 	if err != nil {
 		return fmt.Errorf("render cosign options: %w", err)
 	}
-	cos.Opts = opts
 
 	if cos.Signature != nil {
 		sigFile, err := afero.TempFile(verifier.fs, "", "")
@@ -84,7 +83,7 @@ func (verifier *VerifierImpl) Verify(ctx context.Context, logE *logrus.Entry, rt
 		if err := verifier.downloadCosignFile(ctx, logE, f, sigFile); err != nil {
 			return fmt.Errorf("download a signature: %w", err)
 		}
-		cos.Opts = append(cos.Opts, "--signature", sigFile.Name())
+		opts = append(opts, "--signature", sigFile.Name())
 	}
 	if cos.Key != nil {
 		keyFile, err := afero.TempFile(verifier.fs, "", "")
@@ -102,7 +101,7 @@ func (verifier *VerifierImpl) Verify(ctx context.Context, logE *logrus.Entry, rt
 			return fmt.Errorf("download a signature: %w", err)
 		}
 
-		cos.Opts = append(cos.Opts, "--key", keyFile.Name())
+		opts = append(opts, "--key", keyFile.Name())
 	}
 	if cos.Certificate != nil {
 		certFile, err := afero.TempFile(verifier.fs, "", "")
@@ -123,16 +122,16 @@ func (verifier *VerifierImpl) Verify(ctx context.Context, logE *logrus.Entry, rt
 		if err := verifier.downloadCosignFile(ctx, logE, f, certFile); err != nil {
 			return fmt.Errorf("download a certificate: %w", err)
 		}
-		cos.Opts = append(cos.Opts, "--certificate", certFile.Name())
+		opts = append(opts, "--certificate", certFile.Name())
 	}
 
 	if err := verifier.verify(ctx, logE, &ParamVerify{
-		Opts:               cos.Opts,
+		Opts:               opts,
 		CosignExperimental: cos.CosignExperimental,
 		Target:             verifiedFilePath,
 	}); err != nil {
 		return fmt.Errorf("verify a signature file with Cosign: %w", logerr.WithFields(err, logrus.Fields{
-			"cosign_opts":         strings.Join(cos.Opts, ", "),
+			"cosign_opts":         strings.Join(opts, ", "),
 			"cosign_experimental": cos.CosignExperimental,
 			"target":              verifiedFilePath,
 		}))

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aquaproj/aqua/pkg/util"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
+	"github.com/suzuki-shunsuke/logrus-error/logerr"
 )
 
 type VerifierImpl struct {
@@ -130,7 +131,11 @@ func (verifier *VerifierImpl) Verify(ctx context.Context, logE *logrus.Entry, rt
 		CosignExperimental: cos.CosignExperimental,
 		Target:             verifiedFilePath,
 	}); err != nil {
-		return fmt.Errorf("verify a signature file with Cosign: %w", err)
+		return fmt.Errorf("verify a signature file with Cosign: %w", logerr.WithFields(err, logrus.Fields{
+			"cosign_opts":         strings.Join(cos.Opts, ", "),
+			"cosign_experimental": cos.CosignExperimental,
+			"target":              verifiedFilePath,
+		}))
 	}
 	return nil
 }

--- a/pkg/installpackage/cosign.go
+++ b/pkg/installpackage/cosign.go
@@ -3,6 +3,7 @@ package installpackage
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/aquaproj/aqua/pkg/checksum"
 	"github.com/aquaproj/aqua/pkg/config"
@@ -14,9 +15,12 @@ import (
 
 type Cosign struct {
 	installer *InstallerImpl
+	mutex     *sync.Mutex
 }
 
 func (cos *Cosign) installCosign(ctx context.Context, logE *logrus.Entry, version string) error {
+	cos.mutex.Lock()
+	defer cos.mutex.Unlock()
 	assetTemplate := `cosign-{{.OS}}-{{.Arch}}`
 	pkg := &config.Package{
 		Package: &aqua.Package{

--- a/pkg/installpackage/installer.go
+++ b/pkg/installpackage/installer.go
@@ -53,6 +53,7 @@ func New(param *config.Param, downloader download.ClientAPI, rt *runtime.Runtime
 	installer := newInstaller(param, downloader, rt, fs, linker, executor, chkDL, chkCalc, unarchiver, policyChecker, cosignVerifier, slsaVerifier)
 	installer.cosignInstaller = &Cosign{
 		installer: newInstaller(param, downloader, runtime.NewR(), fs, linker, executor, chkDL, chkCalc, unarchiver, policyChecker, cosignVerifier, slsaVerifier),
+		mutex:     &sync.Mutex{},
 	}
 	return installer
 }


### PR DESCRIPTION
## bug: Lock installing Cosign

When aqua tries to install cosign multiple times in parallel, it would cause the error.
Cosign should be installed only once, and another goroutines should wait until the installation finishes.

## bug: Fix a bug that options of Cosign could be wrong if the same package's multiple versions are installed at the same time