### PR TITLE
fix: Fix a bug that `aqua i -a` and `aqua cp -a` don't read policy files properly

### DIFF
--- a/.github/workflows/macos-test.yaml
+++ b/.github/workflows/macos-test.yaml
@@ -3,7 +3,6 @@ name: Integration Test on macOS
 on: workflow_dispatch
 
 env:
-  AQUA_POLICY_CONFIG: ${{ github.workspace }}/aqua/aqua-policy.yaml
   AQUA_LOG_COLOR: always
 
 permissions: {}
@@ -19,6 +18,7 @@ jobs:
           cache: true
       - run: go install ./cmd/aqua
       - run: echo "${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua/bin" >> "$GITHUB_PATH"
+      - run: aqua policy allow
       - run: aqua i -l
         working-directory: tests/macos
         env:

--- a/.github/workflows/wc-integration-test.yaml
+++ b/.github/workflows/wc-integration-test.yaml
@@ -10,7 +10,6 @@ jobs:
       AQUA_LOG_LEVEL: debug
       AQUA_LOG_COLOR: always
       AQUA_GLOBAL_CONFIG: ${{ github.workspace }}/tests/main/aqua-global.yaml:${{ github.workspace }}/tests/main/aqua-global-2.yaml
-      AQUA_POLICY_CONFIG: ${{ github.workspace }}/aqua/aqua-policy.yaml
     steps:
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
@@ -20,6 +19,7 @@ jobs:
 
       - run: go install ./cmd/aqua
       - run: echo "${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua/bin" >> "$GITHUB_PATH"
+      - run: aqua policy allow
       - run: echo "standard,kubernetes-sigs/kind" | aqua g -f -
       - run: echo "x-motemen/ghq" | aqua g -f -
       - run: echo "local,aquaproj/aqua-installer" | aqua -c tests/main/aqua-global.yaml g -f -

--- a/.github/workflows/windows-test.yaml
+++ b/.github/workflows/windows-test.yaml
@@ -3,7 +3,6 @@ name: Integration Test on Windows
 on: workflow_dispatch
 
 env:
-  AQUA_POLICY_CONFIG: ${{ github.workspace }}/aqua/aqua-policy.yaml
   AQUA_GLOBAL_CONFIG: ${{ github.workspace }}/tests/main/aqua-global.yaml:${{ github.workspace }}/tests/main/aqua-global-2.yaml
   AQUA_LOG_COLOR: always
   AQUA_LOG_LEVEL: debug
@@ -27,6 +26,7 @@ jobs:
 
       - run: go install ./cmd/aqua
       - run: echo "$HOME/AppData/Local/aquaproj-aqua/bin" >> "$GITHUB_PATH"
+      - run: aqua policy allow
       - run: echo "AQUA_GLOBAL_CONFIG=$PWD/tests/main/aqua-global.yaml:$PWD/tests/main/aqua-global-2.yaml" >> "$GITHUB_ENV"
       - run: echo "standard,kubernetes-sigs/kind" | aqua g -f -
       - run: echo "x-motemen/ghq" | aqua g -f -

--- a/pkg/controller/install/install.go
+++ b/pkg/controller/install/install.go
@@ -90,16 +90,20 @@ func (ctrl *Controller) Install(ctx context.Context, logE *logrus.Entry, param *
 		}
 	}
 
-	return ctrl.installAll(ctx, logE, param, policyCfgs)
+	return ctrl.installAll(ctx, logE, param, policyCfgs, globalPolicyPaths)
 }
 
