### PR TITLE
Revert "feat: support omitting `{{.Format}}` in Asset and provide the variable `AssetWithoutExt`"

### DIFF
--- a/pkg/config/const.go
+++ b/pkg/config/const.go
@@ -1,5 +1,0 @@
-package config
-
-const (
-	formatRaw = "raw"
-)

--- a/pkg/template/render.go
+++ b/pkg/template/render.go
@@ -7,26 +7,24 @@ import (
 )
 
 type Artifact struct {
-	Version         string
-	SemVer          string
-	OS              string
-	Arch            string
-	Format          string
-	Asset           string
-	AssetWithoutExt string
+	Version string
+	SemVer  string
+	OS      string
+	Arch    string
+	Format  string
+	Asset   string
 }
 
 func renderParam(art *Artifact, rt *runtime.Runtime) map[string]interface{} {
 	return map[string]interface{}{
-		"Version":         art.Version,
-		"SemVer":          art.SemVer,
-		"GOOS":            rt.GOOS,
-		"GOARCH":          rt.GOARCH,
-		"OS":              art.OS,
-		"Arch":            art.Arch,
-		"Format":          art.Format,
-		"Asset":           art.Asset,
-		"AssetWithoutExt": art.AssetWithoutExt,
+		"Version": art.Version,
+		"SemVer":  art.SemVer,
+		"GOOS":    rt.GOOS,
+		"GOARCH":  rt.GOARCH,
+		"OS":      art.OS,
+		"Arch":    art.Arch,
+		"Format":  art.Format,
+		"Asset":   art.Asset,
 	}
 }
 


### PR DESCRIPTION
Reverts aquaproj/aqua#1853

If the file extension is different from `format`, there is an issue.

- https://github.com/aquaproj/aqua-registry/issues/11365