### PR TITLE
fix: list package contents if the executable file isn't found in Windows

### DIFF
--- a/pkg/installpackage/find_src.go
+++ b/pkg/installpackage/find_src.go
@@ -6,18 +6,6 @@ import (
 	"path/filepath"
 )
 
-type FileNotFoundError struct {
-	err error
-}
-
-func (errorFileNotFound *FileNotFoundError) Error() string {
-	return errorFileNotFound.err.Error()
-}
-
-func (errorFileNotFound *FileNotFoundError) Unwrap() error {
-	return errorFileNotFound.err
-}
-
 func containPath(p string) bool {
 	switch p {
 	case "README", "README.md", "LICENSE":

--- a/pkg/installpackage/installer.go
+++ b/pkg/installpackage/installer.go
@@ -258,7 +258,7 @@ func (inst *InstallerImpl) InstallPackage(ctx context.Context, logE *logrus.Entr
 	for _, file := range pkgInfo.GetFiles() {
 		file := file
 		logE := logE.WithField("file_name", file.Name)
-		var errFileNotFound *FileNotFoundError
+		var errFileNotFound *config.FileNotFoundError
 		if err := inst.checkAndCopyFile(pkg, file, logE); err != nil {
 			if errors.As(err, &errFileNotFound) {
 				notFound = true
@@ -349,8 +349,8 @@ func (inst *InstallerImpl) checkFileSrc(pkg *config.Package, file *registry.File
 	exePath := filepath.Join(pkgPath, fileSrc)
 	finfo, err := inst.fs.Stat(exePath)
 	if err != nil {
-		return "", fmt.Errorf("exe_path isn't found: %w", logerr.WithFields(&FileNotFoundError{
-			err: err,
+		return "", fmt.Errorf("exe_path isn't found: %w", logerr.WithFields(&config.FileNotFoundError{
+			Err: err,
 		}, logE.Data))
 	}
 	if finfo.IsDir() {


### PR DESCRIPTION
- https://github.com/aquaproj/aqua/issues/1904

```
# aqua -c aqua-global.yaml exec -- kustomize version
ERRO[0000] check file_src is correct                     aqua_version= env=windows/amd64 error="check file_src is correct: get file_src: CreateFile C:\\Users\\runneradmin\\AppData\\Local\\aquaproj-aqua\\pkgs\\github_release\\github.com\\kubernetes-sigs\\kustomize\\kustomize\\v4.5.7\\kustomize_v4.5.7_windows_amd64.tar.gz\\hoge: The system cannot find the file specified." exe_name=kustomize file_name=kustomize package=kubernetes-sigs/kustomize/version_prefix package_name=kubernetes-sigs/kustomize/version_prefix package_version=kustomize/v4.5.7 program=aqua registry=local
ERRO[0000] executable files aren't found
Files in the unarchived package:
kustomize.exe
   aqua_version= env=windows/amd64 exe_name=kustomize package=kubernetes-sigs/kustomize/version_prefix package_name=kubernetes-sigs/kustomize/version_prefix package_version=kustomize/v4.5.7 program=aqua registry=local
FATA[0000] aqua failed                                   aqua_version= env=windows/amd64 error="check file_src is correct" exe_name=kustomize package=kubernetes-sigs/kustomize/version_prefix package_version=kustomize/v4.5.7 program=aqua
```