### PR TITLE
chore: set github token

### DIFF
--- a/.github/workflows/debug-with-action-tmate.yaml
+++ b/.github/workflows/debug-with-action-tmate.yaml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - run: gh pr checkout "${{inputs.pr_number}}"
         if: inputs.pr_number != ''
+        env:
+          GITHUB_TOKEN: ${{github.token}}
       - uses: aquaproj/aqua-installer@v2.1.1
         with:
           aqua_version: v2.3.7


### PR DESCRIPTION
Follow up #1921

https://github.com/aquaproj/aqua/actions/runs/4868678091/jobs/8682358685

```
Run gh pr checkout "1919"
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
Error: Process completed with exit code 1.
```