### PR TITLE
fix: stop outputting checksum file paths except for aqua update-checksum

### DIFF
--- a/pkg/checksum/type.go
+++ b/pkg/checksum/type.go
@@ -26,8 +26,11 @@ func New() *Checksums {
 		m:       map[string]*Checksum{},
 		newM:    map[string]*Checksum{},
 		rwmutex: &sync.RWMutex{},
-		stdout:  os.Stdout,
 	}
+}
+
+func (chksums *Checksums) EnableOutput() {
+	chksums.stdout = os.Stdout
 }
 
 func (chksums *Checksums) Get(key string) *Checksum {
@@ -116,7 +119,9 @@ func (chksums *Checksums) UpdateFile(fs afero.Fs, p string) error {
 	chkJSON := &checksumsJSON{
 		Checksums: arr,
 	}
-	fmt.Fprintln(chksums.stdout, p)
+	if chksums.stdout != nil {
+		fmt.Fprintln(chksums.stdout, p)
+	}
 	if err := encoder.Encode(chkJSON); err != nil {
 		return fmt.Errorf("write a checksum file as JSON: %w", err)
 	}

--- a/pkg/controller/updatechecksum/update.go
+++ b/pkg/controller/updatechecksum/update.go
@@ -84,6 +84,7 @@ func (ctrl *Controller) updateChecksum(ctx context.Context, logE *logrus.Entry, 
 	}
 
 	checksums := checksum.New()
+	checksums.EnableOutput()
 	checksumFilePath, err := checksum.GetChecksumFilePathFromConfigFilePath(ctrl.fs, cfgFilePath)
 	if err != nil {
 		return err //nolint:wrapcheck


### PR DESCRIPTION
Follow up a bug of https://github.com/aquaproj/aqua/pull/2108
The bug affects only aqua v2.10.0.