### PR TITLE
refactor: remove an unused method "RenderDir"

### DIFF
--- a/pkg/config/package.go
+++ b/pkg/config/package.go
@@ -59,21 +59,6 @@ func getArch(rosetta2 bool, replacements registry.Replacements, rt *runtime.Runt
 	return replace(rt.GOARCH, replacements)
 }
 
-func (cpkg *Package) RenderDir(file *registry.File, rt *runtime.Runtime) (string, error) {
-	pkgInfo := cpkg.PackageInfo
-	pkg := cpkg.Package
-	return template.Execute(file.Dir, map[string]interface{}{ //nolint:wrapcheck
-		"Version":  pkg.Version,
-		"SemVer":   cpkg.SemVer(),
-		"GOOS":     rt.GOOS,
-		"GOARCH":   rt.GOARCH,
-		"OS":       replace(rt.GOOS, pkgInfo.GetReplacements()),
-		"Arch":     getArch(pkgInfo.GetRosetta2(), pkgInfo.GetReplacements(), rt),
-		"Format":   pkgInfo.GetFormat(),
-		"FileName": file.Name,
-	})
-}
-
 func (cpkg *Package) WindowsExt() string {
 	if cpkg.PackageInfo.WindowsExt == "" {
 		if cpkg.PackageInfo.Type == registry.PkgInfoTypeGitHubContent || cpkg.PackageInfo.Type == registry.PkgInfoTypeGitHubArchive {


### PR DESCRIPTION
This method seems to have been used for "go" type package.