-func (ctrl *Controller) installAll(ctx context.Context, logE *logrus.Entry, param *config.Param, policyConfigs []*policy.Config) error {
+func (ctrl *Controller) installAll(ctx context.Context, logE *logrus.Entry, param *config.Param, policyConfigs []*policy.Config, globalPolicyPaths map[string]struct{}) error {
 	if !param.All {
 		return nil
 	}
 	for _, cfgFilePath := range param.GlobalConfigFilePaths {
 		if _, err := ctrl.fs.Stat(cfgFilePath); err != nil {
 			continue
+		}
+		policyConfigs, err := ctrl.policyConfigReader.Append(logE, cfgFilePath, policyConfigs, globalPolicyPaths)
+		if err != nil {
+			return err //nolint:wrapcheck
 		}
 		if err := ctrl.install(ctx, logE, cfgFilePath, policyConfigs); err != nil {
 			return err


### PR DESCRIPTION
- https://github.com/aquaproj/aqua/pull/1844/commits/a4a4382902d1be73e0db8a2d3ff78248517f66b7
- https://github.com/aquaproj/aqua/actions/runs/4650825549/jobs/8230051988#step:46:45

--

```console
$ cd tests/main
$ AQUA_GLOBAL_CONFIG=$PWD/aqua-global.yaml aqua cp -a
INFO[0000] copying an executable file                    aqua_version=2.3.0 env=darwin/arm64 file_name=kind package_name=kubernetes-sigs/kind package_version=v0.18.0 program=aqua registry=standard
INFO[0000] copying an executable file                    aqua_version=2.3.0 env=darwin/arm64 file_name=terracognita package_name=cycloidio/terracognita package_version=v0.8.3 program=aqua registry=standard
INFO[0000] copying an executable file                    aqua_version=2.3.0 env=darwin/arm64 file_name=cmdx package_name=suzuki-shunsuke/cmdx package_version=v1.7.2 program=aqua registry=standard
INFO[0000] copying an executable file                    aqua_version=2.3.0 env=darwin/arm64 file_name=cosign package_name=sigstore/cosign package_version=v1.13.1 program=aqua registry=standard
INFO[0000] copying an executable file                    aqua_version=2.3.0 env=darwin/arm64 file_name=reviewdog package_name=reviewdog/reviewdog package_version=v0.14.1 program=aqua registry=standard
INFO[0000] copying an executable file                    aqua_version=2.3.0 env=darwin/arm64 file_name=golangci-lint package_name=golangci/golangci-lint package_version=v1.51.2 program=aqua registry=standard
INFO[0000] copying an executable file                    aqua_version=2.3.0 env=darwin/arm64 file_name=ghalint package_name=suzuki-shunsuke/ghalint package_version=v0.2.2 program=aqua registry=standard
INFO[0000] copying an executable file                    aqua_version=2.3.0 env=darwin/arm64 file_name=actionlint package_name=rhysd/actionlint package_version=v1.6.24 program=aqua registry=standard
INFO[0000] copying an executable file                    aqua_version=2.3.0 env=darwin/arm64 file_name=ghcp package_name=int128/ghcp package_version=v1.13.2 program=aqua registry=standard
INFO[0000] copying an executable file                    aqua_version=2.3.0 env=darwin/arm64 file_name=goreleaser package_name=goreleaser/goreleaser package_version=v1.15.2 program=aqua registry=standard
INFO[0000] copying an executable file                    aqua_version=2.3.0 env=darwin/arm64 file_name=reviewdog package_name=reviewdog/reviewdog package_version=v0.14.1 program=aqua registry=standard
INFO[0000] copying an executable file                    aqua_version=2.3.0 env=darwin/arm64 file_name=ghcp package_name=int128/ghcp package_version=v1.13.2 program=aqua registry=standard
INFO[0000] copying an executable file                    aqua_version=2.3.0 env=darwin/arm64 file_name=ghalint package_name=suzuki-shunsuke/ghalint package_version=v0.2.2 program=aqua registry=standard
INFO[0000] copying an executable file                    aqua_version=2.3.0 env=darwin/arm64 file_name=golangci-lint package_name=golangci/golangci-lint package_version=v1.51.2 program=aqua registry=standard
INFO[0000] copying an executable file                    aqua_version=2.3.0 env=darwin/arm64 file_name=cmdx package_name=suzuki-shunsuke/cmdx package_version=v1.7.2 program=aqua registry=standard
INFO[0000] copying an executable file                    aqua_version=2.3.0 env=darwin/arm64 file_name=actionlint package_name=rhysd/actionlint package_version=v1.6.24 program=aqua registry=standard
INFO[0000] copying an executable file                    aqua_version=2.3.0 env=darwin/arm64 file_name=goreleaser package_name=goreleaser/goreleaser package_version=v1.15.2 program=aqua registry=standard
INFO[0000] copying an executable file                    aqua_version=2.3.0 env=darwin/arm64 file_name=cosign package_name=sigstore/cosign package_version=v1.13.1 program=aqua registry=standard
ERRO[0000] install the package                           aqua_version=2.3.0 doc="https://aquaproj.github.io/docs/reference/codes/002" env=darwin/arm64 error="this package isn't allowed" package_name=kubernetes-sigs/kustomize/version_prefix package_version=kustomize/v4.5.7 program=aqua registry=local
ERRO[0000] install the package                           aqua_version=2.3.0 doc="https://aquaproj.github.io/docs/reference/codes/002" env=darwin/arm64 error="this package isn't allowed" package_name=tfutils/tfenv package_version=v3.0.0 program=aqua registry=local
ERRO[0000] install the package                           aqua_version=2.3.0 doc="https://aquaproj.github.io/docs/reference/codes/002" env=darwin/arm64 error="this package isn't allowed" package_name=aquaproj/aqua-installer package_version=v1.1.2 program=aqua registry=local
ERRO[0000] install the package                           aqua_version=2.3.0 doc="https://aquaproj.github.io/docs/reference/codes/002" env=darwin/arm64 error="this package isn't allowed" package_name=katbyte/terrafmt package_version=v0.5.2 program=aqua registry=local
ERRO[0000] install the package                           aqua_version=2.3.0 doc="https://aquaproj.github.io/docs/reference/codes/002" env=darwin/arm64 error="this package isn't allowed" package_name=helm/helm package_version=v3.10.1 program=aqua registry=local
ERRO[0000] install the package                           aqua_version=2.3.0 doc="https://aquaproj.github.io/docs/reference/codes/002" env=darwin/arm64 error="this package isn't allowed" package_name=tamasfe/taplo package_version=0.8.0 program=aqua registry=local
INFO[0000] copying an executable file                    aqua_version=2.3.0 env=darwin/arm64 file_name=bats package_name=bats-core/bats-core package_version=9695e7c589a07756c999893764ccd9a506a47f89 program=aqua registry=standard
INFO[0000] copying an executable file                    aqua_version=2.3.0 env=darwin/arm64 file_name=restic package_name=restic/restic package_version=v0.14.0 program=aqua registry=aqua-registry
INFO[0000] copying an executable file                    aqua_version=2.3.0 env=darwin/arm64 file_name=ghq package_name=x-motemen/ghq package_version=v1.3.0 program=aqua registry=standard
INFO[0000] copying an executable file                    aqua_version=2.3.0 env=darwin/arm64 file_name=migrate package_name=golang-migrate/migrate package_version=v4.14.1 program=aqua registry=aqua-registry
INFO[0000] copying an executable file                    aqua_version=2.3.0 env=darwin/arm64 file_name=migrate package_name=golang-migrate/migrate package_version=v4.15.2 program=aqua registry=standard
INFO[0000] copying an executable file                    aqua_version=2.3.0 env=darwin/arm64 file_name=kind package_name=kubernetes-sigs/kind package_version=v0.17.0 program=aqua registry=standard
ERRO[0000] install the package                           aqua_version=2.3.0 doc="https://aquaproj.github.io/docs/reference/codes/002" env=darwin/arm64 error="this package isn't allowed" package_name=github.com/anqiansong/github-compare package_version=e9ceff4e053200afb1eb7e8e3c16932b2e2f01ee program=aqua registry=local
FATA[0000] aqua failed                                   aqua_version=2.3.0 env=darwin/arm64 error="it failed to install some packages" program=aqua
```