### PR TITLE
ci: fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,7 @@ jobs:
     with:
       homebrew: true
       aqua_policy_config: aqua-policy.yaml
+      aqua_version: v1.32.3
     secrets:
       gh_app_id: ${{secrets.APP_ID}}
       gh_app_private_key: ${{secrets.APP_PRIVATE_KEY}}


### PR DESCRIPTION
https://github.com/aquaproj/aqua/actions/runs/4098959265

```
Invalid workflow file: .github/workflows/release.yaml#L9
The workflow is not valid. .github/workflows/release.yaml (Line: 9, Col: 11): Input aqua_version is required, but not provided while calling.
```