### PR TITLE
feat: support omitting `{{.Format}}` in Asset and provide the variable `AssetWithoutExt`

### DIFF
--- a/pkg/config/const.go
+++ b/pkg/config/const.go
@@ -1,0 +1,5 @@
+package config
+
+const (
+	formatRaw = "raw"
+)

--- a/pkg/config/package.go
+++ b/pkg/config/package.go
@@ -181,7 +181,14 @@ type Param struct {
 	PolicyConfigFilePaths []string
 }
 
-func (cpkg *Package) RenderAsset(rt *runtime.Runtime) (string, error) { //nolint:cyclop
+func appendExt(s, format string) string {
+	if format == formatRaw || format == "" || strings.HasSuffix(s, fmt.Sprintf(".%s", format)) {
+		return s
+	}
+	return fmt.Sprintf("%s.%s", s, format)
+}
+
+func (cpkg *Package) RenderAsset(rt *runtime.Runtime) (string, error) {
 	asset, err := cpkg.renderAsset(rt)
 	if err != nil {
 		return "", err
@@ -191,9 +198,7 @@ func (cpkg *Package) RenderAsset(rt *runtime.Runtime) (string, error) { //nolint
 	}
 
 	format := cpkg.PackageInfo.Format
-	if format != formatRaw && format != "" && !strings.HasSuffix(asset, fmt.Sprintf(".%s", format)) {
-		asset = fmt.Sprintf("%s.%s", asset, format)
-	}
+	asset = appendExt(asset, format)
 
 	if isWindows(rt.GOOS) && !strings.HasSuffix(asset, ".exe") {
 		if cpkg.PackageInfo.Format == formatRaw {
@@ -297,6 +302,8 @@ func (cpkg *Package) RenderURL(rt *runtime.Runtime) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	format := cpkg.PackageInfo.Format
+	s = appendExt(s, format)
 	if isWindows(rt.GOOS) && !strings.HasSuffix(s, ".exe") {
 		if cpkg.PackageInfo.Format == formatRaw {
 			return cpkg.CompleteWindowsExt(s), nil

--- a/pkg/template/render.go
+++ b/pkg/template/render.go
@@ -7,24 +7,26 @@ import (
 )
 
 type Artifact struct {
-	Version string
-	SemVer  string
-	OS      string
-	Arch    string
-	Format  string
-	Asset   string
+	Version         string
+	SemVer          string
+	OS              string
+	Arch            string
+	Format          string
+	Asset           string
+	AssetWithoutExt string
 }
 
 func renderParam(art *Artifact, rt *runtime.Runtime) map[string]interface{} {
 	return map[string]interface{}{
-		"Version": art.Version,
-		"SemVer":  art.SemVer,
-		"GOOS":    rt.GOOS,
-		"GOARCH":  rt.GOARCH,
-		"OS":      art.OS,
-		"Arch":    art.Arch,
-		"Format":  art.Format,
-		"Asset":   art.Asset,
+		"Version":         art.Version,
+		"SemVer":          art.SemVer,
+		"GOOS":            rt.GOOS,
+		"GOARCH":          rt.GOARCH,
+		"OS":              art.OS,
+		"Arch":            art.Arch,
+		"Format":          art.Format,
+		"Asset":           art.Asset,
+		"AssetWithoutExt": art.AssetWithoutExt,
 	}
 }
 


### PR DESCRIPTION
- https://github.com/aquaproj/aqua/issues/1774