### PR TITLE
feat: move aqua-proxy from bin dir to AQUA_ROOT_DIR

### DIFF
--- a/pkg/controller/install/install_test.go
+++ b/pkg/controller/install/install_test.go
@@ -73,13 +73,13 @@ packages:
 				"/home/foo/.local/share/aquaproj-aqua/pkgs/github_content/github.com/aquaproj/aqua-installer/v1.0.0/aqua-installer/aqua-installer":                                                       ``,
 				fmt.Sprintf("/home/foo/.local/share/aquaproj-aqua/internal/pkgs/github_release/github.com/aquaproj/aqua-proxy/%s/aqua-proxy_linux_amd64.tar.gz/aqua-proxy", installpackage.ProxyVersion): ``,
 				"/home/foo/.local/share/aquaproj-aqua/bin/aqua-installer": ``,
-				"/home/foo/.local/share/aquaproj-aqua/bin/aqua-proxy":     ``,
+				"/home/foo/.local/share/aquaproj-aqua/aqua-proxy":         ``,
 			},
 			dirs: []string{
 				"/home/foo/workspace/.git",
 			},
 			links: map[string]string{
-				"aqua-proxy": "/home/foo/.local/share/aquaproj-aqua/bin/aqua-installer",
+				"../aqua-proxy": "/home/foo/.local/share/aquaproj-aqua/bin/aqua-installer",
 				fmt.Sprintf("../internal/pkgs/github_release/github.com/aquaproj/aqua-proxy/%s/aqua-proxy_linux_amd64.tar.gz/aqua-proxy", installpackage.ProxyVersion): "/home/foo/.local/share/aquaproj-aqua/bin/aqua-proxy",
 			},
 		},

--- a/pkg/installpackage/installer.go
+++ b/pkg/installpackage/installer.go
@@ -297,7 +297,7 @@ func (inst *InstallerImpl) createLinks(logE *logrus.Entry, pkgs []*config.Packag
 				}
 				continue
 			}
-			if err := inst.createLink(filepath.Join(inst.rootDir, "bin", file.Name), proxyName, logE); err != nil {
+			if err := inst.createLink(filepath.Join(inst.rootDir, "bin", file.Name), filepath.Join("..", proxyName), logE); err != nil {
 				logerr.WithError(logE, err).Error("create the symbolic link")
 				failed = true
 				continue

--- a/pkg/installpackage/installer_test.go
+++ b/pkg/installpackage/installer_test.go
@@ -88,7 +88,7 @@ func Test_installer_InstallPackages(t *testing.T) { //nolint:funlen
 				"/home/foo/.local/share/aquaproj-aqua/pkgs/github_release/github.com/suzuki-shunsuke/ci-info/v2.0.3/ci-info_2.0.3_linux_amd64.tar.gz/ci-info": ``,
 			},
 			links: map[string]string{
-				"aqua-proxy": "/home/foo/.local/share/aquaproj-aqua/bin/ci-info",
+				"../aqua-proxy": "/home/foo/.local/share/aquaproj-aqua/bin/ci-info",
 			},
 		},
 		{
@@ -140,7 +140,7 @@ func Test_installer_InstallPackages(t *testing.T) { //nolint:funlen
 				"/home/foo/.local/share/aquaproj-aqua/pkgs/github_release/github.com/suzuki-shunsuke/ci-info/v2.0.3/ci-info_2.0.3_linux_amd64.tar.gz/ci-info": ``,
 			},
 			links: map[string]string{
-				"aqua-proxy": "/home/foo/.local/share/aquaproj-aqua/bin/ci-info",
+				"../aqua-proxy": "/home/foo/.local/share/aquaproj-aqua/bin/ci-info",
 			},
 		},
 		{

--- a/pkg/installpackage/proxy.go
+++ b/pkg/installpackage/proxy.go
@@ -87,10 +87,10 @@ func (inst *InstallerImpl) InstallProxy(ctx context.Context, logE *logrus.Entry)
 
 	// create a symbolic link
 	binName := proxyName
-	a, err := filepath.Rel(filepath.Join(inst.rootDir, "bin"), filepath.Join(pkgPath, binName))
+	a, err := filepath.Rel(inst.rootDir, filepath.Join(pkgPath, binName))
 	if err != nil {
 		return fmt.Errorf("get a relative path: %w", err)
 	}
 
-	return inst.createLink(filepath.Join(inst.rootDir, "bin", proxyName), a, logE)
+	return inst.createLink(filepath.Join(inst.rootDir, proxyName), a, logE)
 }


### PR DESCRIPTION
Close #1872

Move the symbolic link for `aqua-proxy` from `$AQUA_ROOT_DIR/bin/aqua-proxy` to `$AQUA_ROOT_DIR/aqua-proxy`.