### PR TITLE
feat: show the content of the unarchived directory if the executable file isn't found

### DIFF
--- a/pkg/installpackage/find_src.go
+++ b/pkg/installpackage/find_src.go
@@ -1,0 +1,51 @@
+package installpackage
+
+import (
+	"fmt"
+	"io/fs"
+	"path/filepath"
+)
+
+type FileNotFoundError struct {
+	err error
+}
+
+func (errorFileNotFound *FileNotFoundError) Error() string {
+	return errorFileNotFound.err.Error()
+}
+
+func (errorFileNotFound *FileNotFoundError) Unwrap() error {
+	return errorFileNotFound.err
+}
+
+func containPath(p string) bool {
+	switch p {
+	case "README", "README.md", "LICENSE":
+		return false
+	}
+	return true
+}
+
+func (inst *InstallerImpl) walk(pkgPath string) ([]string, error) {
+	paths := []string{}
+	if err := filepath.WalkDir(pkgPath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil //nolint:nilerr
+		}
+		if d.Type().IsDir() {
+			return nil
+		}
+		f, err := filepath.Rel(pkgPath, path)
+		if err != nil {
+			return fmt.Errorf("get a relative path: %w", err)
+		}
+		name := d.Name()
+		if containPath(name) {
+			paths = append(paths, f)
+		}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("walks the file tree of the unarchived package: %w", err)
+	}
+	return paths, nil
+}


### PR DESCRIPTION
- https://github.com/aquaproj/aqua/issues/1668

e.g.

```console
$ aqua i --test
ERRO[0000] check file_src is correct                     aqua_version= env=darwin/arm64 error="check file_src is correct: exe_path isn't found: stat /Users/shunsukesuzuki/.local/share/aquaproj-aqua/pkgs/github_release/github.com/Azure/aks-engine/v0.76.0/aks-engine-v0.76.0-darwin-amd64.tar.gz/aks-engine: no such file or directory" file_name=aks-engine package_name=Azure/aks-engine package_version=v0.76.0 program=aqua registry=standard
ERRO[0000] executable files aren't found
Files in the unarchived package:
aks-engine-v0.76.0-darwin-amd64/aks-engine
   aqua_version= env=darwin/arm64 package_name=Azure/aks-engine package_version=v0.76.0 program=aqua registry=standard
ERRO[0000] install the package                           aqua_version= env=darwin/arm64 error="check file_src is correct" package_name=Azure/aks-engine package_version=v0.76.0 program=aqua registry=standard
FATA[0000] aqua failed                                   aqua_version= env=darwin/arm64 error="it failed to install some packages" program=aqua
```