### PR TITLE
feat: support aggregating configuration files in one directory

### DIFF
--- a/pkg/config-finder/config_finder.go
+++ b/pkg/config-finder/config_finder.go
@@ -39,7 +39,16 @@ func ParseGlobalConfigFilePaths(env string) []string {
 }
 
 func configFileNames() []string {
-	return []string{"aqua.yaml", "aqua.yml", ".aqua.yaml", ".aqua.yml"}
+	return []string{
+		"aqua.yaml",
+		"aqua.yml",
+		".aqua.yaml",
+		".aqua.yml",
+		"aquaproj/aqua.yaml",
+		"aquaproj/aqua.yml",
+		".aquaproj/aqua.yaml",
+		".aquaproj/aqua.yml",
+	}
 }
 
 func (finder *ConfigFinder) Find(wd, configFilePath string, globalConfigFilePaths ...string) (string, error) {


### PR DESCRIPTION
- https://github.com/aquaproj/aqua/issues/1595

The following files are supported.

- aqua.yaml
- aqua.yml
- .aqua.yaml
- .aqua.yml
- aquaproj/aqua.yaml
- aquaproj/aqua.yml
- .aquaproj/aqua.yaml
- .aquaproj/aqua.yml

## Action List to aggregate configuration files in one directory

- Update aqua to v1.33.0 or later
- Move files

```sh
mkdir aquaproj
cp -R aqua aquaproj/imports
mv aqua.yaml aqua-checksums.json aquaproj
rm -R aqua
vi aquaproj/aqua.yaml # Fix `import` if you change the directory name
cp aqua-policy.yaml aquaproj/policy.yaml # `cp` instead of `mv` to prevent an error
```

- Fix `AQUA_POLICY_CONFIG`
- After fixing `AQUA_POLICY_CONFIG`, remove the old policy file

```sh
rm aqua-policy.yaml
```