### PR TITLE
fix: fix a bug the default checksum parser can't extract the checksum if the checksum has a prefix "*"

### DIFF
--- a/pkg/checksum/parser.go
+++ b/pkg/checksum/parser.go
@@ -82,7 +82,7 @@ func (parser *FileParser) parseDefault(content string) (map[string]string, strin
 		if idx == -1 {
 			continue
 		}
-		m[path.Base(strings.TrimSpace(line[idx:]))] = line[:idx]
+		m[strings.TrimPrefix(path.Base(strings.TrimSpace(line[idx:])), "*")] = line[:idx]
 	}
 	if len(m) == 0 {
 		return nil, "", ErrNoChecksumExtracted


### PR DESCRIPTION
- https://github.com/aquaproj/aqua/issues/1956