### PR TITLE
fix: change directory name from aquaproj to aqua

### DIFF
--- a/pkg/config-finder/config_finder.go
+++ b/pkg/config-finder/config_finder.go
@@ -44,10 +44,10 @@ func configFileNames() []string {
 		"aqua.yml",
 		".aqua.yaml",
 		".aqua.yml",
-		"aquaproj/aqua.yaml",
-		"aquaproj/aqua.yml",
-		".aquaproj/aqua.yaml",
-		".aquaproj/aqua.yml",
+		"aqua/aqua.yaml",
+		"aqua/aqua.yml",
+		".aqua/aqua.yaml",
+		".aqua/aqua.yml",
 	}
 }
 


### PR DESCRIPTION
- https://github.com/aquaproj/aqua/issues/1595#issuecomment-1416714321
- https://github.com/aquaproj/aqua/pull/1615

I reconsidered the directory name.
I think `aqua` is better than `aquaproj`, because `aqua` is simple and easy to understand.
I had a concern the conflict with other projects, but the conflict would rarely occur.

Even if the directory name conflicts, aqua still works.
And you can also separate directory by the prefix `.`.

```
aqua # For another project
.aqua # For aqua
```