### PR TITLE
fix: fix a bug Registry's checksums are compared without normalization

### DIFF
--- a/aqua-checksums.json
+++ b/aqua-checksums.json
@@ -202,7 +202,7 @@
     },
     {
       "id": "registries/github_content/github.com/aquaproj/aqua-registry/v3.127.0/registry.yaml",
-      "checksum": "603942E90F42411891411460A1FF5CEAC0E9AE9233CC828B7CAB5D8BEDD76D90BBE5476E6744C50DE6827869DA2641562990FE649DD5F872CB98397B2E2C30E6",
+      "checksum": "603942e90f42411891411460a1ff5ceac0e9ae9233cc828b7cab5d8bedd76d90bbe5476e6744c50de6827869da2641562990fe649dd5f872cb98397b2e2c30e6",
       "algorithm": "sha512"
     }
   ]

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -1,6 +1,9 @@
 ---
 # aqua - Declarative CLI Version Manager
 # https://aquaproj.github.io/
+checksum:
+  enabled: true
+  require_checksum: true
 registries:
   - type: standard
     ref: v3.127.0 # renovate: depName=aquaproj/aqua-registry

--- a/pkg/checksum/registry.go
+++ b/pkg/checksum/registry.go
@@ -34,10 +34,10 @@ func CheckRegistry(regist *aqua.Registry, checksums *Checksums, content []byte) 
 		checksums.Set(checksumID, chksum)
 		return nil
 	}
-	if chksum.Checksum != chk {
+	if !strings.EqualFold(chksum.Checksum, chk) {
 		return logerr.WithFields(errInvalidChecksum, logrus.Fields{ //nolint:wrapcheck
-			"actual_checksum":   chk,
-			"expected_checksum": chksum.Checksum,
+			"actual_checksum":   strings.ToUpper(chk),
+			"expected_checksum": strings.ToUpper(chksum.Checksum),
 		})
 	}
 	return nil

--- a/pkg/installpackage/checksum.go
+++ b/pkg/installpackage/checksum.go
@@ -153,10 +153,6 @@ func (inst *InstallerImpl) verifyChecksum(ctx context.Context, logE *logrus.Entr
 		checksums.Set(checksumID, chksum)
 	}
 
-	if chksum != nil {
-		chksum.Checksum = strings.ToUpper(chksum.Checksum)
-	}
-
 	algorithm := "sha512"
 	if chksum != nil {
 		algorithm = chksum.Algorithm
@@ -167,12 +163,11 @@ func (inst *InstallerImpl) verifyChecksum(ctx context.Context, logE *logrus.Entr
 			"temp_file": tempFilePath,
 		}))
 	}
-	calculatedSum = strings.ToUpper(calculatedSum)
 
-	if chksum != nil && calculatedSum != chksum.Checksum {
+	if chksum != nil && !strings.EqualFold(calculatedSum, chksum.Checksum) {
 		return nil, logerr.WithFields(errInvalidChecksum, logrus.Fields{ //nolint:wrapcheck
-			"actual_checksum":   calculatedSum,
-			"expected_checksum": chksum.Checksum,
+			"actual_checksum":   strings.ToUpper(calculatedSum),
+			"expected_checksum": strings.ToUpper(chksum.Checksum),
 		})
 	}
 


### PR DESCRIPTION
```
time="2023-02-02T01:22:11Z" level=error msg="install the registry" actual_checksum=603942e90f42411891411460a1ff5ceac0e9ae9233cc828b7cab5d8bedd76d90bbe5476e6744c50de6827869da2641562990fe649dd5f872cb98397b2e2c30e6 aqua_version=1.32.2 env=linux/amd64 error="check a registry's checksum: checksum is invalid" expected_checksum=603942E90F42411891411460A1FF5CEAC0E9AE9233CC828B7CAB5D8BEDD76D90BBE5476E6744C50DE6827869DA2641562990FE649DD5F872CB98397B2E2C30E6 program=aqua registry_name=standard
```

This bug occurs when a Registry is installed and the Registry's checksum in `aqua-checksums.json` is uppercase,
because the calculated checksum is lowercase.

This bug raises by https://github.com/aquaproj/aqua/releases/tag/v1.32.2 , because this release makes checksums uppercase.