### PR TITLE
fix: get a write lock before writing a map

### DIFF
--- a/pkg/checksum/type.go
+++ b/pkg/checksum/type.go
@@ -27,12 +27,12 @@ func New() *Checksums {
 }
 
 func (chksums *Checksums) Get(key string) *Checksum {
-	chksums.rwmutex.RLock()
+	chksums.rwmutex.Lock()
 	chk := chksums.m[key]
 	if chk != nil {
 		chksums.newM[key] = chk
 	}
-	chksums.rwmutex.RUnlock()
+	chksums.rwmutex.Unlock()
 	return chk
 }
 


### PR DESCRIPTION
Fix a panic `fatal error: concurrent map writes`