### PR TITLE
feat(generate-registry): support generating version_overrides and testdata

### DIFF
--- a/pkg/checksum/checksum.go
+++ b/pkg/checksum/checksum.go
@@ -72,7 +72,7 @@ func convertChecksumFileName(filename, version string) string {
 
 func GetChecksumConfigFromFilename(filename, version string) *registry.Checksum {
 	s := strings.ToLower(filename)
-	for _, suffix := range []string{"sig", "asc"} {
+	for _, suffix := range []string{"sig", "asc", "pem"} {
 		if strings.HasSuffix(s, "."+suffix) {
 			return nil
 		}

--- a/pkg/cli/generate_registry.go
+++ b/pkg/cli/generate_registry.go
@@ -36,6 +36,29 @@ packages:
       - linux
       - amd64
     rosetta2: true
+
+By default, aqua gets the information from the latest GitHub Releases.
+You can specify a specific package version.
+
+e.g.
+
+$ aqua gr cli/cli@v2.0.0
+
+By default, aqua gr doesn't generate version_overrides.
+If --deep is set, aqua generates version_overrides.
+
+e.g.
+
+$ aqua gr --deep suzuki-shunsuke/tfcmt
+
+Note that if --deep is set, GitHub API is called per GitHub Release.
+This may cause GitHub API rate limiting.
+
+If --out-testdata is set, aqua inserts testdata into the specified file.
+
+e.g.
+
+$ aqua gr --out-testdata testdata.yaml suzuki-shunsuke/tfcmt
 `
 
 func (runner *Runner) newGenerateRegistryCommand() *cli.Command {

--- a/pkg/cli/generate_registry.go
+++ b/pkg/cli/generate_registry.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/aquaproj/aqua/pkg/config"
 	"github.com/aquaproj/aqua/pkg/controller"
@@ -46,12 +47,20 @@ func (runner *Runner) newGenerateRegistryCommand() *cli.Command {
 		Description: generateRegistryDescription,
 		Action:      runner.generateRegistryAction,
 		// TODO support "i" option
-		// Flags: []cli.Flag{
-		// 	&cli.StringFlag{
-		// 		Name:  "i",
-		// 		Usage: "Insert a registry to configuration file",
-		// 	},
-		// },
+		Flags: []cli.Flag{
+			// 	&cli.StringFlag{
+			// 		Name:  "i",
+			// 		Usage: "Insert a registry to configuration file",
+			// 	},
+			&cli.StringFlag{
+				Name:  "out-testdata",
+				Usage: "A file path where the testdata is outputted",
+			},
+			&cli.BoolFlag{
+				Name:  "deep",
+				Usage: "Resolve version_overrides",
+			},
+		},
 	}
 }
 
@@ -72,6 +81,6 @@ func (runner *Runner) generateRegistryAction(c *cli.Context) error {
 	if err := runner.setParam(c, "generate-registry", param); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
-	ctrl := controller.InitializeGenerateRegistryCommandController(c.Context, param, http.DefaultClient)
+	ctrl := controller.InitializeGenerateRegistryCommandController(c.Context, param, http.DefaultClient, os.Stdout)
 	return ctrl.GenerateRegistry(c.Context, param, runner.LogE, c.Args().Slice()...) //nolint:wrapcheck
 }

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -40,6 +40,7 @@ func (runner *Runner) setParam(c *cli.Context, commandName string, param *config
 	}
 	param.ConfigFilePath = c.String("config")
 	param.Dest = c.String("o")
+	param.OutTestData = c.String("out-testdata")
 	param.OnlyLink = c.Bool("only-link")
 	param.IsTest = c.Bool("test")
 	if commandName == "generate-registry" {

--- a/pkg/config/package.go
+++ b/pkg/config/package.go
@@ -175,6 +175,7 @@ type Param struct {
 	LogColor              string
 	Dest                  string
 	HomeDir               string
+	OutTestData           string
 	MaxParallelism        int
 	Args                  []string
 	Tags                  map[string]struct{}

--- a/pkg/config/registry/checksum.go
+++ b/pkg/config/registry/checksum.go
@@ -4,7 +4,7 @@ type Checksum struct {
 	Type         string           `json:"type,omitempty" jsonschema:"enum=github_release,enum=http"`
 	Asset        string           `json:"asset,omitempty"`
 	URL          string           `json:"url,omitempty"`
-	FileFormat   string           `yaml:"file_format" json:"file_format,omitempty"`
+	FileFormat   string           `yaml:"file_format,omitempty" json:"file_format,omitempty"`
 	Algorithm    string           `json:"algorithm,omitempty" jsonschema:"enum=md5,enum=sha1,enum=sha256,enum=sha512"`
 	Pattern      *ChecksumPattern `json:"pattern,omitempty"`
 	Enabled      *bool            `json:"enabled,omitempty"`

--- a/pkg/config/registry/package_info.go
+++ b/pkg/config/registry/package_info.go
@@ -20,35 +20,35 @@ const (
 
 type PackageInfo struct {
 	Name               string             `json:"name,omitempty" yaml:",omitempty"`
+	Aliases            []*Alias           `yaml:",omitempty" json:"aliases,omitempty"`
+	SearchWords        []string           `json:"search_words,omitempty" yaml:"search_words,omitempty"`
 	Type               string             `validate:"required" json:"type" jsonschema:"enum=github_release,enum=github_content,enum=github_archive,enum=http,enum=go,enum=go_install"`
 	RepoOwner          string             `yaml:"repo_owner,omitempty" json:"repo_owner,omitempty"`
 	RepoName           string             `yaml:"repo_name,omitempty" json:"repo_name,omitempty"`
-	Asset              *string            `json:"asset,omitempty" yaml:",omitempty"`
-	Path               *string            `json:"path,omitempty" yaml:",omitempty"`
-	Format             string             `json:"format,omitempty" jsonschema:"example=tar.gz,example=raw,example=zip" yaml:",omitempty"`
-	Files              []*File            `json:"files,omitempty" yaml:",omitempty"`
-	URL                *string            `json:"url,omitempty" yaml:",omitempty"`
 	Description        string             `json:"description,omitempty" yaml:",omitempty"`
 	Link               string             `json:"link,omitempty" yaml:",omitempty"`
-	Replacements       Replacements       `json:"replacements,omitempty" yaml:",omitempty"`
+	Asset              *string            `json:"asset,omitempty" yaml:",omitempty"`
+	URL                *string            `json:"url,omitempty" yaml:",omitempty"`
+	Path               *string            `json:"path,omitempty" yaml:",omitempty"`
+	Format             string             `json:"format,omitempty" jsonschema:"example=tar.gz,example=raw,example=zip" yaml:",omitempty"`
 	Overrides          []*Override        `json:"overrides,omitempty" yaml:",omitempty"`
 	FormatOverrides    []*FormatOverride  `yaml:"format_overrides,omitempty" json:"format_overrides,omitempty"`
-	VersionConstraints string             `yaml:"version_constraint,omitempty" json:"version_constraint,omitempty"`
-	VersionOverrides   []*VersionOverride `yaml:"version_overrides,omitempty" json:"version_overrides,omitempty"`
+	Files              []*File            `json:"files,omitempty" yaml:",omitempty"`
+	Replacements       Replacements       `json:"replacements,omitempty" yaml:",omitempty"`
 	SupportedIf        *string            `yaml:"supported_if,omitempty" json:"supported_if,omitempty"`
 	SupportedEnvs      SupportedEnvs      `yaml:"supported_envs,omitempty" json:"supported_envs,omitempty"`
 	VersionFilter      *string            `yaml:"version_filter,omitempty" json:"version_filter,omitempty"`
 	VersionPrefix      *string            `yaml:"version_prefix,omitempty" json:"version_prefix,omitempty"`
 	Rosetta2           *bool              `yaml:",omitempty" json:"rosetta2,omitempty"`
-	Aliases            []*Alias           `yaml:",omitempty" json:"aliases,omitempty"`
 	VersionSource      string             `json:"version_source,omitempty" yaml:"version_source,omitempty" jsonschema:"enum=github_tag"`
 	CompleteWindowsExt *bool              `json:"complete_windows_ext,omitempty" yaml:"complete_windows_ext,omitempty"`
 	WindowsExt         string             `json:"windows_ext,omitempty" yaml:"windows_ext,omitempty"`
-	SearchWords        []string           `json:"search_words,omitempty" yaml:"search_words,omitempty"`
 	Checksum           *Checksum          `json:"checksum,omitempty"`
 	Cosign             *Cosign            `json:"cosign,omitempty"`
 	SLSAProvenance     *SLSAProvenance    `json:"slsa_provenance,omitempty" yaml:"slsa_provenance,omitempty"`
 	Private            bool               `json:"private,omitempty"`
+	VersionConstraints string             `yaml:"version_constraint,omitempty" json:"version_constraint,omitempty"`
+	VersionOverrides   []*VersionOverride `yaml:"version_overrides,omitempty" json:"version_overrides,omitempty"`
 }
 
 func (pkgInfo *PackageInfo) Copy() *PackageInfo {

--- a/pkg/config/registry/package_info.go
+++ b/pkg/config/registry/package_info.go
@@ -221,20 +221,20 @@ func (pkgInfo *PackageInfo) OverrideByRuntime(rt *runtime.Runtime) { //nolint:cy
 }
 
 type VersionOverride struct {
+	VersionConstraints string            `yaml:"version_constraint,omitempty" json:"version_constraint,omitempty"`
 	Type               string            `yaml:",omitempty" json:"type,omitempty" jsonschema:"enum=github_release,enum=github_content,enum=github_archive,enum=http,enum=go,enum=go_install"`
 	RepoOwner          string            `yaml:"repo_owner,omitempty" json:"repo_owner,omitempty"`
 	RepoName           string            `yaml:"repo_name,omitempty" json:"repo_name,omitempty"`
 	Asset              *string           `yaml:",omitempty" json:"asset,omitempty"`
 	Path               *string           `yaml:",omitempty" json:"path,omitempty"`
-	Format             string            `yaml:",omitempty" json:"format,omitempty" jsonschema:"example=tar.gz,example=raw,example=zip"`
-	Files              []*File           `yaml:",omitempty" json:"files,omitempty"`
 	URL                *string           `yaml:",omitempty" json:"url,omitempty"`
-	Replacements       Replacements      `yaml:",omitempty" json:"replacements,omitempty"`
-	Overrides          []*Override       `yaml:",omitempty" json:"overrides,omitempty"`
+	Files              []*File           `yaml:",omitempty" json:"files,omitempty"`
+	Format             string            `yaml:",omitempty" json:"format,omitempty" jsonschema:"example=tar.gz,example=raw,example=zip"`
 	FormatOverrides    []*FormatOverride `yaml:"format_overrides,omitempty" json:"format_overrides,omitempty"`
+	Overrides          []*Override       `yaml:",omitempty" json:"overrides,omitempty"`
+	Replacements       Replacements      `yaml:",omitempty" json:"replacements,omitempty"`
 	SupportedIf        *string           `yaml:"supported_if,omitempty" json:"supported_if,omitempty"`
 	SupportedEnvs      SupportedEnvs     `yaml:"supported_envs,omitempty" json:"supported_envs,omitempty"`
-	VersionConstraints string            `yaml:"version_constraint,omitempty" json:"version_constraint,omitempty"`
 	VersionFilter      *string           `yaml:"version_filter,omitempty" json:"version_filter,omitempty"`
 	VersionPrefix      *string           `yaml:"version_prefix,omitempty" json:"version_prefix,omitempty"`
 	VersionSource      string            `json:"version_source,omitempty" yaml:"version_source,omitempty"`

--- a/pkg/config/registry/replacements.go
+++ b/pkg/config/registry/replacements.go
@@ -7,15 +7,15 @@ import (
 type Override struct {
 	GOOS               string          `yaml:",omitempty" json:"goos,omitempty" jsonschema:"enum=aix,enum=android,enum=darwin,enum=dragonfly,enum=freebsd,enum=illumos,enum=ios,enum=linux,enum=netbsd,enum=openbsd,enum=plan9,enum=solaris,enum=windows"`
 	GOArch             string          `yaml:",omitempty" json:"goarch,omitempty" jsonschema:"enum=386,enum=amd64,enum=arm,enum=arm64,enum=mips,enum=mips64,enum=mips64le,enum=mipsle,enum=ppc64,enum=ppc64le,enum=riscv64,enum=s390x"`
-	Replacements       Replacements    `yaml:",omitempty" json:"replacements,omitempty"`
+	Type               string          `json:"type,omitempty" jsonschema:"enum=github_release,enum=github_content,enum=github_archive,enum=http,enum=go,enum=go_install"`
 	Format             string          `yaml:",omitempty" json:"format,omitempty" jsonschema:"example=tar.gz,example=raw,example=zip"`
 	Asset              *string         `yaml:",omitempty" json:"asset,omitempty"`
 	Files              []*File         `yaml:",omitempty" json:"files,omitempty"`
 	URL                *string         `yaml:",omitempty" json:"url,omitempty"`
 	CompleteWindowsExt *bool           `json:"complete_windows_ext,omitempty" yaml:"complete_windows_ext,omitempty"`
 	WindowsExt         string          `json:"windows_ext,omitempty" yaml:"windows_ext,omitempty"`
+	Replacements       Replacements    `yaml:",omitempty" json:"replacements,omitempty"`
 	Checksum           *Checksum       `json:"checksum,omitempty"`
-	Type               string          `json:"type,omitempty" jsonschema:"enum=github_release,enum=github_content,enum=github_archive,enum=http,enum=go,enum=go_install"`
 	Cosign             *Cosign         `json:"cosign,omitempty"`
 	SLSAProvenance     *SLSAProvenance `json:"slsa_provenance,omitempty" yaml:"slsa_provenance,omitempty"`
 }

--- a/pkg/controller/generate-registry/generate.go
+++ b/pkg/controller/generate-registry/generate.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aquaproj/aqua/pkg/asset"
 	"github.com/aquaproj/aqua/pkg/checksum"
 	"github.com/aquaproj/aqua/pkg/config"
-	"github.com/aquaproj/aqua/pkg/config/aqua"
 	"github.com/aquaproj/aqua/pkg/config/registry"
 	"github.com/aquaproj/aqua/pkg/controller/generate/output"
 	"github.com/aquaproj/aqua/pkg/github"
@@ -49,24 +48,6 @@ func (ctrl *Controller) GenerateRegistry(ctx context.Context, param *config.Para
 		}
 	}
 	return nil
-}
-
-func listPkgsFromVersions(pkgName string, versions []string) []*aqua.Package {
-	if len(versions) == 0 {
-		return nil
-	}
-	pkgs := []*aqua.Package{
-		{
-			Name: fmt.Sprintf("%s@%s", pkgName, versions[0]),
-		},
-	}
-	for _, v := range versions[1:] {
-		pkgs = append(pkgs, &aqua.Package{
-			Name:    pkgName,
-			Version: v,
-		})
-	}
-	return pkgs
 }
 
 func (ctrl *Controller) genRegistry(ctx context.Context, param *config.Param, logE *logrus.Entry, pkgName string) error {

--- a/pkg/controller/generate-registry/generate.go
+++ b/pkg/controller/generate-registry/generate.go
@@ -143,18 +143,17 @@ func (ctrl *Controller) getPackageInfo(ctx context.Context, logE *logrus.Entry, 
 		logE.WithField("version", release.GetTagName()).Debug("got the release")
 		assets := ctrl.listReleaseAssets(ctx, logE, pkgInfo, release.GetID())
 		logE.WithField("num_of_assets", len(assets)).Debug("got assets")
-		ctrl.patchRelease(logE, pkgInfo, pkgName, release, assets)
+		ctrl.patchRelease(logE, pkgInfo, pkgName, release.GetTagName(), assets)
 	}
 	return pkgInfo, []string{version}
 }
 
-func (ctrl *Controller) patchRelease(logE *logrus.Entry, pkgInfo *registry.PackageInfo, pkgName string, release *github.RepositoryRelease, assets []*github.ReleaseAsset) { //nolint:funlen,cyclop
+func (ctrl *Controller) patchRelease(logE *logrus.Entry, pkgInfo *registry.PackageInfo, pkgName string, tagName string, assets []*github.ReleaseAsset) { //nolint:funlen,cyclop
 	if len(assets) == 0 {
 		return
 	}
 	assetInfos := make([]*asset.AssetInfo, 0, len(assets))
 	pkgNameContainChecksum := strings.Contains(strings.ToLower(pkgName), "checksum")
-	tagName := release.GetTagName()
 	assetNames := map[string]struct{}{}
 	checksumNames := map[string]struct{}{}
 	for _, aset := range assets {
@@ -166,7 +165,7 @@ func (ctrl *Controller) patchRelease(logE *logrus.Entry, pkgInfo *registry.Packa
 				continue
 			}
 		}
-		if asset.Exclude(pkgName, assetName, release.GetTagName()) {
+		if asset.Exclude(pkgName, assetName, tagName) {
 			logE.WithField("asset_name", assetName).Debug("exclude an asset")
 			continue
 		}

--- a/pkg/controller/generate-registry/generate_internal_test.go
+++ b/pkg/controller/generate-registry/generate_internal_test.go
@@ -111,8 +111,8 @@ func TestController_getPackageInfo(t *testing.T) { //nolint:funlen
 				Assets:   d.assets,
 				Repo:     d.repo,
 			}
-			ctrl := NewController(nil, gh)
-			pkgInfo := ctrl.getPackageInfo(ctx, logE, d.pkgName)
+			ctrl := NewController(nil, gh, nil)
+			pkgInfo, _ := ctrl.getPackageInfo(ctx, logE, d.pkgName, true)
 			if diff := cmp.Diff(d.exp, pkgInfo); diff != "" {
 				t.Fatal(diff)
 			}

--- a/pkg/controller/generate-registry/interface.go
+++ b/pkg/controller/generate-registry/interface.go
@@ -11,4 +11,5 @@ type RepositoriesService interface {
 	GetLatestRelease(ctx context.Context, repoOwner, repoName string) (*github.RepositoryRelease, *github.Response, error)
 	GetReleaseByTag(ctx context.Context, owner, repo, tag string) (*github.RepositoryRelease, *github.Response, error)
 	ListReleaseAssets(ctx context.Context, owner, repo string, id int64, opts *github.ListOptions) ([]*github.ReleaseAsset, *github.Response, error)
+	ListReleases(ctx context.Context, owner, repo string, opts *github.ListOptions) ([]*github.RepositoryRelease, *github.Response, error)
 }

--- a/pkg/controller/generate-registry/version_overrides.go
+++ b/pkg/controller/generate-registry/version_overrides.go
@@ -1,0 +1,175 @@
+package genrgst
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/aquaproj/aqua/pkg/config/registry"
+	"github.com/aquaproj/aqua/pkg/github"
+	"github.com/sirupsen/logrus"
+	"github.com/suzuki-shunsuke/logrus-error/logerr"
+)
+
+type Package struct {
+	Info    *registry.PackageInfo
+	Version string
+}
+
+func getString(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}
+
+func getBool(p *bool) bool {
+	if p == nil {
+		return false
+	}
+	return *p
+}
+
+func (ctrl *Controller) getPackageInfoWithVersionOverrides(ctx context.Context, logE *logrus.Entry, pkgName string, pkgInfo *registry.PackageInfo) (*registry.PackageInfo, []string) {
+	releases := ctrl.listReleases(ctx, logE, pkgInfo)
+	pkgs := make([]*Package, 0, len(releases))
+	for _, release := range releases {
+		pkgInfo := &registry.PackageInfo{
+			Type:      "github_release",
+			RepoOwner: pkgInfo.RepoOwner,
+			RepoName:  pkgInfo.RepoName,
+		}
+		assets := ctrl.listReleaseAssets(ctx, logE, pkgInfo, release.GetID())
+		logE.WithField("num_of_assets", len(assets)).Debug("got assets")
+		if len(assets) == 0 {
+			continue
+		}
+		ctrl.patchRelease(logE, pkgInfo, pkgName, release, assets)
+		pkgs = append(pkgs, &Package{
+			Info:    pkgInfo,
+			Version: release.GetTagName(),
+		})
+	}
+	p, versions := mergePackages(pkgs)
+	if p == nil {
+		return pkgInfo, versions
+	}
+	p.Description = pkgInfo.Description
+	p.Name = pkgInfo.Name
+	return p, versions
+}
+
+func getVersionOverride(latestPkgInfo, pkgInfo *registry.PackageInfo) *registry.VersionOverride { //nolint:cyclop
+	vo := &registry.VersionOverride{}
+	if getString(pkgInfo.Asset) != getString(latestPkgInfo.Asset) {
+		vo.Asset = pkgInfo.Asset
+	}
+	if pkgInfo.Format != latestPkgInfo.Format {
+		vo.Format = pkgInfo.Format
+	}
+	if !reflect.DeepEqual(pkgInfo.Replacements, latestPkgInfo.Replacements) {
+		vo.Replacements = pkgInfo.Replacements
+	}
+	if !reflect.DeepEqual(pkgInfo.Overrides, latestPkgInfo.Overrides) {
+		vo.Overrides = pkgInfo.Overrides
+		if pkgInfo.Overrides == nil {
+			vo.Overrides = []*registry.Override{}
+		}
+	}
+	if !reflect.DeepEqual(pkgInfo.SupportedEnvs, latestPkgInfo.SupportedEnvs) {
+		vo.SupportedEnvs = pkgInfo.SupportedEnvs
+		if pkgInfo.SupportedEnvs == nil {
+			vo.SupportedEnvs = []string{}
+		}
+	}
+	if getBool(pkgInfo.Rosetta2) != getBool(latestPkgInfo.Rosetta2) {
+		vo.Rosetta2 = pkgInfo.Rosetta2
+		if pkgInfo.Rosetta2 == nil {
+			vo.Rosetta2 = boolP(false)
+		}
+	}
+	if pkgInfo.WindowsExt != latestPkgInfo.WindowsExt {
+		vo.WindowsExt = pkgInfo.WindowsExt
+	}
+	if !reflect.DeepEqual(pkgInfo.Checksum, latestPkgInfo.Checksum) {
+		vo.Checksum = pkgInfo.Checksum
+		if pkgInfo.Checksum == nil {
+			vo.Checksum = &registry.Checksum{
+				Enabled: boolP(false),
+			}
+		}
+	}
+	return vo
+}
+
+func mergePackages(pkgs []*Package) (*registry.PackageInfo, []string) {
+	if len(pkgs) == 0 {
+		return nil, nil
+	}
+	if len(pkgs) == 1 {
+		return pkgs[0].Info, []string{pkgs[0].Version}
+	}
+	basePkg := pkgs[0]
+	basePkgInfo := basePkg.Info
+	latestPkgInfo := basePkgInfo
+	minimumVersion := basePkg.Version
+	var lastMinimumVersion string
+	vos := []*registry.VersionOverride{}
+	var lastVO *registry.VersionOverride
+	versions := []string{basePkg.Version}
+	for _, pkg := range pkgs[1:] {
+		pkg := pkg
+		pkgInfo := pkg.Info
+		if reflect.DeepEqual(basePkgInfo, pkgInfo) {
+			minimumVersion = pkg.Version
+			continue
+		}
+		versions = append(versions, minimumVersion)
+		lastMinimumVersion = strings.TrimPrefix(minimumVersion, "v")
+		if lastVO == nil {
+			latestPkgInfo.VersionConstraints = fmt.Sprintf(`semver(">= %s")`, lastMinimumVersion)
+		} else {
+			lastVO.VersionConstraints = fmt.Sprintf(`semver(">= %s")`, lastMinimumVersion)
+			vos = append(vos, lastVO)
+		}
+		lastVO = getVersionOverride(latestPkgInfo, pkgInfo)
+		basePkgInfo = pkgInfo
+		minimumVersion = pkg.Version
+	}
+	if lastMinimumVersion != "" {
+		versions = append(versions, minimumVersion)
+		lastVO.VersionConstraints = fmt.Sprintf(`semver("< %s")`, lastMinimumVersion)
+		vos = append(vos, lastVO)
+	}
+	if len(vos) != 0 {
+		latestPkgInfo.VersionOverrides = vos
+	}
+	return latestPkgInfo, versions
+}
+
+func (ctrl *Controller) listReleases(ctx context.Context, logE *logrus.Entry, pkgInfo *registry.PackageInfo) []*github.RepositoryRelease {
+	repoOwner := pkgInfo.RepoOwner
+	repoName := pkgInfo.RepoName
+	opt := &github.ListOptions{
+		PerPage: 100, //nolint:gomnd
+	}
+	var arr []*github.RepositoryRelease
+
+	for i := 0; i < 10; i++ {
+		releases, _, err := ctrl.github.ListReleases(ctx, repoOwner, repoName, opt)
+		if err != nil {
+			logerr.WithError(logE, err).WithFields(logrus.Fields{
+				"repo_owner": repoOwner,
+				"repo_name":  repoName,
+			}).Warn("list releases")
+			return arr
+		}
+		arr = append(arr, releases...)
+		if len(releases) != opt.PerPage {
+			return arr
+		}
+		opt.Page++
+	}
+	return arr
+}

--- a/pkg/controller/generate/output/output.go
+++ b/pkg/controller/generate/output/output.go
@@ -3,9 +3,9 @@ package output
 import (
 	"fmt"
 	"io"
-	"strings"
 
 	"github.com/aquaproj/aqua/pkg/config/aqua"
+	goccyYAML "github.com/goccy/go-yaml"
 	"github.com/spf13/afero"
 	"gopkg.in/yaml.v2"
 )
@@ -50,16 +50,11 @@ func (out *Outputter) Output(param *Param) error {
 		return fmt.Errorf("create a file: %w", err)
 	}
 	defer f.Close()
-	if _, err := f.WriteString("packages:\n  "); err != nil {
-		return fmt.Errorf("write a string to a file %s: %w", param.Dest, err)
-	}
 
-	b, err := yaml.Marshal(param.List)
-	if err != nil {
-		return fmt.Errorf("marshal packages as YAML: %w", err)
-	}
-	if _, err := f.WriteString(strings.Join(strings.Split(strings.TrimSpace(string(b)), "\n"), "\n  ") + "\n"); err != nil {
-		return fmt.Errorf("write a string to a file %s: %w", param.Dest, err)
+	if err := goccyYAML.NewEncoder(f, goccyYAML.IndentSequence(true)).Encode(map[string]interface{}{
+		"packages": param.List,
+	}); err != nil {
+		return fmt.Errorf("encode YAML: %w", err)
 	}
 	return nil
 }

--- a/pkg/controller/generate/output/output.go
+++ b/pkg/controller/generate/output/output.go
@@ -58,7 +58,7 @@ func (out *Outputter) Output(param *Param) error {
 	if err != nil {
 		return fmt.Errorf("marshal packages as YAML: %w", err)
 	}
-	if _, err := f.WriteString(strings.Join(strings.Split(strings.TrimSpace(string(b)), "\n"), "\n  ")); err != nil {
+	if _, err := f.WriteString(strings.Join(strings.Split(strings.TrimSpace(string(b)), "\n"), "\n  ") + "\n"); err != nil {
 		return fmt.Errorf("write a string to a file %s: %w", param.Dest, err)
 	}
 	return nil

--- a/pkg/controller/wire.go
+++ b/pkg/controller/wire.go
@@ -5,6 +5,7 @@ package controller
 
 import (
 	"context"
+	"io"
 	"net/http"
 
 	"github.com/aquaproj/aqua/pkg/checksum"
@@ -15,6 +16,7 @@ import (
 	cexec "github.com/aquaproj/aqua/pkg/controller/exec"
 	"github.com/aquaproj/aqua/pkg/controller/generate"
 	genrgst "github.com/aquaproj/aqua/pkg/controller/generate-registry"
+	"github.com/aquaproj/aqua/pkg/controller/generate/output"
 	"github.com/aquaproj/aqua/pkg/controller/initcmd"
 	"github.com/aquaproj/aqua/pkg/controller/initpolicy"
 	"github.com/aquaproj/aqua/pkg/controller/install"
@@ -89,7 +91,7 @@ func InitializeListCommandController(ctx context.Context, param *config.Param, h
 	return &list.Controller{}
 }
 
-func InitializeGenerateRegistryCommandController(ctx context.Context, param *config.Param, httpClient *http.Client) *genrgst.Controller {
+func InitializeGenerateRegistryCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, stdout io.Writer) *genrgst.Controller {
 	wire.Build(
 		genrgst.NewController,
 		wire.NewSet(
@@ -97,6 +99,10 @@ func InitializeGenerateRegistryCommandController(ctx context.Context, param *con
 			wire.Bind(new(genrgst.RepositoriesService), new(*github.RepositoriesServiceImpl)),
 		),
 		afero.NewOsFs,
+		wire.NewSet(
+			output.New,
+			wire.Bind(new(genrgst.TestdataOutputter), new(*output.Outputter)),
+		),
 	)
 	return &genrgst.Controller{}
 }

--- a/pkg/controller/wire_gen.go
+++ b/pkg/controller/wire_gen.go
@@ -16,6 +16,7 @@ import (
 	exec2 "github.com/aquaproj/aqua/pkg/controller/exec"
 	"github.com/aquaproj/aqua/pkg/controller/generate"
 	"github.com/aquaproj/aqua/pkg/controller/generate-registry"
+	"github.com/aquaproj/aqua/pkg/controller/generate/output"
 	"github.com/aquaproj/aqua/pkg/controller/initcmd"
 	"github.com/aquaproj/aqua/pkg/controller/initpolicy"
 	"github.com/aquaproj/aqua/pkg/controller/install"
@@ -36,6 +37,7 @@ import (
 	"github.com/aquaproj/aqua/pkg/unarchive"
 	"github.com/spf13/afero"
 	"github.com/suzuki-shunsuke/go-osenv/osenv"
+	"io"
 	"net/http"
 )
 
@@ -58,10 +60,11 @@ func InitializeListCommandController(ctx context.Context, param *config.Param, h
 	return controller
 }
 
-func InitializeGenerateRegistryCommandController(ctx context.Context, param *config.Param, httpClient *http.Client) *genrgst.Controller {
+func InitializeGenerateRegistryCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, stdout io.Writer) *genrgst.Controller {
 	fs := afero.NewOsFs()
 	repositoriesService := github.New(ctx)
-	controller := genrgst.NewController(fs, repositoriesService)
+	outputter := output.New(stdout, fs)
+	controller := genrgst.NewController(fs, repositoriesService, outputter)
 	return controller
 }
 


### PR DESCRIPTION
https://github.com/aquaproj/aqua/issues/1655

Add command line options `--deep` and `--out-testdata` to `aqua gr` command.

- `--deep`: Generate `version_overrides`
- `--out-testdata`: Output testdata to a file

⚠️ `--deep` option calls GitHub API per GitHub Release. So if there are a lot of GitHub Releases, many GitHub API are called and GitHub API rate limiting may occur.

## Example

```console
$ aqua gr --deep --out-testdata pkg.yaml cloudspannerecosystem/wrench
```

Result: https://github.com/aquaproj/generate-registry-deep/actions/runs/4263618160

```yaml
packages:
  - type: github_release
    repo_owner: cloudspannerecosystem
    repo_name: wrench
    description: wrench - Schema management tool for Cloud Spanner -
    asset: wrench_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
    checksum:
      type: github_release
      asset: wrench_{{trimV .Version}}_checksums.txt
      file_format: regexp
      algorithm: sha256
      pattern:
        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
    version_constraint: semver(">= 1.3.3")
    version_overrides:
      - version_constraint: semver(">= 1.3.0")
        supported_envs:
          - linux
          - darwin
      - version_constraint: semver(">= 1.1.0")
        asset: wrench_{{.OS}}_{{.Arch}}
        format: raw
        supported_envs:
          - linux
          - darwin
        checksum:
          enabled: false
      - version_constraint: semver("< 1.1.0")
        asset: wrench_{{.OS}}_{{.Arch}}
        format: raw
        supported_envs:
          - linux/amd64
          - darwin
        rosetta2: true
        checksum:
          enabled: false
```

pkg.yaml

```yaml
packages:
  - name: cloudspannerecosystem/wrench@v1.3.3
  - name: cloudspannerecosystem/wrench
    version: v1.3.0
  - name: cloudspannerecosystem/wrench
    version: v1.1.0
  - name: cloudspannerecosystem/wrench
    version: v1.0.0
```