### PR TITLE
feat: output the content of a checksum file when it fails to parse a checksum file

### DIFF
--- a/pkg/checksum/parser.go
+++ b/pkg/checksum/parser.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	errUnknownChecksumFileFormat = errors.New("checksum file format is unknown")
-	errNoChecksumExtracted       = errors.New("no checksum is extracted")
+	ErrNoChecksumExtracted       = errors.New("no checksum is extracted")
 )
 
 type FileParser struct{}
@@ -22,7 +22,7 @@ func (parser *FileParser) ParseChecksumFile(content string, pkg *config.Package)
 		return nil, "", err
 	}
 	if len(m) == 0 && s == "" {
-		return nil, "", errNoChecksumExtracted
+		return nil, "", ErrNoChecksumExtracted
 	}
 	return m, s, nil
 }

--- a/pkg/installpackage/checksum.go
+++ b/pkg/installpackage/checksum.go
@@ -17,15 +17,33 @@ import (
 	"github.com/suzuki-shunsuke/logrus-error/logerr"
 )
 
-func (inst *InstallerImpl) extractChecksum(pkg *config.Package, assetName string, checksumFile []byte) (string, error) {
+func (inst *InstallerImpl) extractChecksum(logE *logrus.Entry, pkg *config.Package, assetName string, checksumFile []byte) (string, error) {
 	pkgInfo := pkg.PackageInfo
 
+	checksumFileContent := string(checksumFile)
+
 	if pkgInfo.Checksum.FileFormat == "raw" {
-		return strings.TrimSpace(string(checksumFile)), nil
+		return strings.TrimSpace(checksumFileContent), nil
 	}
 
-	m, s, err := inst.checksumFileParser.ParseChecksumFile(string(checksumFile), pkg)
-	if err != nil {
+	m, s, err := inst.checksumFileParser.ParseChecksumFile(checksumFileContent, pkg)
+	if err != nil { //nolint:nestif
+		if errors.Is(err, checksum.ErrNoChecksumExtracted) {
+			logE := logE.WithFields(logrus.Fields{
+				"checksum_file_format": pkg.PackageInfo.Checksum.FileFormat,
+			})
+			if pkgInfo.Checksum.Pattern != nil {
+				logE = logE.WithFields(logrus.Fields{
+					"checksum_pattern_checksum": pkg.PackageInfo.Checksum.Pattern.Checksum,
+					"checksum_pattern_file":     pkg.PackageInfo.Checksum.Pattern.File,
+				})
+			}
+			s := checksumFileContent
+			if len(s) > 10000 { //nolint:gomnd
+				s = checksumFileContent[:10000]
+			}
+			logE.Error(fmt.Sprintf("Checksum isn't found in a checksum file. Checksum file content:\n%s", s))
+		}
 		return "", fmt.Errorf("parse a checksum file: %w", err)
 	}
 	if s != "" {
@@ -71,7 +89,7 @@ func (inst *InstallerImpl) dlAndExtractChecksum(ctx context.Context, logE *logru
 		}
 	}
 
-	c, err := inst.extractChecksum(pkg, assetName, b)
+	c, err := inst.extractChecksum(logE, pkg, assetName, b)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/installpackage/checksum_internal_test.go
+++ b/pkg/installpackage/checksum_internal_test.go
@@ -93,6 +93,7 @@ func TestInstallerImpl_extractChecksum(t *testing.T) { //nolint:funlen
 			},
 		},
 	}
+	logE := logrus.NewEntry(logrus.New())
 	for _, d := range data {
 		d := d
 		t.Run(d.name, func(t *testing.T) {
@@ -106,7 +107,7 @@ func TestInstallerImpl_extractChecksum(t *testing.T) { //nolint:funlen
 			if d.runtime != nil {
 				inst.runtime = d.runtime
 			}
-			c, err := inst.extractChecksum(d.pkg, d.assetName, d.checksumFile)
+			c, err := inst.extractChecksum(logE, d.pkg, d.assetName, d.checksumFile)
 			if err != nil {
 				if d.isErr {
 					return


### PR DESCRIPTION
- https://github.com/aquaproj/aqua/issues/1692

e.g.

```
ERRO[0005] Checksum isn't found in a checksum file. Checksum file content:
237db2e5a4fa7525362c012e94c8a76b36a73d138ac7950cc1c07d862a7cc74a  github-comment_5.0.3_windows_amd64.tar.gz
48e49e0b5f1b3af4b5be13b7031bfb38d856259f09f3582e4f67bcae4b357429  github-comment_5.0.3_linux_arm64.tar.gz
58a32e01623ea00fc3650ffb149f724d3e76a06b2aa5237bb128da138ee79359  github-comment_5.0.3_linux_amd64.tar.gz
621a03cd09ee7eb57d9a00cdfb8c2fe70232b64db070c74122df5a0d7f26ae02  github-comment_5.0.3_darwin_arm64.tar.gz
b893acb1bef079724017590a115bc1447208ea92b0c1fdf8563c6dfc1ef19ff0  github-comment_5.0.3_darwin_amd64.tar.gz
c1a3e184957850e333e24ee437a14b55c8ea78d2e190be71c0f72b0eac0e09d7  github-comment_5.0.3_windows_arm64.tar.gz  aqua_version= checksum_file_format=regexp checksum_pattern_checksum="^(\\b[A-Fa-f0-9]{128}\\b)" checksum_pattern_file="^\\b[A-Fa-f0-9]{128}\\b\\s+(\\S+)$" env=darwin/arm64 exe_name=github-comment exe_path=/Users/shunsukesuzuki/.local/share/aquaproj-aqua/pkgs/github_release/github.com/suzuki-shunsuke/github-comment/v5.0.3/github-comment_5.0.3_darwin_arm64.tar.gz/github-comment package=suzuki-shunsuke/github-comment package_name=suzuki-shunsuke/github-comment package_version=v5.0.3 program=aqua registry=standard
```