### PR TITLE
refactor: replace suzuki-shunsuke/go-timeout to exec.CommandContext, Cmd.Cancel, and Cmd.WaitDelay

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/suzuki-shunsuke/go-error-with-exit-code v1.0.0
 	github.com/suzuki-shunsuke/go-findconfig v1.1.1
 	github.com/suzuki-shunsuke/go-osenv v0.1.0
-	github.com/suzuki-shunsuke/go-timeout v1.0.0
 	github.com/suzuki-shunsuke/logrus-error v0.1.4
 	github.com/urfave/cli/v2 v2.25.7
 	golang.org/x/oauth2 v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -255,7 +255,6 @@ github.com/otiai10/mint v1.5.1 h1:XaPLeE+9vGbuyEHem1JNk3bYc7KKqyI/na0/mLd/Kks=
 github.com/pierrec/lz4/v4 v4.1.2 h1:qvY3YFXRQE/XB8MlLzJH7mSzBs74eA2gg52YTk6jUPM=
 github.com/pierrec/lz4/v4 v4.1.2/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
@@ -308,8 +307,6 @@ github.com/suzuki-shunsuke/go-jsoneq v0.1.2 h1:A4czEbmFqSELTbrEtXVo4dSgfz2e2Z0y6
 github.com/suzuki-shunsuke/go-jsoneq v0.1.2/go.mod h1:ETXAwfruZTqMMKDxc9CYoS34CNSsnzcdcVIAW3+RujI=
 github.com/suzuki-shunsuke/go-osenv v0.1.0 h1:hBQ7yaeO1WBZsEWuDj1wrOWF+N7HSWSOpEiEZqfCjjk=
 github.com/suzuki-shunsuke/go-osenv v0.1.0/go.mod h1:ZlSVi4kYvV51JEtYpdHh9hAxXKLOWExXel3Jo74aacQ=
-github.com/suzuki-shunsuke/go-timeout v1.0.0 h1:SWiJc8HuLWK4N01x76XUg75rbbwDiHiFoyPbwHcNI4Q=
-github.com/suzuki-shunsuke/go-timeout v1.0.0/go.mod h1:ZX3QIig4tvTVXnZUJE3ivC9qy5TJy9Uk5sIcvwjwSNE=
 github.com/suzuki-shunsuke/gomic v0.6.0 h1:oSmoXR1nmt7X05TssjBTcX9BCTNnFCcNlA5yshaTjsk=
 github.com/suzuki-shunsuke/gomic v0.6.0/go.mod h1:/+uhQJ1H5f9ythus/MbXOotAZDmkN1QOjKlsSiH2v+I=
 github.com/suzuki-shunsuke/logrus-error v0.1.4 h1:nWo98uba1fANHdZ9Y5pJ2RKs/PpVjrLzRp5m+mRb9KE=

--- a/pkg/exec/dmg.go
+++ b/pkg/exec/dmg.go
@@ -6,11 +6,11 @@ import (
 )
 
 func (exe *Executor) HdiutilDetach(ctx context.Context, mountPath string) (int, error) {
-	cmd := exe.command(exec.Command("hdiutil", "detach", mountPath))
-	return exe.execAndOutputWhenFailure(ctx, cmd)
+	cmd := exe.command(exec.CommandContext(ctx, "hdiutil", "detach", mountPath))
+	return exe.execAndOutputWhenFailure(cmd)
 }
 
 func (exe *Executor) HdiutilAttach(ctx context.Context, dmgPath, mountPoint string) (int, error) {
-	cmd := exe.command(exec.Command("hdiutil", "attach", dmgPath, "-mountpoint", mountPoint))
-	return exe.execAndOutputWhenFailure(ctx, cmd)
+	cmd := exe.command(exec.CommandContext(ctx, "hdiutil", "attach", dmgPath, "-mountpoint", mountPoint))
+	return exe.execAndOutputWhenFailure(cmd)
 }

--- a/pkg/exec/pkg.go
+++ b/pkg/exec/pkg.go
@@ -6,6 +6,5 @@ import (
 )
 
 func (exe *Executor) UnarchivePkg(ctx context.Context, pkgFilePath, dest string) (int, error) {
-	cmd := exe.command(exec.Command("pkgutil", "--expand-full", pkgFilePath, dest))
-	return exe.execAndOutputWhenFailure(ctx, cmd)
+	return exe.execAndOutputWhenFailure(exe.command(exec.CommandContext(ctx, "pkgutil", "--expand-full", pkgFilePath, dest)))
 }


### PR DESCRIPTION
Go 1.20 supports Cmd.Cancel, and Cmd.WaitDelay.