### PR TITLE
feat: support default checksum parser

### DIFF
--- a/pkg/checksum/error.go
+++ b/pkg/checksum/error.go
@@ -2,4 +2,8 @@ package checksum
 
 import "errors"
 
-var errInvalidChecksum = errors.New("checksum is invalid")
+var (
+	errInvalidChecksum           = errors.New("checksum is invalid")
+	errUnknownChecksumFileFormat = errors.New("checksum file format is unknown")
+	ErrNoChecksumExtracted       = errors.New("no checksum is extracted")
+)

--- a/pkg/checksum/parser.go
+++ b/pkg/checksum/parser.go
@@ -3,6 +3,7 @@ package checksum
 import (
 	"errors"
 	"fmt"
+	"path"
 	"regexp"
 	"strings"
 
@@ -28,11 +29,32 @@ func (parser *FileParser) ParseChecksumFile(content string, pkg *config.Package)
 }
 
 func (parser *FileParser) parseChecksumFile(content string, pkg *config.Package) (map[string]string, string, error) {
-	switch pkg.PackageInfo.Checksum.FileFormat { //nolint:gocritic
+	switch pkg.PackageInfo.Checksum.FileFormat {
 	case "regexp":
 		return parser.parseRegex(content, pkg)
+	case "":
+		return parser.parseDefault(content)
 	}
 	return nil, "", errUnknownChecksumFileFormat
+}
+
+func (parser *FileParser) parseDefault(content string) (map[string]string, string, error) {
+	lines := strings.Split(strings.TrimSpace(content), "\n")
+	if len(lines) == 1 && !strings.Contains(lines[0], " ") {
+		return nil, lines[0], nil
+	}
+	m := make(map[string]string, len(lines))
+	for _, line := range lines {
+		idx := strings.Index(line, " ")
+		if idx == -1 {
+			continue
+		}
+		m[path.Base(strings.TrimSpace(line[idx:]))] = line[:idx]
+	}
+	if len(m) == 0 {
+		return nil, "", errNoChecksumExtracted
+	}
+	return m, "", nil
 }
 
 func (parser *FileParser) parseRegex(content string, pkg *config.Package) (map[string]string, string, error) {

--- a/pkg/checksum/parser.go
+++ b/pkg/checksum/parser.go
@@ -1,18 +1,12 @@
 package checksum
 
 import (
-	"errors"
 	"fmt"
 	"path"
 	"regexp"
 	"strings"
 
 	"github.com/aquaproj/aqua/pkg/config"
-)
-
-var (
-	errUnknownChecksumFileFormat = errors.New("checksum file format is unknown")
-	ErrNoChecksumExtracted       = errors.New("no checksum is extracted")
 )
 
 type FileParser struct{}
@@ -52,7 +46,7 @@ func (parser *FileParser) parseDefault(content string) (map[string]string, strin
 		m[path.Base(strings.TrimSpace(line[idx:]))] = line[:idx]
 	}
 	if len(m) == 0 {
-		return nil, "", errNoChecksumExtracted
+		return nil, "", ErrNoChecksumExtracted
 	}
 	return m, "", nil
 }

--- a/pkg/checksum/parser_test.go
+++ b/pkg/checksum/parser_test.go
@@ -20,15 +20,6 @@ func TestFileParser_ParseChecksumFile(t *testing.T) { //nolint:funlen
 		isErr   bool
 	}{
 		{
-			name: "unknown format",
-			pkg: &config.Package{
-				PackageInfo: &registry.PackageInfo{
-					Checksum: &registry.Checksum{},
-				},
-			},
-			isErr: true,
-		},
-		{
 			name:    "sha256",
 			content: `89f744a88dad0e73866d06e79afccd5476152770c70101361566b234b0722101  nova_3.2.0_darwin_arm64.tar.gz`,
 			pkg: &config.Package{
@@ -60,6 +51,61 @@ func TestFileParser_ParseChecksumFile(t *testing.T) { //nolint:funlen
 				},
 			},
 			s: "89f744a88dad0e73866d06e79afccd5476152770c70101361566b234b0722101",
+		},
+		{
+			name:    "default",
+			content: `89f744a88dad0e73866d06e79afccd5476152770c70101361566b234b0722101  nova_3.2.0_darwin_arm64.tar.gz`,
+			pkg: &config.Package{
+				PackageInfo: &registry.PackageInfo{
+					Checksum: &registry.Checksum{},
+				},
+			},
+			m: map[string]string{
+				"nova_3.2.0_darwin_arm64.tar.gz": "89f744a88dad0e73866d06e79afccd5476152770c70101361566b234b0722101",
+			},
+		},
+		{
+			name:    "default absolute",
+			content: `89f744a88dad0e73866d06e79afccd5476152770c70101361566b234b0722101  /home/runner/nova_3.2.0_darwin_arm64.tar.gz`,
+			pkg: &config.Package{
+				PackageInfo: &registry.PackageInfo{
+					Checksum: &registry.Checksum{},
+				},
+			},
+			m: map[string]string{
+				"nova_3.2.0_darwin_arm64.tar.gz": "89f744a88dad0e73866d06e79afccd5476152770c70101361566b234b0722101",
+			},
+		},
+		{
+			name:    "default only checksum",
+			content: `89f744a88dad0e73866d06e79afccd5476152770c70101361566b234b0722101`,
+			pkg: &config.Package{
+				PackageInfo: &registry.PackageInfo{
+					Checksum: &registry.Checksum{},
+				},
+			},
+			s: "89f744a88dad0e73866d06e79afccd5476152770c70101361566b234b0722101",
+		},
+		{
+			name: "default multiple lines",
+			content: `955ec1e8d329f75e6e3803ffae8a6f8e586576904ac418e9ed88f2cc31178c15  ./imgpkg-darwin-amd64
+1182217e827a44e22df22be4b95e5392f52530eaed52da5195b5f026d06f41f4  ./imgpkg-darwin-arm64
+2c289cf6b5c88a4dd4bec17c9e57e49c2c7531c127ea130737945392cdc65362  ./imgpkg-linux-amd64
+eb972061a7a71b03ee224b3e3d7aa0ec9a45ec20a6c8c5b11917b223c58a9570  ./imgpkg-linux-arm64
+d3e8e4d8da6b6f5e0a77335864944fc3e74c109c3d4959c976c1caec1dc1807c  ./imgpkg-windows-amd64.exe
+`,
+			pkg: &config.Package{
+				PackageInfo: &registry.PackageInfo{
+					Checksum: &registry.Checksum{},
+				},
+			},
+			m: map[string]string{
+				"imgpkg-darwin-amd64":      "955ec1e8d329f75e6e3803ffae8a6f8e586576904ac418e9ed88f2cc31178c15",
+				"imgpkg-darwin-arm64":      "1182217e827a44e22df22be4b95e5392f52530eaed52da5195b5f026d06f41f4",
+				"imgpkg-linux-amd64":       "2c289cf6b5c88a4dd4bec17c9e57e49c2c7531c127ea130737945392cdc65362",
+				"imgpkg-linux-arm64":       "eb972061a7a71b03ee224b3e3d7aa0ec9a45ec20a6c8c5b11917b223c58a9570",
+				"imgpkg-windows-amd64.exe": "d3e8e4d8da6b6f5e0a77335864944fc3e74c109c3d4959c976c1caec1dc1807c",
+			},
 		},
 	}
 	parser := &checksum.FileParser{}


### PR DESCRIPTION
Cherry pick a commit from https://github.com/aquaproj/aqua/pull/1577 .
https://github.com/aquaproj/aqua/pull/1577 has not breaking change, so we can release this feature in aqua v1.

- https://github.com/aquaproj/aqua/pull/1577

```console
$ git cherry-pick e15e93b1f51f26600cf61a3b4eb90d5d0e07d6c1
```