### PR TITLE
fix: skip setting checksum if the key already exists

### DIFF
--- a/pkg/checksum/type.go
+++ b/pkg/checksum/type.go
@@ -37,9 +37,13 @@ func (chksums *Checksums) Get(key string) *Checksum {
 
 func (chksums *Checksums) Set(key string, chk *Checksum) {
 	chksums.rwmutex.Lock()
-	chksums.m[key] = chk
-	chksums.newM[key] = chk
-	chksums.changed = true
+	if _, ok := chksums.m[key]; !ok {
+		chksums.m[key] = chk
+		chksums.changed = true
+	}
+	if _, ok := chksums.newM[key]; !ok {
+		chksums.newM[key] = chk
+	}
 	chksums.rwmutex.Unlock()
 }
 


### PR DESCRIPTION
Close #1599