### PR TITLE
fix: change the log level from warn to debug

### DIFF
--- a/pkg/config/registry/config.go
+++ b/pkg/config/registry/config.go
@@ -21,10 +21,6 @@ func (pkgInfos *PackageInfos) ToMap(logE *logrus.Entry) map[string]*PackageInfo 
 	return pkgInfos.toMap(logE, logrus.DebugLevel)
 }
 
-func (pkgInfos *PackageInfos) ToMapWarn(logE *logrus.Entry) map[string]*PackageInfo {
-	return pkgInfos.toMap(logE, logrus.WarnLevel)
-}
-
 func (pkgInfos *PackageInfos) toMap(logE *logrus.Entry, logLevel logrus.Level) map[string]*PackageInfo {
 	m := make(map[string]*PackageInfo, len(*pkgInfos))
 	logE = logE.WithField("package_name", "")

--- a/pkg/controller/generate/generate.go
+++ b/pkg/controller/generate/generate.go
@@ -164,7 +164,7 @@ func (ctrl *Controller) listPkgsWithFinder(ctx context.Context, logE *logrus.Ent
 func (ctrl *Controller) setPkgMap(logE *logrus.Entry, registryContents map[string]*registry.Config, m map[string]*FindingPackage) {
 	for registryName, registryContent := range registryContents {
 		logE := logE.WithField("registry_name", registryName)
-		for pkgName, pkg := range registryContent.PackageInfos.ToMapWarn(logE) {
+		for pkgName, pkg := range registryContent.PackageInfos.ToMap(logE) {
 			pkg := pkg
 			logE := logE.WithField("package_name", pkgName)
 			m[registryName+","+pkgName] = &FindingPackage{

--- a/pkg/controller/list/list.go
+++ b/pkg/controller/list/list.go
@@ -66,7 +66,7 @@ func (ctrl *Controller) List(ctx context.Context, param *config.Param, logE *log
 		return err //nolint:wrapcheck
 	}
 	for registryName, registryContent := range registryContents {
-		for pkgName := range registryContent.PackageInfos.ToMapWarn(logE) {
+		for pkgName := range registryContent.PackageInfos.ToMap(logE) {
 			if pkgName == "" {
 				logE.Debug("ignore a package because the package name is empty")
 				continue


### PR DESCRIPTION
## What

Change the log level if packages don't have names.

## Why

If aqua supports new package types and add packages to Standard Registry,
old aqua outputs warnings because it can't get package names correctly.
But if those packages aren't used, aqua don't need to output the warning.
To suppress the warning, this pull request changes the log level to debug.