### PR TITLE
feat: add -detail option to "generate" command

### DIFF
--- a/pkg/cli/generate.go
+++ b/pkg/cli/generate.go
@@ -128,6 +128,7 @@ func (runner *Runner) newGenerateCommand() *cli.Command {
 				Name:    "detail",
 				Aliases: []string{"d"},
 				Usage:   `Output additional fields such as description and link`,
+				EnvVars: []string{"AQUA_GENERATE_WITH_DETAIL"},
 			},
 			&cli.StringFlag{
 				Name:  "o",

--- a/pkg/cli/generate.go
+++ b/pkg/cli/generate.go
@@ -94,6 +94,13 @@ The option "-pin" is useful to prevent the package from being updated by Renovat
 $ aqua g -pin cli/cli
 - name: cli/cli
   version: v2.2.0
+
+With -detail option, aqua outputs additional information such as description and link.
+
+$ aqua g -detail cli/cli
+- name: cli/cli@v2.2.0
+  description: GitHub’s official command line tool
+  link: https://github.com/cli/cli
 `
 
 func (runner *Runner) newGenerateCommand() *cli.Command {
@@ -116,6 +123,11 @@ func (runner *Runner) newGenerateCommand() *cli.Command {
 			&cli.BoolFlag{
 				Name:  "pin",
 				Usage: `Pin version`,
+			},
+			&cli.BoolFlag{
+				Name:    "detail",
+				Aliases: []string{"d"},
+				Usage:   `Output additional fields such as description and link`,
 			},
 			&cli.StringFlag{
 				Name:  "o",

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -50,6 +50,7 @@ func (runner *Runner) setParam(c *cli.Context, commandName string, param *config
 		param.Insert = c.Bool("i")
 	}
 	param.All = c.Bool("all")
+	param.Detail = c.Bool("detail")
 	param.Prune = c.Bool("prune")
 	param.SelectVersion = c.Bool("select-version")
 	param.File = c.String("f")

--- a/pkg/config/aqua/config.go
+++ b/pkg/config/aqua/config.go
@@ -7,11 +7,13 @@ import (
 )
 
 type Package struct {
-	Name     string   `validate:"required" json:"name,omitempty"`
-	Registry string   `validate:"required" yaml:",omitempty" json:"registry,omitempty" jsonschema:"description=Registry name,example=foo,example=local,default=standard"`
-	Version  string   `validate:"required" yaml:",omitempty" json:"version,omitempty"`
-	Import   string   `yaml:",omitempty" json:"import,omitempty"`
-	Tags     []string `yaml:",omitempty" json:"tags,omitempty"`
+	Name        string   `validate:"required" json:"name,omitempty"`
+	Registry    string   `validate:"required" yaml:",omitempty" json:"registry,omitempty" jsonschema:"description=Registry name,example=foo,example=local,default=standard"`
+	Version     string   `validate:"required" yaml:",omitempty" json:"version,omitempty"`
+	Import      string   `yaml:",omitempty" json:"import,omitempty"`
+	Tags        []string `yaml:",omitempty" json:"tags,omitempty"`
+	Description string   `yaml:",omitempty" json:"description,omitempty"`
+	Link        string   `yaml:",omitempty" json:"link,omitempty"`
 }
 
 func (pkg *Package) UnmarshalYAML(unmarshal func(interface{}) error) error {

--- a/pkg/config/package.go
+++ b/pkg/config/package.go
@@ -295,6 +295,7 @@ type Param struct {
 	Prune                 bool
 	RequireChecksum       bool
 	DisablePolicy         bool
+	Detail                bool
 	PolicyConfigFilePaths []string
 }
 

--- a/pkg/controller/generate/generate.go
+++ b/pkg/controller/generate/generate.go
@@ -255,6 +255,10 @@ func (ctrl *Controller) getOutputtedPkg(ctx context.Context, logE *logrus.Entry,
 		Registry: pkg.RegistryName,
 		Version:  pkg.Version,
 	}
+	if param.Detail {
+		outputPkg.Link = pkg.PackageInfo.GetLink()
+		outputPkg.Description = pkg.PackageInfo.GetDescription()
+	}
 	if outputPkg.Registry == registryStandard {
 		outputPkg.Registry = ""
 	}


### PR DESCRIPTION
https://github.com/orgs/aquaproj/discussions/2027

With -detail (-d) option, aqua outputs additional information such as description and link.

```console
$ aqua g -detail cli/cli
- name: cli/cli@v2.2.0
  description: GitHub’s official command line tool
  link: https://github.com/cli/cli
```

The environment variable `AQUA_GENERATE_WITH_DETAIL` is also available.

```sh
export AQUA_GENERATE_WITH_DETAIL=true
```