### PR TITLE
fix: add a link to the document "command is not found"

### DIFF
--- a/pkg/controller/which/which.go
+++ b/pkg/controller/which/which.go
@@ -102,6 +102,7 @@ func (ctrl *ControllerImpl) Which(ctx context.Context, logE *logrus.Entry, param
 	}
 	return nil, logerr.WithFields(errCommandIsNotFound, logrus.Fields{ //nolint:wrapcheck
 		"exe_name": exeName,
+		"doc":      "https://aquaproj.github.io/docs/reference/codes/004",
 	})
 }
 


### PR DESCRIPTION
- https://github.com/aquaproj/aqua/issues/1818