### PR TITLE
refactor: shorten receiver names

### DIFF
--- a/pkg/cargo/versions.go
+++ b/pkg/cargo/versions.go
@@ -39,19 +39,19 @@ type MockClient struct {
 	CratePayload *CratePayload
 }
 
-func (mock *MockClient) ListVersions(ctx context.Context, crate string) ([]string, error) {
-	return mock.Versions, mock.Err
+func (m *MockClient) ListVersions(ctx context.Context, crate string) ([]string, error) {
+	return m.Versions, m.Err
 }
 
-func (mock *MockClient) GetLatestVersion(ctx context.Context, crate string) (string, error) {
-	if len(mock.Versions) == 0 {
-		return "", mock.Err
+func (m *MockClient) GetLatestVersion(ctx context.Context, crate string) (string, error) {
+	if len(m.Versions) == 0 {
+		return "", m.Err
 	}
-	return mock.Versions[0], mock.Err
+	return m.Versions[0], m.Err
 }
 
-func (mock *MockClient) GetCrate(ctx context.Context, crate string) (*CratePayload, error) {
-	return mock.CratePayload, mock.Err
+func (m *MockClient) GetCrate(ctx context.Context, crate string) (*CratePayload, error) {
+	return m.CratePayload, m.Err
 }
 
 type ClientImpl struct {
@@ -64,21 +64,21 @@ func NewClientImpl(client *http.Client) *ClientImpl {
 	}
 }
 
-func (searcher *ClientImpl) ListVersions(ctx context.Context, crate string) ([]string, error) {
-	versions, _, err := listInstallableVersions(ctx, searcher.client, fmt.Sprintf("https://crates.io/api/v1/crates/%s/versions", crate))
+func (c *ClientImpl) ListVersions(ctx context.Context, crate string) ([]string, error) {
+	versions, _, err := listInstallableVersions(ctx, c.client, fmt.Sprintf("https://crates.io/api/v1/crates/%s/versions", crate))
 	return versions, err
 }
 
-func (searcher *ClientImpl) GetLatestVersion(ctx context.Context, crate string) (string, error) {
-	versions, err := searcher.ListVersions(ctx, crate)
+func (c *ClientImpl) GetLatestVersion(ctx context.Context, crate string) (string, error) {
+	versions, err := c.ListVersions(ctx, crate)
 	if len(versions) == 0 {
 		return "", err
 	}
 	return versions[0], err
 }
 
-func (searcher *ClientImpl) GetCrate(ctx context.Context, crate string) (*CratePayload, error) {
-	payload, _, err := getCrate(ctx, searcher.client, fmt.Sprintf("https://crates.io/api/v1/crates/%s", crate))
+func (c *ClientImpl) GetCrate(ctx context.Context, crate string) (*CratePayload, error) {
+	payload, _, err := getCrate(ctx, c.client, fmt.Sprintf("https://crates.io/api/v1/crates/%s", crate))
 	return payload, err
 }
 

--- a/pkg/checksum/checksum.go
+++ b/pkg/checksum/checksum.go
@@ -20,7 +20,7 @@ func NewCalculator() *Calculator {
 
 type Calculator struct{}
 
-func (calc *Calculator) Calculate(fs afero.Fs, filename, algorithm string) (string, error) {
+func (*Calculator) Calculate(fs afero.Fs, filename, algorithm string) (string, error) {
 	f, err := fs.Open(filename)
 	if err != nil {
 		return "", fmt.Errorf("open a file to calculate the checksum: %w", err)

--- a/pkg/cli/allow_policy.go
+++ b/pkg/cli/allow_policy.go
@@ -8,7 +8,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func (runner *Runner) newAllowPolicyCommand() *cli.Command {
+func (r *Runner) newAllowPolicyCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "allow",
 		Usage: "Allow a policy file",
@@ -16,11 +16,11 @@ func (runner *Runner) newAllowPolicyCommand() *cli.Command {
 e.g.
 $ aqua policy allow [<policy file path>]
 `,
-		Action: runner.allowPolicyAction,
+		Action: r.allowPolicyAction,
 	}
 }
 
-func (runner *Runner) allowPolicyAction(c *cli.Context) error {
+func (r *Runner) allowPolicyAction(c *cli.Context) error {
 	tracer, err := startTrace(c.String("trace"))
 	if err != nil {
 		return err
@@ -34,9 +34,9 @@ func (runner *Runner) allowPolicyAction(c *cli.Context) error {
 	defer cpuProfiler.Stop()
 
 	param := &config.Param{}
-	if err := runner.setParam(c, "allow-policy", param); err != nil {
+	if err := r.setParam(c, "allow-policy", param); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
 	ctrl := controller.InitializeAllowPolicyCommandController(c.Context, param)
-	return ctrl.Allow(c.Context, runner.LogE, param, c.Args().First()) //nolint:wrapcheck
+	return ctrl.Allow(c.Context, r.LogE, param, c.Args().First()) //nolint:wrapcheck
 }

--- a/pkg/cli/completion.go
+++ b/pkg/cli/completion.go
@@ -6,7 +6,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func (runner *Runner) newCompletionCommand() *cli.Command {
+func (r *Runner) newCompletionCommand() *cli.Command {
 	// https://github.com/aquaproj/aqua/pull/859
 	// https://cli.urfave.org/v2/#bash-completion
 	return &cli.Command{
@@ -27,21 +27,21 @@ if command -v aqua &> /dev/null; then source <(aqua completion zsh); fi
 			{
 				Name:   "bash",
 				Usage:  "Output shell completion script for bash",
-				Action: runner.bashCompletionAction,
+				Action: r.bashCompletionAction,
 			},
 			{
 				Name:   "zsh",
 				Usage:  "Output shell completion script for zsh",
-				Action: runner.zshCompletionAction,
+				Action: r.zshCompletionAction,
 			},
 		},
 	}
 }
 
-func (runner *Runner) bashCompletionAction(c *cli.Context) error {
+func (r *Runner) bashCompletionAction(c *cli.Context) error {
 	// https://github.com/urfave/cli/blob/main/autocomplete/bash_autocomplete
 	// https://github.com/urfave/cli/blob/c3f51bed6fffdf84227c5b59bd3f2e90683314df/autocomplete/bash_autocomplete#L5-L20
-	fmt.Fprintln(runner.Stdout, `
+	fmt.Fprintln(r.Stdout, `
 _cli_bash_autocomplete() {
   if [[ "${COMP_WORDS[0]}" != "source" ]]; then
     local cur opts base
@@ -61,10 +61,10 @@ complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete aqua`)
 	return nil
 }
 
-func (runner *Runner) zshCompletionAction(c *cli.Context) error {
+func (r *Runner) zshCompletionAction(c *cli.Context) error {
 	// https://github.com/urfave/cli/blob/main/autocomplete/zsh_autocomplete
 	// https://github.com/urfave/cli/blob/947f9894eef4725a1c15ed75459907b52dde7616/autocomplete/zsh_autocomplete
-	fmt.Fprintln(runner.Stdout, `
+	fmt.Fprintln(r.Stdout, `
 #compdef aqua
 
 _cli_zsh_autocomplete() {

--- a/pkg/cli/cp.go
+++ b/pkg/cli/cp.go
@@ -9,7 +9,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func (runner *Runner) newCpCommand() *cli.Command {
+func (r *Runner) newCpCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "cp",
 		Usage:     "Copy executable files in a directory",
@@ -60,11 +60,11 @@ e.g.
 $ aqua cp -t foo # Copy only packages having a tag "foo"
 $ aqua cp --exclude-tags foo # Copy only packages not having a tag "foo"
 `,
-		Action: runner.cpAction,
+		Action: r.cpAction,
 	}
 }
 
-func (runner *Runner) cpAction(c *cli.Context) error {
+func (r *Runner) cpAction(c *cli.Context) error {
 	tracer, err := startTrace(c.String("trace"))
 	if err != nil {
 		return err
@@ -78,12 +78,12 @@ func (runner *Runner) cpAction(c *cli.Context) error {
 	defer cpuProfiler.Stop()
 
 	param := &config.Param{}
-	if err := runner.setParam(c, "cp", param); err != nil {
+	if err := r.setParam(c, "cp", param); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
 	param.SkipLink = true
-	ctrl := controller.InitializeCopyCommandController(c.Context, param, http.DefaultClient, runner.Runtime)
-	if err := ctrl.Copy(c.Context, runner.LogE, param); err != nil {
+	ctrl := controller.InitializeCopyCommandController(c.Context, param, http.DefaultClient, r.Runtime)
+	if err := ctrl.Copy(c.Context, r.LogE, param); err != nil {
 		return err //nolint:wrapcheck
 	}
 	return nil

--- a/pkg/cli/deny_policy.go
+++ b/pkg/cli/deny_policy.go
@@ -8,7 +8,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func (runner *Runner) newDenyPolicyCommand() *cli.Command {
+func (r *Runner) newDenyPolicyCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "deny",
 		Usage: "Deny a policy file",
@@ -16,11 +16,11 @@ func (runner *Runner) newDenyPolicyCommand() *cli.Command {
 e.g.
 $ aqua policy deny [<policy file path>]
 `,
-		Action: runner.denyPolicyAction,
+		Action: r.denyPolicyAction,
 	}
 }
 
-func (runner *Runner) denyPolicyAction(c *cli.Context) error {
+func (r *Runner) denyPolicyAction(c *cli.Context) error {
 	tracer, err := startTrace(c.String("trace"))
 	if err != nil {
 		return err
@@ -34,9 +34,9 @@ func (runner *Runner) denyPolicyAction(c *cli.Context) error {
 	defer cpuProfiler.Stop()
 
 	param := &config.Param{}
-	if err := runner.setParam(c, "deny-policy", param); err != nil {
+	if err := r.setParam(c, "deny-policy", param); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
 	ctrl := controller.InitializeDenyPolicyCommandController(c.Context, param)
-	return ctrl.Deny(c.Context, runner.LogE, param, c.Args().First()) //nolint:wrapcheck
+	return ctrl.Deny(c.Context, r.LogE, param, c.Args().First()) //nolint:wrapcheck
 }

--- a/pkg/cli/exec.go
+++ b/pkg/cli/exec.go
@@ -20,7 +20,7 @@ func parseExecArgs(args []string) (string, []string, error) {
 	return filepath.Base(args[0]), args[1:], nil
 }
 
-func (runner *Runner) newExecCommand() *cli.Command {
+func (r *Runner) newExecCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "exec",
 		Usage: "Execute tool",
@@ -31,12 +31,12 @@ e.g.
 $ aqua exec -- gh version
 gh version 2.4.0 (2021-12-21)
 https://github.com/cli/cli/releases/tag/v2.4.0`,
-		Action:    runner.execAction,
+		Action:    r.execAction,
 		ArgsUsage: `<executed command> [<arg> ...]`,
 	}
 }
 
-func (runner *Runner) execAction(c *cli.Context) error {
+func (r *Runner) execAction(c *cli.Context) error {
 	tracer, err := startTrace(c.String("trace"))
 	if err != nil {
 		return err
@@ -50,13 +50,13 @@ func (runner *Runner) execAction(c *cli.Context) error {
 	defer cpuProfiler.Stop()
 
 	param := &config.Param{}
-	if err := runner.setParam(c, "exec", param); err != nil {
+	if err := r.setParam(c, "exec", param); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
-	ctrl := controller.InitializeExecCommandController(c.Context, param, http.DefaultClient, runner.Runtime)
+	ctrl := controller.InitializeExecCommandController(c.Context, param, http.DefaultClient, r.Runtime)
 	exeName, args, err := parseExecArgs(c.Args().Slice())
 	if err != nil {
 		return err
 	}
-	return ctrl.Exec(c.Context, runner.LogE, param, exeName, args...) //nolint:wrapcheck
+	return ctrl.Exec(c.Context, r.LogE, param, exeName, args...) //nolint:wrapcheck
 }

--- a/pkg/cli/generate.go
+++ b/pkg/cli/generate.go
@@ -103,14 +103,14 @@ $ aqua g -detail cli/cli
   link: https://github.com/cli/cli
 `
 
-func (runner *Runner) newGenerateCommand() *cli.Command {
+func (r *Runner) newGenerateCommand() *cli.Command {
 	return &cli.Command{
 		Name:        "generate",
 		Aliases:     []string{"g"},
 		Usage:       "Search packages in registries and output the configuration interactively",
 		ArgsUsage:   `[<registry name>,<package name> ...]`,
 		Description: generateDescription,
-		Action:      runner.generateAction,
+		Action:      r.generateAction,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "f",
@@ -143,7 +143,7 @@ func (runner *Runner) newGenerateCommand() *cli.Command {
 	}
 }
 
-func (runner *Runner) generateAction(c *cli.Context) error {
+func (r *Runner) generateAction(c *cli.Context) error {
 	tracer, err := startTrace(c.String("trace"))
 	if err != nil {
 		return err
@@ -157,9 +157,9 @@ func (runner *Runner) generateAction(c *cli.Context) error {
 	defer cpuProfiler.Stop()
 
 	param := &config.Param{}
-	if err := runner.setParam(c, "generate", param); err != nil {
+	if err := r.setParam(c, "generate", param); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
-	ctrl := controller.InitializeGenerateCommandController(c.Context, param, http.DefaultClient, runner.Runtime)
-	return ctrl.Generate(c.Context, runner.LogE, param, c.Args().Slice()...) //nolint:wrapcheck
+	ctrl := controller.InitializeGenerateCommandController(c.Context, param, http.DefaultClient, r.Runtime)
+	return ctrl.Generate(c.Context, r.LogE, param, c.Args().Slice()...) //nolint:wrapcheck
 }

--- a/pkg/cli/generate_registry.go
+++ b/pkg/cli/generate_registry.go
@@ -61,14 +61,14 @@ e.g.
 $ aqua gr --out-testdata testdata.yaml suzuki-shunsuke/tfcmt
 `
 
-func (runner *Runner) newGenerateRegistryCommand() *cli.Command {
+func (r *Runner) newGenerateRegistryCommand() *cli.Command {
 	return &cli.Command{
 		Name:        "generate-registry",
 		Aliases:     []string{"gr"},
 		Usage:       "Generate a registry's package configuration",
 		ArgsUsage:   `<package name>`,
 		Description: generateRegistryDescription,
-		Action:      runner.generateRegistryAction,
+		Action:      r.generateRegistryAction,
 		// TODO support "i" option
 		Flags: []cli.Flag{
 			// 	&cli.StringFlag{
@@ -87,7 +87,7 @@ func (runner *Runner) newGenerateRegistryCommand() *cli.Command {
 	}
 }
 
-func (runner *Runner) generateRegistryAction(c *cli.Context) error {
+func (r *Runner) generateRegistryAction(c *cli.Context) error {
 	tracer, err := startTrace(c.String("trace"))
 	if err != nil {
 		return err
@@ -101,9 +101,9 @@ func (runner *Runner) generateRegistryAction(c *cli.Context) error {
 	defer cpuProfiler.Stop()
 
 	param := &config.Param{}
-	if err := runner.setParam(c, "generate-registry", param); err != nil {
+	if err := r.setParam(c, "generate-registry", param); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
 	ctrl := controller.InitializeGenerateRegistryCommandController(c.Context, param, http.DefaultClient, os.Stdout)
-	return ctrl.GenerateRegistry(c.Context, param, runner.LogE, c.Args().Slice()...) //nolint:wrapcheck
+	return ctrl.GenerateRegistry(c.Context, param, r.LogE, c.Args().Slice()...) //nolint:wrapcheck
 }

--- a/pkg/cli/info.go
+++ b/pkg/cli/info.go
@@ -8,18 +8,18 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func (runner *Runner) newInfoCommand() *cli.Command {
+func (r *Runner) newInfoCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "info",
 		Usage: "Show information",
 		Description: `Show information.
 e.g.
 $ aqua info`,
-		Action: runner.info,
+		Action: r.info,
 	}
 }
 
-func (runner *Runner) info(c *cli.Context) error {
+func (r *Runner) info(c *cli.Context) error {
 	tracer, err := startTrace(c.String("trace"))
 	if err != nil {
 		return err
@@ -33,9 +33,9 @@ func (runner *Runner) info(c *cli.Context) error {
 	defer cpuProfiler.Stop()
 
 	param := &config.Param{}
-	if err := runner.setParam(c, "info", param); err != nil {
+	if err := r.setParam(c, "info", param); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
-	ctrl := controller.InitializeInfoCommandController(c.Context, param, runner.Runtime)
-	return ctrl.Info(c.Context, runner.LogE, param, c.Args().First()) //nolint:wrapcheck
+	ctrl := controller.InitializeInfoCommandController(c.Context, param, r.Runtime)
+	return ctrl.Info(c.Context, r.LogE, param, c.Args().First()) //nolint:wrapcheck
 }

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -8,7 +8,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func (runner *Runner) newInitCommand() *cli.Command {
+func (r *Runner) newInitCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "init",
 		Usage:     "Create a configuration file if it doesn't exist",
@@ -17,11 +17,11 @@ func (runner *Runner) newInitCommand() *cli.Command {
 e.g.
 $ aqua init # create "aqua.yaml"
 $ aqua init foo.yaml # create foo.yaml`,
-		Action: runner.initAction,
+		Action: r.initAction,
 	}
 }
 
-func (runner *Runner) initAction(c *cli.Context) error {
+func (r *Runner) initAction(c *cli.Context) error {
 	tracer, err := startTrace(c.String("trace"))
 	if err != nil {
 		return err
@@ -35,9 +35,9 @@ func (runner *Runner) initAction(c *cli.Context) error {
 	defer cpuProfiler.Stop()
 
 	param := &config.Param{}
-	if err := runner.setParam(c, "init", param); err != nil {
+	if err := r.setParam(c, "init", param); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
 	ctrl := controller.InitializeInitCommandController(c.Context, param)
-	return ctrl.Init(c.Context, c.Args().First(), runner.LogE) //nolint:wrapcheck
+	return ctrl.Init(c.Context, c.Args().First(), r.LogE) //nolint:wrapcheck
 }

--- a/pkg/cli/init_policy.go
+++ b/pkg/cli/init_policy.go
@@ -8,7 +8,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func (runner *Runner) newInitPolicyCommand() *cli.Command {
+func (r *Runner) newInitPolicyCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "init-policy",
 		Usage:     "[Deprecated] Create a policy file if it doesn't exist",
@@ -20,11 +20,11 @@ Please use "aqua policy init" command instead.
 e.g.
 $ aqua init-policy # create "aqua-policy.yaml"
 $ aqua init-policy foo.yaml # create foo.yaml`,
-		Action: runner.initPolicyAction,
+		Action: r.initPolicyAction,
 	}
 }
 
-func (runner *Runner) initPolicyAction(c *cli.Context) error {
+func (r *Runner) initPolicyAction(c *cli.Context) error {
 	tracer, err := startTrace(c.String("trace"))
 	if err != nil {
 		return err
@@ -38,9 +38,9 @@ func (runner *Runner) initPolicyAction(c *cli.Context) error {
 	defer cpuProfiler.Stop()
 
 	param := &config.Param{}
-	if err := runner.setParam(c, "init-policy", param); err != nil {
+	if err := r.setParam(c, "init-policy", param); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
 	ctrl := controller.InitializeInitPolicyCommandController(c.Context)
-	return ctrl.Init(c.Context, c.Args().First(), runner.LogE) //nolint:wrapcheck
+	return ctrl.Init(c.Context, c.Args().First(), r.LogE) //nolint:wrapcheck
 }

--- a/pkg/cli/install.go
+++ b/pkg/cli/install.go
@@ -9,7 +9,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func (runner *Runner) newInstallCommand() *cli.Command {
+func (r *Runner) newInstallCommand() *cli.Command {
 	return &cli.Command{
 		Name:    "install",
 		Aliases: []string{"i"},
@@ -35,7 +35,7 @@ e.g.
 $ aqua i -t foo # Install only packages having a tag "foo"
 $ aqua i --exclude-tags foo # Install only packages not having a tag "foo"
 `,
-		Action: runner.installAction,
+		Action: r.installAction,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:    "only-link",
@@ -64,7 +64,7 @@ $ aqua i --exclude-tags foo # Install only packages not having a tag "foo"
 	}
 }
 
-func (runner *Runner) installAction(c *cli.Context) error {
+func (r *Runner) installAction(c *cli.Context) error {
 	tracer, err := startTrace(c.String("trace"))
 	if err != nil {
 		return err
@@ -78,9 +78,9 @@ func (runner *Runner) installAction(c *cli.Context) error {
 	defer cpuProfiler.Stop()
 
 	param := &config.Param{}
-	if err := runner.setParam(c, "install", param); err != nil {
+	if err := r.setParam(c, "install", param); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
-	ctrl := controller.InitializeInstallCommandController(c.Context, param, http.DefaultClient, runner.Runtime)
-	return ctrl.Install(c.Context, runner.LogE, param) //nolint:wrapcheck
+	ctrl := controller.InitializeInstallCommandController(c.Context, param, http.DefaultClient, r.Runtime)
+	return ctrl.Install(c.Context, r.LogE, param) //nolint:wrapcheck
 }

--- a/pkg/cli/list.go
+++ b/pkg/cli/list.go
@@ -9,11 +9,11 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func (runner *Runner) newListCommand() *cli.Command {
+func (r *Runner) newListCommand() *cli.Command {
 	return &cli.Command{
 		Name:   "list",
 		Usage:  "List packages in Registries",
-		Action: runner.listAction,
+		Action: r.listAction,
 		Description: `Output the list of packages in registries.
 The output format is <registry name>,<package name>
 
@@ -27,7 +27,7 @@ standard,abs-lang/abs
 	}
 }
 
-func (runner *Runner) listAction(c *cli.Context) error {
+func (r *Runner) listAction(c *cli.Context) error {
 	tracer, err := startTrace(c.String("trace"))
 	if err != nil {
 		return err
@@ -41,9 +41,9 @@ func (runner *Runner) listAction(c *cli.Context) error {
 	defer cpuProfiler.Stop()
 
 	param := &config.Param{}
-	if err := runner.setParam(c, "list", param); err != nil {
+	if err := r.setParam(c, "list", param); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
-	ctrl := controller.InitializeListCommandController(c.Context, param, http.DefaultClient, runner.Runtime)
-	return ctrl.List(c.Context, param, runner.LogE) //nolint:wrapcheck
+	ctrl := controller.InitializeListCommandController(c.Context, param, http.DefaultClient, r.Runtime)
+	return ctrl.List(c.Context, param, r.LogE) //nolint:wrapcheck
 }

--- a/pkg/cli/policy.go
+++ b/pkg/cli/policy.go
@@ -4,14 +4,14 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func (runner *Runner) newPolicyCommand() *cli.Command {
+func (r *Runner) newPolicyCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "policy",
 		Usage: "Manage Policy",
 		Subcommands: []*cli.Command{
-			runner.newAllowPolicyCommand(),
-			runner.newDenyPolicyCommand(),
-			runner.newPolicyInitCommand(),
+			r.newAllowPolicyCommand(),
+			r.newDenyPolicyCommand(),
+			r.newPolicyInitCommand(),
 		},
 	}
 }

--- a/pkg/cli/policy_init.go
+++ b/pkg/cli/policy_init.go
@@ -4,7 +4,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func (runner *Runner) newPolicyInitCommand() *cli.Command {
+func (r *Runner) newPolicyInitCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "init",
 		Usage:     "Create a policy file if it doesn't exist",
@@ -13,6 +13,6 @@ func (runner *Runner) newPolicyInitCommand() *cli.Command {
 e.g.
 $ aqua policy init # create "aqua-policy.yaml"
 $ aqua policy init foo.yaml # create foo.yaml`,
-		Action: runner.initPolicyAction,
+		Action: r.initPolicyAction,
 	}
 }

--- a/pkg/cli/root_dir.go
+++ b/pkg/cli/root_dir.go
@@ -8,7 +8,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func (runner *Runner) newRootDirCommand() *cli.Command {
+func (r *Runner) newRootDirCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "root-dir",
 		Usage: "Output the aqua root directory (AQUA_ROOT_DIR)",
@@ -20,11 +20,11 @@ $ aqua root-dir
 
 $ export "PATH=$(aqua root-dir)/bin:PATH"
 `,
-		Action: runner.rootDirAction,
+		Action: r.rootDirAction,
 	}
 }
 
-func (runner *Runner) rootDirAction(c *cli.Context) error {
+func (r *Runner) rootDirAction(c *cli.Context) error {
 	tracer, err := startTrace(c.String("trace"))
 	if err != nil {
 		return err
@@ -37,6 +37,6 @@ func (runner *Runner) rootDirAction(c *cli.Context) error {
 	}
 	defer cpuProfiler.Stop()
 
-	fmt.Fprintln(runner.Stdout, config.GetRootDir(osenv.New()))
+	fmt.Fprintln(r.Stdout, config.GetRootDir(osenv.New()))
 	return nil
 }

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -35,7 +35,7 @@ type LDFlags struct {
 	Date    string
 }
 
-func (runner *Runner) setParam(c *cli.Context, commandName string, param *config.Param) error { //nolint:funlen,cyclop
+func (r *Runner) setParam(c *cli.Context, commandName string, param *config.Param) error { //nolint:funlen,cyclop
 	param.Args = c.Args().Slice()
 	if logLevel := c.String("log-level"); logLevel != "" {
 		param.LogLevel = logLevel
@@ -55,12 +55,12 @@ func (runner *Runner) setParam(c *cli.Context, commandName string, param *config
 	param.SelectVersion = c.Bool("select-version")
 	param.File = c.String("f")
 	param.LogColor = os.Getenv("AQUA_LOG_COLOR")
-	param.AQUAVersion = runner.LDFlags.Version
-	param.AquaCommitHash = runner.LDFlags.Commit
+	param.AQUAVersion = r.LDFlags.Version
+	param.AquaCommitHash = r.LDFlags.Commit
 	param.RootDir = config.GetRootDir(osenv.New())
 	homeDir, _ := os.UserHomeDir()
 	param.HomeDir = homeDir
-	logE := runner.LogE
+	logE := r.LogE
 	log.SetLevel(param.LogLevel, logE)
 	log.SetColor(param.LogColor, logE)
 	param.MaxParallelism = config.GetMaxParallelism(os.Getenv("AQUA_MAX_PARALLELISM"), logE)
@@ -121,15 +121,15 @@ func parseTags(tags []string) map[string]struct{} {
 	return tagsM
 }
 
-func (runner *Runner) Run(ctx context.Context, args ...string) error {
-	compiledDate, err := time.Parse(time.RFC3339, runner.LDFlags.Date)
+func (r *Runner) Run(ctx context.Context, args ...string) error {
+	compiledDate, err := time.Parse(time.RFC3339, r.LDFlags.Date)
 	if err != nil {
 		compiledDate = time.Now()
 	}
 	app := cli.App{
 		Name:           "aqua",
 		Usage:          "Version Manager of CLI. https://aquaproj.github.io/",
-		Version:        runner.LDFlags.Version + " (" + runner.LDFlags.Commit + ")",
+		Version:        r.LDFlags.Version + " (" + r.LDFlags.Commit + ")",
 		Compiled:       compiledDate,
 		ExitErrHandler: exitErrHandlerFunc,
 		Flags: []cli.Flag{
@@ -155,22 +155,22 @@ func (runner *Runner) Run(ctx context.Context, args ...string) error {
 		},
 		EnableBashCompletion: true,
 		Commands: []*cli.Command{
-			runner.newInitCommand(),
-			runner.newInfoCommand(),
-			runner.newInitPolicyCommand(),
-			runner.newPolicyCommand(),
-			runner.newInstallCommand(),
-			runner.newUpdateAquaCommand(),
-			runner.newGenerateCommand(),
-			runner.newWhichCommand(),
-			runner.newExecCommand(),
-			runner.newListCommand(),
-			runner.newGenerateRegistryCommand(),
-			runner.newCompletionCommand(),
-			runner.newVersionCommand(),
-			runner.newCpCommand(),
-			runner.newRootDirCommand(),
-			runner.newUpdateChecksumCommand(),
+			r.newInitCommand(),
+			r.newInfoCommand(),
+			r.newInitPolicyCommand(),
+			r.newPolicyCommand(),
+			r.newInstallCommand(),
+			r.newUpdateAquaCommand(),
+			r.newGenerateCommand(),
+			r.newWhichCommand(),
+			r.newExecCommand(),
+			r.newListCommand(),
+			r.newGenerateRegistryCommand(),
+			r.newCompletionCommand(),
+			r.newVersionCommand(),
+			r.newCpCommand(),
+			r.newRootDirCommand(),
+			r.newUpdateChecksumCommand(),
 		},
 	}
 

--- a/pkg/cli/update_aqua.go
+++ b/pkg/cli/update_aqua.go
@@ -9,7 +9,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func (runner *Runner) newUpdateAquaCommand() *cli.Command {
+func (r *Runner) newUpdateAquaCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "update-aqua",
 		Usage: "Update aqua",
@@ -25,11 +25,11 @@ e.g.
 $ aqua update-aqua # Install the latest version
 $ aqua update-aqua v1.20.0 # Install v1.20.0
 `,
-		Action: runner.updaetAquaAction,
+		Action: r.updaetAquaAction,
 	}
 }
 
-func (runner *Runner) updaetAquaAction(c *cli.Context) error {
+func (r *Runner) updaetAquaAction(c *cli.Context) error {
 	tracer, err := startTrace(c.String("trace"))
 	if err != nil {
 		return err
@@ -43,9 +43,9 @@ func (runner *Runner) updaetAquaAction(c *cli.Context) error {
 	defer cpuProfiler.Stop()
 
 	param := &config.Param{}
-	if err := runner.setParam(c, "update-aqua", param); err != nil {
+	if err := r.setParam(c, "update-aqua", param); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
-	ctrl := controller.InitializeUpdateAquaCommandController(c.Context, param, http.DefaultClient, runner.Runtime)
-	return ctrl.UpdateAqua(c.Context, runner.LogE, param) //nolint:wrapcheck
+	ctrl := controller.InitializeUpdateAquaCommandController(c.Context, param, http.DefaultClient, r.Runtime)
+	return ctrl.UpdateAqua(c.Context, r.LogE, param) //nolint:wrapcheck
 }

--- a/pkg/cli/update_checksum.go
+++ b/pkg/cli/update_checksum.go
@@ -9,7 +9,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func (runner *Runner) newUpdateChecksumCommand() *cli.Command {
+func (r *Runner) newUpdateChecksumCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "update-checksum",
 		Usage: "Create or Update aqua-checksums.json",
@@ -44,11 +44,11 @@ If -prune option is set, aqua unused checksums would be removed.
 
 $ aqua update-checksum -prune
 `,
-		Action: runner.updateChecksumAction,
+		Action: r.updateChecksumAction,
 	}
 }
 
-func (runner *Runner) updateChecksumAction(c *cli.Context) error {
+func (r *Runner) updateChecksumAction(c *cli.Context) error {
 	tracer, err := startTrace(c.String("trace"))
 	if err != nil {
 		return err
@@ -62,9 +62,9 @@ func (runner *Runner) updateChecksumAction(c *cli.Context) error {
 	defer cpuProfiler.Stop()
 
 	param := &config.Param{}
-	if err := runner.setParam(c, "update-checksum", param); err != nil {
+	if err := r.setParam(c, "update-checksum", param); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
-	ctrl := controller.InitializeUpdateChecksumCommandController(c.Context, param, http.DefaultClient, runner.Runtime)
-	return ctrl.UpdateChecksum(c.Context, runner.LogE, param) //nolint:wrapcheck
+	ctrl := controller.InitializeUpdateChecksumCommandController(c.Context, param, http.DefaultClient, r.Runtime)
+	return ctrl.UpdateChecksum(c.Context, r.LogE, param) //nolint:wrapcheck
 }

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -4,15 +4,15 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func (runner *Runner) newVersionCommand() *cli.Command {
+func (r *Runner) newVersionCommand() *cli.Command {
 	return &cli.Command{
 		Name:   "version",
 		Usage:  "Show version",
-		Action: runner.versionAction,
+		Action: r.versionAction,
 	}
 }
 
-func (runner *Runner) versionAction(c *cli.Context) error {
+func (r *Runner) versionAction(c *cli.Context) error {
 	cli.ShowVersion(c)
 	return nil
 }

--- a/pkg/cli/which.go
+++ b/pkg/cli/which.go
@@ -10,7 +10,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func (runner *Runner) newWhichCommand() *cli.Command {
+func (r *Runner) newWhichCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "which",
 		Usage:     "Output the absolute file path of the given command",
@@ -30,11 +30,11 @@ If the command isn't found, exits with non zero exit code.
 $ aqua which foo
 FATA[0000] aqua failed                                   aqua_version=0.8.6 error="command is not found" exe_name=foo program=aqua
 `,
-		Action: runner.whichAction,
+		Action: r.whichAction,
 	}
 }
 
-func (runner *Runner) whichAction(c *cli.Context) error {
+func (r *Runner) whichAction(c *cli.Context) error {
 	tracer, err := startTrace(c.String("trace"))
 	if err != nil {
 		return err
@@ -48,15 +48,15 @@ func (runner *Runner) whichAction(c *cli.Context) error {
 	defer cpuProfiler.Stop()
 
 	param := &config.Param{}
-	if err := runner.setParam(c, "which", param); err != nil {
+	if err := r.setParam(c, "which", param); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
-	ctrl := controller.InitializeWhichCommandController(c.Context, param, http.DefaultClient, runner.Runtime)
+	ctrl := controller.InitializeWhichCommandController(c.Context, param, http.DefaultClient, r.Runtime)
 	exeName, _, err := parseExecArgs(c.Args().Slice())
 	if err != nil {
 		return err
 	}
-	which, err := ctrl.Which(c.Context, runner.LogE, param, exeName)
+	which, err := ctrl.Which(c.Context, r.LogE, param, exeName)
 	if err != nil {
 		return err //nolint:wrapcheck
 	}

--- a/pkg/config-finder/config_finder.go
+++ b/pkg/config-finder/config_finder.go
@@ -51,16 +51,16 @@ func configFileNames() []string {
 	}
 }
 
-func (finder *ConfigFinder) Find(wd, configFilePath string, globalConfigFilePaths ...string) (string, error) {
+func (f *ConfigFinder) Find(wd, configFilePath string, globalConfigFilePaths ...string) (string, error) {
 	if configFilePath != "" {
 		return util.Abs(wd, configFilePath), nil
 	}
-	configFilePath = findconfig.Find(wd, finder.exist, configFileNames()...)
+	configFilePath = findconfig.Find(wd, f.exist, configFileNames()...)
 	if configFilePath != "" {
 		return configFilePath, nil
 	}
 	for _, p := range globalConfigFilePaths {
-		if _, err := finder.fs.Stat(p); err != nil {
+		if _, err := f.fs.Stat(p); err != nil {
 			continue
 		}
 		return p, nil
@@ -68,15 +68,15 @@ func (finder *ConfigFinder) Find(wd, configFilePath string, globalConfigFilePath
 	return "", ErrConfigFileNotFound
 }
 
-func (finder *ConfigFinder) Finds(wd, configFilePath string) []string {
+func (f *ConfigFinder) Finds(wd, configFilePath string) []string {
 	if configFilePath == "" {
-		return findconfig.Finds(wd, finder.exist, configFileNames()...)
+		return findconfig.Finds(wd, f.exist, configFileNames()...)
 	}
 	return []string{util.Abs(wd, configFilePath)}
 }
 
-func (finder *ConfigFinder) exist(p string) bool {
-	b, err := afero.Exists(finder.fs, p)
+func (f *ConfigFinder) exist(p string) bool {
+	b, err := afero.Exists(f.fs, p)
 	if err != nil {
 		return false
 	}

--- a/pkg/config-reader/reader.go
+++ b/pkg/config-reader/reader.go
@@ -38,15 +38,15 @@ type MockConfigReader struct {
 	Err error
 }
 
-func (reader *MockConfigReader) Read(configFilePath string, cfg *aqua.Config) error {
-	*cfg = *reader.Cfg
-	return reader.Err
+func (r *MockConfigReader) Read(configFilePath string, cfg *aqua.Config) error {
+	*cfg = *r.Cfg
+	return r.Err
 }
 
 const homePrefix = "$HOME" + string(os.PathSeparator)
 
-func (reader *ConfigReaderImpl) Read(configFilePath string, cfg *aqua.Config) error {
-	file, err := reader.fs.Open(configFilePath)
+func (r *ConfigReaderImpl) Read(configFilePath string, cfg *aqua.Config) error {
+	file, err := r.fs.Open(configFilePath)
 	if err != nil {
 		return err //nolint:wrapcheck
 	}
@@ -58,10 +58,10 @@ func (reader *ConfigReaderImpl) Read(configFilePath string, cfg *aqua.Config) er
 	for _, rgst := range cfg.Registries {
 		if rgst.Type == "local" {
 			if strings.HasPrefix(rgst.Path, homePrefix) {
-				if reader.homeDir == "" {
+				if r.homeDir == "" {
 					return errHomeDirEmpty
 				}
-				rgst.Path = filepath.Join(reader.homeDir, rgst.Path[6:])
+				rgst.Path = filepath.Join(r.homeDir, rgst.Path[6:])
 			}
 			if configFileDir == "" {
 				configFileDir = filepath.Dir(configFilePath)
@@ -69,13 +69,13 @@ func (reader *ConfigReaderImpl) Read(configFilePath string, cfg *aqua.Config) er
 			rgst.Path = util.Abs(configFileDir, rgst.Path)
 		}
 	}
-	if err := reader.readImports(configFilePath, cfg); err != nil {
+	if err := r.readImports(configFilePath, cfg); err != nil {
 		return fmt.Errorf("read imports (%s): %w", configFilePath, err)
 	}
 	return nil
 }
 
-func (reader *ConfigReaderImpl) readImports(configFilePath string, cfg *aqua.Config) error {
+func (r *ConfigReaderImpl) readImports(configFilePath string, cfg *aqua.Config) error {
 	pkgs := []*aqua.Package{}
 	for _, pkg := range cfg.Packages {
 		if pkg == nil {
@@ -86,14 +86,14 @@ func (reader *ConfigReaderImpl) readImports(configFilePath string, cfg *aqua.Con
 			continue
 		}
 		p := filepath.Join(filepath.Dir(configFilePath), pkg.Import)
-		filePaths, err := afero.Glob(reader.fs, p)
+		filePaths, err := afero.Glob(r.fs, p)
 		if err != nil {
 			return fmt.Errorf("read files with glob pattern (%s): %w", p, err)
 		}
 		sort.Strings(filePaths)
 		for _, filePath := range filePaths {
 			subCfg := &aqua.Config{}
-			if err := reader.Read(filePath, subCfg); err != nil {
+			if err := r.Read(filePath, subCfg); err != nil {
 				return err
 			}
 			pkgs = append(pkgs, subCfg.Packages...)

--- a/pkg/config/aqua/checksum.go
+++ b/pkg/config/aqua/checksum.go
@@ -2,18 +2,18 @@ package aqua
 
 import "github.com/aquaproj/aqua/v2/pkg/config/registry"
 
-func (cfg *Config) ChecksumEnabled() bool {
-	if cfg == nil {
+func (c *Config) ChecksumEnabled() bool {
+	if c == nil {
 		return false
 	}
-	return cfg.Checksum.GetEnabled()
+	return c.Checksum.GetEnabled()
 }
 
-func (cfg *Config) RequireChecksum(defValue bool) bool {
-	if cfg == nil || cfg.Checksum == nil || cfg.Checksum.RequireChecksum == nil {
+func (c *Config) RequireChecksum(defValue bool) bool {
+	if c == nil || c.Checksum == nil || c.Checksum.RequireChecksum == nil {
 		return defValue
 	}
-	return *cfg.Checksum.RequireChecksum
+	return *c.Checksum.RequireChecksum
 }
 
 type Checksum struct {

--- a/pkg/config/aqua/checksum_enabled.go
+++ b/pkg/config/aqua/checksum_enabled.go
@@ -1,8 +1,8 @@
 package aqua
 
-func (chk *Checksum) GetEnabled() bool {
-	if chk == nil || chk.Enabled == nil {
+func (c *Checksum) GetEnabled() bool {
+	if c == nil || c.Enabled == nil {
 		return false
 	}
-	return *chk.Enabled
+	return *c.Enabled
 }

--- a/pkg/config/aqua/config.go
+++ b/pkg/config/aqua/config.go
@@ -16,9 +16,9 @@ type Package struct {
 	Link        string   `yaml:",omitempty" json:"link,omitempty"`
 }
 
-func (pkg *Package) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (p *Package) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type alias Package
-	a := alias(*pkg)
+	a := alias(*p)
 	if err := unmarshal(&a); err != nil {
 		return err
 	}
@@ -29,9 +29,9 @@ func (pkg *Package) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if version != "" {
 		a.Version = version
 	}
-	*pkg = Package(a)
-	if pkg.Registry == "" {
-		pkg.Registry = RegistryTypeStandard
+	*p = Package(a)
+	if p.Registry == "" {
+		p.Registry = RegistryTypeStandard
 	}
 
 	return nil
@@ -67,7 +67,7 @@ const (
 	PkgInfoTypeCargo         = "cargo"
 )
 
-func (registries *Registries) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (r *Registries) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	arr := []*Registry{}
 	if err := unmarshal(&arr); err != nil {
 		return err
@@ -79,6 +79,6 @@ func (registries *Registries) UnmarshalYAML(unmarshal func(interface{}) error) e
 		}
 		m[registry.Name] = registry
 	}
-	*registries = m
+	*r = m
 	return nil
 }

--- a/pkg/config/aqua/registry.go
+++ b/pkg/config/aqua/registry.go
@@ -24,42 +24,42 @@ const (
 	RegistryTypeStandard      = "standard"
 )
 
-func (registry *Registry) Validate() error {
-	switch registry.Type {
+func (r *Registry) Validate() error {
+	switch r.Type {
 	case RegistryTypeLocal:
-		return registry.validateLocal()
+		return r.validateLocal()
 	case RegistryTypeGitHubContent:
-		return registry.validateGitHubContent()
+		return r.validateGitHubContent()
 	default:
 		return logerr.WithFields(errInvalidRegistryType, logrus.Fields{ //nolint:wrapcheck
-			"registry_type": registry.Type,
+			"registry_type": r.Type,
 		})
 	}
 }
 
-func (registry *Registry) validateLocal() error {
-	if registry.Path == "" {
+func (r *Registry) validateLocal() error {
+	if r.Path == "" {
 		return errPathIsRequired
 	}
 	return nil
 }
 
-func (registry *Registry) validateGitHubContent() error {
-	if registry.RepoOwner == "" {
+func (r *Registry) validateGitHubContent() error {
+	if r.RepoOwner == "" {
 		return errRepoOwnerIsRequired
 	}
-	if registry.RepoName == "" {
+	if r.RepoName == "" {
 		return errRepoNameIsRequired
 	}
-	if registry.Ref == "" {
+	if r.Ref == "" {
 		return errRefIsRequired
 	}
 	return nil
 }
 
-func (registry *Registry) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (r *Registry) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type alias Registry
-	a := alias(*registry)
+	a := alias(*r)
 	if err := unmarshal(&a); err != nil {
 		return err
 	}
@@ -78,16 +78,16 @@ func (registry *Registry) UnmarshalYAML(unmarshal func(interface{}) error) error
 			a.Path = "registry.yaml"
 		}
 	}
-	*registry = Registry(a)
+	*r = Registry(a)
 	return nil
 }
 
-func (registry *Registry) GetFilePath(rootDir, cfgFilePath string) (string, error) {
-	switch registry.Type {
+func (r *Registry) GetFilePath(rootDir, cfgFilePath string) (string, error) {
+	switch r.Type {
 	case RegistryTypeLocal:
-		return util.Abs(filepath.Dir(cfgFilePath), registry.Path), nil
+		return util.Abs(filepath.Dir(cfgFilePath), r.Path), nil
 	case RegistryTypeGitHubContent:
-		return filepath.Join(rootDir, "registries", registry.Type, "github.com", registry.RepoOwner, registry.RepoName, registry.Ref, registry.Path), nil
+		return filepath.Join(rootDir, "registries", r.Type, "github.com", r.RepoOwner, r.RepoName, r.Ref, r.Path), nil
 	}
 	return "", errInvalidRegistryType
 }

--- a/pkg/config/checksum.go
+++ b/pkg/config/checksum.go
@@ -12,20 +12,20 @@ import (
 
 var errUnknownChecksumFileType = errors.New("unknown checksum type")
 
-func (cpkg *Package) GetChecksumID(rt *runtime.Runtime) (string, error) {
-	assetName, err := cpkg.RenderAsset(rt)
+func (p *Package) GetChecksumID(rt *runtime.Runtime) (string, error) {
+	assetName, err := p.RenderAsset(rt)
 	if err != nil {
 		return "", fmt.Errorf("render the asset name: %w", err)
 	}
-	pkgInfo := cpkg.PackageInfo
-	pkg := cpkg.Package
+	pkgInfo := p.PackageInfo
+	pkg := p.Package
 	switch pkgInfo.Type {
 	case PkgInfoTypeGitHubArchive:
 		return path.Join(pkgInfo.GetType(), "github.com", pkgInfo.RepoOwner, pkgInfo.RepoName, pkg.Version), nil
 	case PkgInfoTypeGitHubContent, PkgInfoTypeGitHubRelease:
 		return path.Join(pkgInfo.GetType(), "github.com", pkgInfo.RepoOwner, pkgInfo.RepoName, pkg.Version, assetName), nil
 	case PkgInfoTypeHTTP:
-		uS, err := cpkg.RenderURL(rt)
+		uS, err := p.RenderURL(rt)
 		if err != nil {
 			return "", fmt.Errorf("render URL: %w", err)
 		}
@@ -38,13 +38,13 @@ func (cpkg *Package) GetChecksumID(rt *runtime.Runtime) (string, error) {
 	return "", nil
 }
 
-func (cpkg *Package) getRuntimeFromAsset(asset string) (*runtime.Runtime, error) {
-	rts, err := runtime.GetRuntimesFromEnvs(cpkg.PackageInfo.SupportedEnvs)
+func (p *Package) getRuntimeFromAsset(asset string) (*runtime.Runtime, error) {
+	rts, err := runtime.GetRuntimesFromEnvs(p.PackageInfo.SupportedEnvs)
 	if err != nil {
 		return nil, fmt.Errorf("get supported runtimes from supported_envs: %w", err)
 	}
 	for _, rt := range rts {
-		a, err := cpkg.RenderAsset(rt)
+		a, err := p.RenderAsset(rt)
 		if err != nil {
 			return nil, err
 		}
@@ -55,47 +55,47 @@ func (cpkg *Package) getRuntimeFromAsset(asset string) (*runtime.Runtime, error)
 	return nil, nil //nolint:nilnil
 }
 
-func (cpkg *Package) GetChecksumIDFromAsset(asset string) (string, error) {
-	pkgInfo := cpkg.PackageInfo
-	pkg := cpkg.Package
+func (p *Package) GetChecksumIDFromAsset(asset string) (string, error) {
+	pkgInfo := p.PackageInfo
+	pkg := p.Package
 	switch pkgInfo.Type {
 	case PkgInfoTypeGitHubArchive:
 		return path.Join(pkgInfo.GetType(), "github.com", pkgInfo.RepoOwner, pkgInfo.RepoName, pkg.Version), nil
 	case PkgInfoTypeGitHubContent, PkgInfoTypeGitHubRelease:
 		return path.Join(pkgInfo.GetType(), "github.com", pkgInfo.RepoOwner, pkgInfo.RepoName, pkg.Version, asset), nil
 	case PkgInfoTypeHTTP:
-		rt, err := cpkg.getRuntimeFromAsset(asset)
+		rt, err := p.getRuntimeFromAsset(asset)
 		if err != nil {
 			return "", fmt.Errorf("get a runtime from an asset: %w", err)
 		}
 		if rt == nil {
 			return "", nil
 		}
-		return cpkg.GetChecksumID(rt)
+		return p.GetChecksumID(rt)
 	}
 	return "", nil
 }
 
-func (cpkg *Package) RenderChecksumFileName(rt *runtime.Runtime) (string, error) {
-	pkgInfo := cpkg.PackageInfo
+func (p *Package) RenderChecksumFileName(rt *runtime.Runtime) (string, error) {
+	pkgInfo := p.PackageInfo
 	switch pkgInfo.Checksum.Type { //nolint:gocritic
 	case PkgInfoTypeGitHubRelease:
-		asset, err := cpkg.RenderAsset(rt)
+		asset, err := p.RenderAsset(rt)
 		if err != nil {
 			return "", err
 		}
-		return cpkg.renderChecksumFile(asset, rt)
+		return p.renderChecksumFile(asset, rt)
 	}
 	return "", errUnknownChecksumFileType
 }
 
-func (cpkg *Package) RenderChecksumURL(rt *runtime.Runtime) (string, error) {
-	pkgInfo := cpkg.PackageInfo
-	pkg := cpkg.Package
+func (p *Package) RenderChecksumURL(rt *runtime.Runtime) (string, error) {
+	pkgInfo := p.PackageInfo
+	pkg := p.Package
 	replacements := pkgInfo.GetChecksumReplacements()
 	m := map[string]interface{}{
 		"Version": pkg.Version,
-		"SemVer":  cpkg.semVer(),
+		"SemVer":  p.semVer(),
 		"GOOS":    rt.GOOS,
 		"GOARCH":  rt.GOARCH,
 		"OS":      replace(rt.GOOS, replacements),
@@ -103,23 +103,23 @@ func (cpkg *Package) RenderChecksumURL(rt *runtime.Runtime) (string, error) {
 		"Format":  pkgInfo.GetFormat(),
 	}
 	if pkgInfo.Type == "http" {
-		u, err := cpkg.RenderURL(rt)
+		u, err := p.RenderURL(rt)
 		if err != nil {
 			return "", err
 		}
 		m["AssetURL"] = u
 	}
 
-	return template.Execute(cpkg.PackageInfo.Checksum.URL, m) //nolint:wrapcheck
+	return template.Execute(p.PackageInfo.Checksum.URL, m) //nolint:wrapcheck
 }
 
-func (cpkg *Package) RenderChecksumFileID(rt *runtime.Runtime) (string, error) {
-	pkgInfo := cpkg.PackageInfo
+func (p *Package) RenderChecksumFileID(rt *runtime.Runtime) (string, error) {
+	pkgInfo := p.PackageInfo
 	switch pkgInfo.Checksum.Type {
 	case PkgInfoTypeGitHubRelease:
-		return cpkg.RenderChecksumFileName(rt)
+		return p.RenderChecksumFileName(rt)
 	case PkgInfoTypeHTTP:
-		return cpkg.RenderChecksumURL(rt)
+		return p.RenderChecksumURL(rt)
 	}
 	return "", errUnknownChecksumFileType
 }

--- a/pkg/config/cosign.go
+++ b/pkg/config/cosign.go
@@ -5,14 +5,14 @@ import (
 	"github.com/aquaproj/aqua/v2/pkg/runtime"
 )
 
-func (cpkg *Package) RenderCosign(cos *registry.Cosign, rt *runtime.Runtime) (*registry.Cosign, error) {
-	if cpkg == nil || cpkg.PackageInfo == nil || !cos.GetEnabled() {
+func (p *Package) RenderCosign(cos *registry.Cosign, rt *runtime.Runtime) (*registry.Cosign, error) {
+	if p == nil || p.PackageInfo == nil || !cos.GetEnabled() {
 		return nil, nil //nolint:nilnil
 	}
 
 	opts := make([]string, len(cos.Opts))
 	for i, opt := range cos.Opts {
-		s, err := cpkg.RenderTemplateString(opt, rt)
+		s, err := p.RenderTemplateString(opt, rt)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/config/registry/checksum.go
+++ b/pkg/config/registry/checksum.go
@@ -17,33 +17,33 @@ type ChecksumPattern struct {
 	File     string `json:"file,omitempty"`
 }
 
-func (chk *Checksum) GetReplacements() Replacements {
-	if chk == nil {
+func (c *Checksum) GetReplacements() Replacements {
+	if c == nil {
 		return nil
 	}
-	return chk.Replacements
+	return c.Replacements
 }
 
-func (chk *Checksum) GetEnabled() bool {
-	if chk == nil {
+func (c *Checksum) GetEnabled() bool {
+	if c == nil {
 		return false
 	}
-	if chk.Enabled == nil {
+	if c.Enabled == nil {
 		return true
 	}
-	return *chk.Enabled
+	return *c.Enabled
 }
 
-func (chk *Checksum) GetAlgorithm() string {
-	if !chk.GetEnabled() {
+func (c *Checksum) GetAlgorithm() string {
+	if !c.GetEnabled() {
 		return "sha512"
 	}
-	return chk.Algorithm
+	return c.Algorithm
 }
 
-func (chk *Checksum) GetCosign() *Cosign {
-	if chk == nil {
+func (c *Checksum) GetCosign() *Cosign {
+	if c == nil {
 		return nil
 	}
-	return chk.Cosign
+	return c.Cosign
 }

--- a/pkg/config/registry/config.go
+++ b/pkg/config/registry/config.go
@@ -17,14 +17,14 @@ type File struct {
 	Dir  string `json:"dir,omitempty" yaml:",omitempty"`
 }
 
-func (pkgInfos *PackageInfos) ToMap(logE *logrus.Entry) map[string]*PackageInfo {
-	return pkgInfos.toMap(logE, logrus.DebugLevel)
+func (p *PackageInfos) ToMap(logE *logrus.Entry) map[string]*PackageInfo {
+	return p.toMap(logE, logrus.DebugLevel)
 }
 
-func (pkgInfos *PackageInfos) toMap(logE *logrus.Entry, logLevel logrus.Level) map[string]*PackageInfo {
-	m := make(map[string]*PackageInfo, len(*pkgInfos))
+func (p *PackageInfos) toMap(logE *logrus.Entry, logLevel logrus.Level) map[string]*PackageInfo {
+	m := make(map[string]*PackageInfo, len(*p))
 	logE = logE.WithField("package_name", "")
-	for _, pkgInfo := range *pkgInfos {
+	for _, pkgInfo := range *p {
 		logE := logE
 		pkgInfo := pkgInfo
 		if pkgInfo == nil {

--- a/pkg/config/registry/cosign.go
+++ b/pkg/config/registry/cosign.go
@@ -24,19 +24,19 @@ type DownloadedFile struct {
 	URL       *string `json:"url,omitempty" yaml:",omitempty"`
 }
 
-func (cos *Cosign) GetEnabled() bool {
-	if cos == nil {
+func (c *Cosign) GetEnabled() bool {
+	if c == nil {
 		return false
 	}
-	if cos.Enabled != nil {
-		return *cos.Enabled
+	if c.Enabled != nil {
+		return *c.Enabled
 	}
-	return len(cos.Opts) != 0 || cos.Signature != nil || cos.Certificate != nil || cos.Key != nil || cos.CosignExperimental
+	return len(c.Opts) != 0 || c.Signature != nil || c.Certificate != nil || c.Key != nil || c.CosignExperimental
 }
 
-func (cos *Cosign) RenderOpts(rt *runtime.Runtime, art *template.Artifact) ([]string, error) {
-	opts := make([]string, len(cos.Opts))
-	for i, opt := range cos.Opts {
+func (c *Cosign) RenderOpts(rt *runtime.Runtime, art *template.Artifact) ([]string, error) {
+	opts := make([]string, len(c.Opts))
+	for i, opt := range c.Opts {
 		s, err := template.Render(opt, art, rt)
 		if err != nil {
 			return nil, fmt.Errorf("render a cosign option: %w", err)

--- a/pkg/config/registry/override.go
+++ b/pkg/config/registry/override.go
@@ -5,8 +5,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func (pkgInfo *PackageInfo) Override(logE *logrus.Entry, v string, rt *runtime.Runtime) (*PackageInfo, error) {
-	pkg, err := pkgInfo.SetVersion(logE, v)
+func (p *PackageInfo) Override(logE *logrus.Entry, v string, rt *runtime.Runtime) (*PackageInfo, error) {
+	pkg, err := p.SetVersion(logE, v)
 	if err != nil {
 		return nil, err
 	}
@@ -14,8 +14,8 @@ func (pkgInfo *PackageInfo) Override(logE *logrus.Entry, v string, rt *runtime.R
 	return pkg, nil
 }
 
-func (pkgInfo *PackageInfo) getOverride(rt *runtime.Runtime) *Override {
-	for _, ov := range pkgInfo.Overrides {
+func (p *PackageInfo) getOverride(rt *runtime.Runtime) *Override {
+	for _, ov := range p.Overrides {
 		if ov.Match(rt) {
 			return ov
 		}

--- a/pkg/config/registry/package_info.go
+++ b/pkg/config/registry/package_info.go
@@ -103,103 +103,103 @@ type Override struct {
 	SLSAProvenance     *SLSAProvenance `json:"slsa_provenance,omitempty" yaml:"slsa_provenance,omitempty"`
 }
 
-func (pkgInfo *PackageInfo) Copy() *PackageInfo {
+func (p *PackageInfo) Copy() *PackageInfo {
 	pkg := &PackageInfo{
-		Name:               pkgInfo.Name,
-		Type:               pkgInfo.Type,
-		RepoOwner:          pkgInfo.RepoOwner,
-		RepoName:           pkgInfo.RepoName,
-		Asset:              pkgInfo.Asset,
-		Crate:              pkgInfo.Crate,
-		Cargo:              pkgInfo.Cargo,
-		Path:               pkgInfo.Path,
-		Format:             pkgInfo.Format,
-		Files:              pkgInfo.Files,
-		URL:                pkgInfo.URL,
-		Description:        pkgInfo.Description,
-		Link:               pkgInfo.Link,
-		Replacements:       pkgInfo.Replacements,
-		Overrides:          pkgInfo.Overrides,
-		FormatOverrides:    pkgInfo.FormatOverrides,
-		VersionConstraints: pkgInfo.VersionConstraints,
-		VersionOverrides:   pkgInfo.VersionOverrides,
-		SupportedEnvs:      pkgInfo.SupportedEnvs,
-		VersionFilter:      pkgInfo.VersionFilter,
-		VersionPrefix:      pkgInfo.VersionPrefix,
-		Rosetta2:           pkgInfo.Rosetta2,
-		Aliases:            pkgInfo.Aliases,
-		VersionSource:      pkgInfo.VersionSource,
-		CompleteWindowsExt: pkgInfo.CompleteWindowsExt,
-		WindowsExt:         pkgInfo.WindowsExt,
-		Checksum:           pkgInfo.Checksum,
-		Cosign:             pkgInfo.Cosign,
-		SLSAProvenance:     pkgInfo.SLSAProvenance,
-		Private:            pkgInfo.Private,
-		ErrorMessage:       pkgInfo.ErrorMessage,
-		NoAsset:            pkgInfo.NoAsset,
+		Name:               p.Name,
+		Type:               p.Type,
+		RepoOwner:          p.RepoOwner,
+		RepoName:           p.RepoName,
+		Asset:              p.Asset,
+		Crate:              p.Crate,
+		Cargo:              p.Cargo,
+		Path:               p.Path,
+		Format:             p.Format,
+		Files:              p.Files,
+		URL:                p.URL,
+		Description:        p.Description,
+		Link:               p.Link,
+		Replacements:       p.Replacements,
+		Overrides:          p.Overrides,
+		FormatOverrides:    p.FormatOverrides,
+		VersionConstraints: p.VersionConstraints,
+		VersionOverrides:   p.VersionOverrides,
+		SupportedEnvs:      p.SupportedEnvs,
+		VersionFilter:      p.VersionFilter,
+		VersionPrefix:      p.VersionPrefix,
+		Rosetta2:           p.Rosetta2,
+		Aliases:            p.Aliases,
+		VersionSource:      p.VersionSource,
+		CompleteWindowsExt: p.CompleteWindowsExt,
+		WindowsExt:         p.WindowsExt,
+		Checksum:           p.Checksum,
+		Cosign:             p.Cosign,
+		SLSAProvenance:     p.SLSAProvenance,
+		Private:            p.Private,
+		ErrorMessage:       p.ErrorMessage,
+		NoAsset:            p.NoAsset,
 	}
 	return pkg
 }
 
-func (pkgInfo *PackageInfo) resetByPkgType(typ string) { //nolint:funlen
+func (p *PackageInfo) resetByPkgType(typ string) { //nolint:funlen
 	switch typ {
 	case PkgInfoTypeGitHubRelease:
-		pkgInfo.URL = nil
-		pkgInfo.Path = nil
-		pkgInfo.Crate = nil
-		pkgInfo.Cargo = nil
+		p.URL = nil
+		p.Path = nil
+		p.Crate = nil
+		p.Cargo = nil
 	case PkgInfoTypeGitHubContent:
-		pkgInfo.URL = nil
-		pkgInfo.Asset = nil
-		pkgInfo.Crate = nil
-		pkgInfo.Cargo = nil
+		p.URL = nil
+		p.Asset = nil
+		p.Crate = nil
+		p.Cargo = nil
 	case PkgInfoTypeGitHubArchive:
-		pkgInfo.URL = nil
-		pkgInfo.Path = nil
-		pkgInfo.Asset = nil
-		pkgInfo.Crate = nil
-		pkgInfo.Cargo = nil
-		pkgInfo.Format = ""
+		p.URL = nil
+		p.Path = nil
+		p.Asset = nil
+		p.Crate = nil
+		p.Cargo = nil
+		p.Format = ""
 	case PkgInfoTypeHTTP:
-		pkgInfo.Path = nil
-		pkgInfo.Asset = nil
+		p.Path = nil
+		p.Asset = nil
 	case PkgInfoTypeGoInstall:
-		pkgInfo.URL = nil
-		pkgInfo.Asset = nil
-		pkgInfo.Crate = nil
-		pkgInfo.Cargo = nil
-		pkgInfo.WindowsExt = ""
-		pkgInfo.CompleteWindowsExt = nil
-		pkgInfo.Cosign = nil
-		pkgInfo.SLSAProvenance = nil
-		pkgInfo.Format = ""
-		pkgInfo.Rosetta2 = nil
+		p.URL = nil
+		p.Asset = nil
+		p.Crate = nil
+		p.Cargo = nil
+		p.WindowsExt = ""
+		p.CompleteWindowsExt = nil
+		p.Cosign = nil
+		p.SLSAProvenance = nil
+		p.Format = ""
+		p.Rosetta2 = nil
 	case PkgInfoTypeGoBuild:
-		pkgInfo.URL = nil
-		pkgInfo.Asset = nil
-		pkgInfo.Crate = nil
-		pkgInfo.Cargo = nil
-		pkgInfo.WindowsExt = ""
-		pkgInfo.CompleteWindowsExt = nil
-		pkgInfo.Cosign = nil
-		pkgInfo.SLSAProvenance = nil
-		pkgInfo.Format = ""
-		pkgInfo.Rosetta2 = nil
+		p.URL = nil
+		p.Asset = nil
+		p.Crate = nil
+		p.Cargo = nil
+		p.WindowsExt = ""
+		p.CompleteWindowsExt = nil
+		p.Cosign = nil
+		p.SLSAProvenance = nil
+		p.Format = ""
+		p.Rosetta2 = nil
 	case PkgInfoTypeCargo:
-		pkgInfo.URL = nil
-		pkgInfo.Asset = nil
-		pkgInfo.Path = nil
-		pkgInfo.WindowsExt = ""
-		pkgInfo.CompleteWindowsExt = nil
-		pkgInfo.Cosign = nil
-		pkgInfo.SLSAProvenance = nil
-		pkgInfo.Format = ""
-		pkgInfo.Rosetta2 = nil
+		p.URL = nil
+		p.Asset = nil
+		p.Path = nil
+		p.WindowsExt = ""
+		p.CompleteWindowsExt = nil
+		p.Cosign = nil
+		p.SLSAProvenance = nil
+		p.Format = ""
+		p.Rosetta2 = nil
 	}
 }
 
-func (pkgInfo *PackageInfo) overrideVersion(child *VersionOverride) *PackageInfo { //nolint:cyclop,funlen
-	pkg := pkgInfo.Copy()
+func (p *PackageInfo) overrideVersion(child *VersionOverride) *PackageInfo { //nolint:cyclop,funlen
+	pkg := p.Copy()
 	if child.Type != "" {
 		pkg.resetByPkgType(child.Type)
 		pkg.Type = child.Type
@@ -279,76 +279,76 @@ func (pkgInfo *PackageInfo) overrideVersion(child *VersionOverride) *PackageInfo
 	return pkg
 }
 
-func (pkgInfo *PackageInfo) OverrideByRuntime(rt *runtime.Runtime) { //nolint:cyclop,funlen
-	for _, fo := range pkgInfo.FormatOverrides {
+func (p *PackageInfo) OverrideByRuntime(rt *runtime.Runtime) { //nolint:cyclop,funlen
+	for _, fo := range p.FormatOverrides {
 		if fo.GOOS == rt.GOOS {
-			pkgInfo.Format = fo.Format
+			p.Format = fo.Format
 			break
 		}
 	}
 
-	ov := pkgInfo.getOverride(rt)
+	ov := p.getOverride(rt)
 	if ov == nil {
 		return
 	}
 
 	if ov.Type != "" {
-		pkgInfo.resetByPkgType(ov.Type)
-		pkgInfo.Type = ov.Type
+		p.resetByPkgType(ov.Type)
+		p.Type = ov.Type
 	}
 
-	if pkgInfo.Replacements == nil {
-		pkgInfo.Replacements = ov.Replacements
+	if p.Replacements == nil {
+		p.Replacements = ov.Replacements
 	} else {
-		replacements := make(Replacements, len(pkgInfo.Replacements))
-		for k, v := range pkgInfo.Replacements {
+		replacements := make(Replacements, len(p.Replacements))
+		for k, v := range p.Replacements {
 			replacements[k] = v
 		}
 		for k, v := range ov.Replacements {
 			replacements[k] = v
 		}
-		pkgInfo.Replacements = replacements
+		p.Replacements = replacements
 	}
 
 	if ov.Format != "" {
-		pkgInfo.Format = ov.Format
+		p.Format = ov.Format
 	}
 
 	if ov.Asset != nil {
-		pkgInfo.Asset = ov.Asset
+		p.Asset = ov.Asset
 	}
 
 	if ov.Crate != nil {
-		pkgInfo.Crate = ov.Crate
+		p.Crate = ov.Crate
 	}
 
 	if ov.Cargo != nil {
-		pkgInfo.Cargo = ov.Cargo
+		p.Cargo = ov.Cargo
 	}
 
 	if ov.Files != nil {
-		pkgInfo.Files = ov.Files
+		p.Files = ov.Files
 	}
 
 	if ov.URL != nil {
-		pkgInfo.URL = ov.URL
+		p.URL = ov.URL
 	}
 
 	if ov.Checksum != nil {
-		pkgInfo.Checksum = ov.Checksum
+		p.Checksum = ov.Checksum
 	}
 
 	if ov.CompleteWindowsExt != nil {
-		pkgInfo.CompleteWindowsExt = ov.CompleteWindowsExt
+		p.CompleteWindowsExt = ov.CompleteWindowsExt
 	}
 	if ov.WindowsExt != "" {
-		pkgInfo.WindowsExt = ov.WindowsExt
+		p.WindowsExt = ov.WindowsExt
 	}
 	if ov.Cosign != nil {
-		pkgInfo.Cosign = ov.Cosign
+		p.Cosign = ov.Cosign
 	}
 	if ov.SLSAProvenance != nil {
-		pkgInfo.SLSAProvenance = ov.SLSAProvenance
+		p.SLSAProvenance = ov.SLSAProvenance
 	}
 }
 
@@ -415,80 +415,80 @@ func (SupportedEnvs) JSONSchema() *jsonschema.Schema {
 	}
 }
 
-func (pkgInfo *PackageInfo) GetRosetta2() bool {
-	return pkgInfo.Rosetta2 != nil && *pkgInfo.Rosetta2
+func (p *PackageInfo) GetRosetta2() bool {
+	return p.Rosetta2 != nil && *p.Rosetta2
 }
 
-func (pkgInfo *PackageInfo) HasRepo() bool {
-	return pkgInfo.RepoOwner != "" && pkgInfo.RepoName != ""
+func (p *PackageInfo) HasRepo() bool {
+	return p.RepoOwner != "" && p.RepoName != ""
 }
 
-func (pkgInfo *PackageInfo) GetName() string {
-	if pkgInfo.Name != "" {
-		return pkgInfo.Name
+func (p *PackageInfo) GetName() string {
+	if p.Name != "" {
+		return p.Name
 	}
-	if pkgInfo.HasRepo() {
-		return pkgInfo.RepoOwner + "/" + pkgInfo.RepoName
+	if p.HasRepo() {
+		return p.RepoOwner + "/" + p.RepoName
 	}
-	if pkgInfo.Type == PkgInfoTypeGoInstall && pkgInfo.Path != nil {
-		return *pkgInfo.Path
+	if p.Type == PkgInfoTypeGoInstall && p.Path != nil {
+		return *p.Path
 	}
 	return ""
 }
 
-func (pkgInfo *PackageInfo) GetPath() string {
-	if pkgInfo.Path != nil {
-		return *pkgInfo.Path
+func (p *PackageInfo) GetPath() string {
+	if p.Path != nil {
+		return *p.Path
 	}
-	if pkgInfo.Type == PkgInfoTypeGoInstall && pkgInfo.HasRepo() {
-		return "github.com/" + pkgInfo.RepoOwner + "/" + pkgInfo.RepoName
-	}
-	return ""
-}
-
-func (pkgInfo *PackageInfo) GetLink() string {
-	if pkgInfo.Link != "" {
-		return pkgInfo.Link
-	}
-	if pkgInfo.HasRepo() {
-		return "https://github.com/" + pkgInfo.RepoOwner + "/" + pkgInfo.RepoName
+	if p.Type == PkgInfoTypeGoInstall && p.HasRepo() {
+		return "github.com/" + p.RepoOwner + "/" + p.RepoName
 	}
 	return ""
 }
 
-func (pkgInfo *PackageInfo) GetFormat() string {
-	if pkgInfo.Type == PkgInfoTypeGitHubArchive || pkgInfo.Type == PkgInfoTypeGoBuild {
+func (p *PackageInfo) GetLink() string {
+	if p.Link != "" {
+		return p.Link
+	}
+	if p.HasRepo() {
+		return "https://github.com/" + p.RepoOwner + "/" + p.RepoName
+	}
+	return ""
+}
+
+func (p *PackageInfo) GetFormat() string {
+	if p.Type == PkgInfoTypeGitHubArchive || p.Type == PkgInfoTypeGoBuild {
 		return "tar.gz"
 	}
-	return pkgInfo.Format
+	return p.Format
 }
 
-func (pkgInfo *PackageInfo) GetDescription() string {
-	return pkgInfo.Description
+func (p *PackageInfo) GetDescription() string {
+	return p.Description
 }
 
-func (pkgInfo *PackageInfo) IsNoAsset() bool {
-	return pkgInfo.NoAsset != nil && *pkgInfo.NoAsset
+func (p *PackageInfo) IsNoAsset() bool {
+	return p.NoAsset != nil && *p.NoAsset
 }
 
-func (pkgInfo *PackageInfo) GetType() string {
-	return pkgInfo.Type
+func (p *PackageInfo) GetType() string {
+	return p.Type
 }
 
-func (pkgInfo *PackageInfo) GetReplacements() Replacements {
-	return pkgInfo.Replacements
+func (p *PackageInfo) GetReplacements() Replacements {
+	return p.Replacements
 }
 
-func (pkgInfo *PackageInfo) GetChecksumReplacements() Replacements {
-	cr := pkgInfo.Checksum.GetReplacements()
+func (p *PackageInfo) GetChecksumReplacements() Replacements {
+	cr := p.Checksum.GetReplacements()
 	if cr == nil {
-		return pkgInfo.Replacements
+		return p.Replacements
 	}
 	if len(cr) == 0 {
 		return cr
 	}
 	m := Replacements{}
-	for k, v := range pkgInfo.Replacements {
+	for k, v := range p.Replacements {
 		m[k] = v
 	}
 	for k, v := range cr {
@@ -497,48 +497,48 @@ func (pkgInfo *PackageInfo) GetChecksumReplacements() Replacements {
 	return m
 }
 
-func (pkgInfo *PackageInfo) GetAsset() *string {
-	return pkgInfo.Asset
+func (p *PackageInfo) GetAsset() *string {
+	return p.Asset
 }
 
-func (pkgInfo *PackageInfo) Validate() error { //nolint:cyclop
-	if pkgInfo.GetName() == "" {
+func (p *PackageInfo) Validate() error { //nolint:cyclop
+	if p.GetName() == "" {
 		return errPkgNameIsRequired
 	}
-	switch pkgInfo.Type {
+	switch p.Type {
 	case PkgInfoTypeGitHubArchive, PkgInfoTypeGoBuild:
-		if !pkgInfo.HasRepo() {
+		if !p.HasRepo() {
 			return errRepoRequired
 		}
 		return nil
 	case PkgInfoTypeGoInstall:
-		if pkgInfo.GetPath() == "" {
+		if p.GetPath() == "" {
 			return errGoInstallRequirePath
 		}
 		return nil
 	case PkgInfoTypeCargo:
-		if pkgInfo.Crate == nil {
+		if p.Crate == nil {
 			return errCargoRequireCrate
 		}
 		return nil
 	case PkgInfoTypeGitHubContent:
-		if !pkgInfo.HasRepo() {
+		if !p.HasRepo() {
 			return errRepoRequired
 		}
-		if pkgInfo.Path == nil {
+		if p.Path == nil {
 			return errGitHubContentRequirePath
 		}
 		return nil
 	case PkgInfoTypeGitHubRelease:
-		if !pkgInfo.HasRepo() {
+		if !p.HasRepo() {
 			return errRepoRequired
 		}
-		if pkgInfo.Asset == nil {
+		if p.Asset == nil {
 			return errAssetRequired
 		}
 		return nil
 	case PkgInfoTypeHTTP:
-		if pkgInfo.URL == nil {
+		if p.URL == nil {
 			return errURLRequired
 		}
 		return nil
@@ -546,42 +546,42 @@ func (pkgInfo *PackageInfo) Validate() error { //nolint:cyclop
 	return errInvalidPackageType
 }
 
-func (pkgInfo *PackageInfo) GetFiles() []*File {
-	if len(pkgInfo.Files) != 0 {
-		return pkgInfo.Files
+func (p *PackageInfo) GetFiles() []*File {
+	if len(p.Files) != 0 {
+		return p.Files
 	}
 
-	if cmdName := pkgInfo.getDefaultCmdName(); cmdName != "" {
+	if cmdName := p.getDefaultCmdName(); cmdName != "" {
 		return []*File{
 			{
 				Name: cmdName,
 			},
 		}
 	}
-	return pkgInfo.Files
+	return p.Files
 }
 
-func (pkgInfo *PackageInfo) getDefaultCmdName() string {
-	if pkgInfo.HasRepo() {
-		if pkgInfo.Name == "" {
-			return pkgInfo.RepoName
+func (p *PackageInfo) getDefaultCmdName() string {
+	if p.HasRepo() {
+		if p.Name == "" {
+			return p.RepoName
 		}
-		if i := strings.LastIndex(pkgInfo.Name, "/"); i != -1 {
-			return pkgInfo.Name[i+1:]
+		if i := strings.LastIndex(p.Name, "/"); i != -1 {
+			return p.Name[i+1:]
 		}
-		return pkgInfo.Name
+		return p.Name
 	}
-	if pkgInfo.Type == PkgInfoTypeGoInstall {
-		if pkgInfo.Asset != nil {
-			return *pkgInfo.Asset
+	if p.Type == PkgInfoTypeGoInstall {
+		if p.Asset != nil {
+			return *p.Asset
 		}
-		return path.Base(pkgInfo.GetPath())
+		return path.Base(p.GetPath())
 	}
-	return path.Base(pkgInfo.GetName())
+	return path.Base(p.GetName())
 }
 
-func (pkgInfo *PackageInfo) SLSASourceURI() string {
-	sp := pkgInfo.SLSAProvenance
+func (p *PackageInfo) SLSASourceURI() string {
+	sp := p.SLSAProvenance
 	if sp == nil {
 		return ""
 	}
@@ -591,16 +591,16 @@ func (pkgInfo *PackageInfo) SLSASourceURI() string {
 	repoOwner := sp.RepoOwner
 	repoName := sp.RepoName
 	if repoOwner == "" {
-		repoOwner = pkgInfo.RepoOwner
+		repoOwner = p.RepoOwner
 	}
 	if repoName == "" {
-		repoName = pkgInfo.RepoName
+		repoName = p.RepoName
 	}
 	return fmt.Sprintf("github.com/%s/%s", repoOwner, repoName)
 }
 
-func (pkgInfo *PackageInfo) GetVersionPrefix() string {
-	prefix := pkgInfo.VersionPrefix
+func (p *PackageInfo) GetVersionPrefix() string {
+	prefix := p.VersionPrefix
 	if prefix == nil {
 		return ""
 	}

--- a/pkg/config/registry/supported_envs.go
+++ b/pkg/config/registry/supported_envs.go
@@ -4,21 +4,21 @@ import (
 	"github.com/aquaproj/aqua/v2/pkg/runtime"
 )
 
-func (pkgInfo *PackageInfo) CheckSupported(rt *runtime.Runtime, env string) (bool, error) {
-	if pkgInfo.SupportedEnvs != nil {
-		return pkgInfo.CheckSupportedEnvs(rt.GOOS, rt.GOARCH, env), nil
+func (p *PackageInfo) CheckSupported(rt *runtime.Runtime, env string) (bool, error) {
+	if p.SupportedEnvs != nil {
+		return p.CheckSupportedEnvs(rt.GOOS, rt.GOARCH, env), nil
 	}
 	return true, nil
 }
 
-func (pkgInfo *PackageInfo) CheckSupportedEnvs(goos, goarch, env string) bool {
-	if pkgInfo.SupportedEnvs == nil {
+func (p *PackageInfo) CheckSupportedEnvs(goos, goarch, env string) bool {
+	if p.SupportedEnvs == nil {
 		return true
 	}
-	if goos == "darwin" && goarch == "arm64" && pkgInfo.GetRosetta2() {
+	if goos == "darwin" && goarch == "arm64" && p.GetRosetta2() {
 		return true
 	}
-	for _, supportedEnv := range pkgInfo.SupportedEnvs {
+	for _, supportedEnv := range p.SupportedEnvs {
 		switch supportedEnv {
 		case goos, goarch, env, "all":
 			return true

--- a/pkg/config/windows_ext.go
+++ b/pkg/config/windows_ext.go
@@ -12,23 +12,23 @@ import (
 	"github.com/spf13/afero"
 )
 
-func (cpkg *Package) RenameFile(logE *logrus.Entry, fs afero.Fs, pkgPath string, file *registry.File, rt *runtime.Runtime) (string, error) {
-	s, err := cpkg.getFileSrcWithoutWindowsExt(file, rt)
+func (p *Package) RenameFile(logE *logrus.Entry, fs afero.Fs, pkgPath string, file *registry.File, rt *runtime.Runtime) (string, error) {
+	s, err := p.getFileSrcWithoutWindowsExt(file, rt)
 	if err != nil {
 		return "", err
 	}
 	if !isWindows(rt.GOOS) {
 		return s, nil
 	}
-	if util.Ext(s, cpkg.Package.Version) != "" {
+	if util.Ext(s, p.Package.Version) != "" {
 		return s, nil
 	}
 
-	return cpkg.renameFile(logE, fs, pkgPath, s)
+	return p.renameFile(logE, fs, pkgPath, s)
 }
 
-func (cpkg *Package) renameFile(logE *logrus.Entry, fs afero.Fs, pkgPath, oldName string) (string, error) {
-	newName := oldName + cpkg.windowsExt()
+func (p *Package) renameFile(logE *logrus.Entry, fs afero.Fs, pkgPath, oldName string) (string, error) {
+	newName := oldName + p.windowsExt()
 	newPath := filepath.Join(pkgPath, newName)
 	if _, err := fs.Stat(newPath); err == nil {
 		return newName, nil
@@ -49,52 +49,52 @@ func (cpkg *Package) renameFile(logE *logrus.Entry, fs afero.Fs, pkgPath, oldNam
 	return newName, nil
 }
 
-func (cpkg *Package) windowsExt() string {
-	if cpkg.PackageInfo.WindowsExt == "" {
-		if cpkg.PackageInfo.Type == registry.PkgInfoTypeGitHubContent || cpkg.PackageInfo.Type == registry.PkgInfoTypeGitHubArchive {
+func (p *Package) windowsExt() string {
+	if p.PackageInfo.WindowsExt == "" {
+		if p.PackageInfo.Type == registry.PkgInfoTypeGitHubContent || p.PackageInfo.Type == registry.PkgInfoTypeGitHubArchive {
 			return ".sh"
 		}
 		return ".exe"
 	}
-	return cpkg.PackageInfo.WindowsExt
+	return p.PackageInfo.WindowsExt
 }
 
-func (cpkg *Package) completeWindowsExt(s string) string {
-	if cpkg.PackageInfo.CompleteWindowsExt != nil {
-		if *cpkg.PackageInfo.CompleteWindowsExt {
-			return s + cpkg.windowsExt()
+func (p *Package) completeWindowsExt(s string) string {
+	if p.PackageInfo.CompleteWindowsExt != nil {
+		if *p.PackageInfo.CompleteWindowsExt {
+			return s + p.windowsExt()
 		}
 		return s
 	}
-	if cpkg.PackageInfo.Type == registry.PkgInfoTypeGitHubContent || cpkg.PackageInfo.Type == registry.PkgInfoTypeGitHubArchive {
+	if p.PackageInfo.Type == registry.PkgInfoTypeGitHubContent || p.PackageInfo.Type == registry.PkgInfoTypeGitHubArchive {
 		return s
 	}
-	return s + cpkg.windowsExt()
+	return s + p.windowsExt()
 }
 
-func (cpkg *Package) completeWindowsExtToAsset(asset string) string {
+func (p *Package) completeWindowsExtToAsset(asset string) string {
 	if strings.HasSuffix(asset, ".exe") {
 		return asset
 	}
-	if cpkg.PackageInfo.Format == "raw" {
-		return cpkg.completeWindowsExt(asset)
+	if p.PackageInfo.Format == "raw" {
+		return p.completeWindowsExt(asset)
 	}
-	if cpkg.PackageInfo.Format != "" {
+	if p.PackageInfo.Format != "" {
 		return asset
 	}
-	if util.Ext(asset, cpkg.Package.Version) == "" {
-		return cpkg.completeWindowsExt(asset)
+	if util.Ext(asset, p.Package.Version) == "" {
+		return p.completeWindowsExt(asset)
 	}
 	return asset
 }
 
-func (cpkg *Package) completeWindowsExtToURL(url string) string {
-	return cpkg.completeWindowsExtToAsset(url)
+func (p *Package) completeWindowsExtToURL(url string) string {
+	return p.completeWindowsExtToAsset(url)
 }
 
-func (cpkg *Package) completeWindowsExtToFileSrc(src string) string {
-	if util.Ext(src, cpkg.Package.Version) == "" {
-		return src + cpkg.windowsExt()
+func (p *Package) completeWindowsExtToFileSrc(src string) string {
+	if util.Ext(src, p.Package.Version) == "" {
+		return src + p.windowsExt()
 	}
 	return src
 }

--- a/pkg/controller/allowpolicy/controller.go
+++ b/pkg/controller/allowpolicy/controller.go
@@ -1,4 +1,4 @@
-package denypolicy
+package allowpolicy
 
 import (
 	"context"
@@ -25,18 +25,18 @@ func New(fs afero.Fs, policyConfigFinder policy.ConfigFinder, policyValidator po
 	}
 }
 
-func (ctrl *Controller) Deny(ctx context.Context, logE *logrus.Entry, param *config.Param, policyFilePath string) error {
-	policyFilePath, err := ctrl.policyConfigFinder.Find(policyFilePath, param.PWD)
+func (c *Controller) Allow(ctx context.Context, logE *logrus.Entry, param *config.Param, policyFilePath string) error {
+	policyFile, err := c.policyConfigFinder.Find(policyFilePath, param.PWD)
 	if err != nil {
 		return fmt.Errorf("find a policy file: %w", err)
 	}
-	if policyFilePath == "" {
+	if policyFile == "" {
 		logE.Info("no policy file is found")
 		return nil
 	}
-	if err := ctrl.policyValidator.Deny(policyFilePath); err != nil {
-		return logerr.WithFields(fmt.Errorf("deny a policy file: %w", err), logrus.Fields{ //nolint:wrapcheck
-			"policy_file": policyFilePath,
+	if err := c.policyValidator.Allow(policyFile); err != nil {
+		return logerr.WithFields(fmt.Errorf("allow a policy file: %w", err), logrus.Fields{ //nolint:wrapcheck
+			"policy_file": policyFile,
 		})
 	}
 	return nil

--- a/pkg/controller/cp/controller.go
+++ b/pkg/controller/cp/controller.go
@@ -42,14 +42,18 @@ func New(param *config.Param, pkgInstaller PackageInstaller, fs afero.Fs, rt *ru
 	}
 }
 
+type ConfigFinder interface {
+	Finds(wd, configFilePath string) []string
+}
+
 var errCopyFailure = errors.New("it failed to copy some tools")
 
-func (ctrl *Controller) Copy(ctx context.Context, logE *logrus.Entry, param *config.Param) error {
-	if err := util.MkdirAll(ctrl.fs, param.Dest); err != nil {
+func (c *Controller) Copy(ctx context.Context, logE *logrus.Entry, param *config.Param) error {
+	if err := util.MkdirAll(c.fs, param.Dest); err != nil {
 		return fmt.Errorf("create the directory: %w", err)
 	}
 	if len(param.Args) == 0 {
-		return ctrl.installer.Install(ctx, logE, param) //nolint:wrapcheck
+		return c.installer.Install(ctx, logE, param) //nolint:wrapcheck
 	}
 
 	maxInstallChan := make(chan struct{}, param.MaxParallelism)
@@ -63,9 +67,9 @@ func (ctrl *Controller) Copy(ctx context.Context, logE *logrus.Entry, param *con
 		flagMutex.Unlock()
 	}
 
-	ctrl.packageInstaller.SetCopyDir("")
+	c.packageInstaller.SetCopyDir("")
 
-	policyCfgs, err := ctrl.policyConfigReader.ReadFromEnv(param.PolicyConfigFilePaths)
+	policyCfgs, err := c.policyConfigReader.ReadFromEnv(param.PolicyConfigFilePaths)
 	if err != nil {
 		return fmt.Errorf("read policy files: %w", err)
 	}
@@ -83,7 +87,7 @@ func (ctrl *Controller) Copy(ctx context.Context, logE *logrus.Entry, param *con
 				<-maxInstallChan
 			}()
 			logE := logE.WithField("exe_name", exeName)
-			if err := ctrl.installAndCopy(ctx, logE, param, exeName, policyCfgs, globalPolicyPaths); err != nil {
+			if err := c.installAndCopy(ctx, logE, param, exeName, policyCfgs, globalPolicyPaths); err != nil {
 				logerr.WithError(logE, err).Error("install the package")
 				handleFailure()
 				return
@@ -97,25 +101,25 @@ func (ctrl *Controller) Copy(ctx context.Context, logE *logrus.Entry, param *con
 	return nil
 }
 
-func (ctrl *Controller) installAndCopy(ctx context.Context, logE *logrus.Entry, param *config.Param, exeName string, policyConfigs []*policy.Config, globalPolicyPaths map[string]struct{}) error {
-	findResult, err := ctrl.which.Which(ctx, logE, param, exeName)
+func (c *Controller) installAndCopy(ctx context.Context, logE *logrus.Entry, param *config.Param, exeName string, policyConfigs []*policy.Config, globalPolicyPaths map[string]struct{}) error {
+	findResult, err := c.which.Which(ctx, logE, param, exeName)
 	if err != nil {
 		return err //nolint:wrapcheck
 	}
 	if findResult.Package != nil {
 		logE = logE.WithField("package", findResult.Package.Package.Name)
 
-		policyConfigs, err := ctrl.policyConfigReader.Append(logE, findResult.ConfigFilePath, policyConfigs, globalPolicyPaths)
+		policyConfigs, err := c.policyConfigReader.Append(logE, findResult.ConfigFilePath, policyConfigs, globalPolicyPaths)
 		if err != nil {
 			return err //nolint:wrapcheck
 		}
 
-		if err := ctrl.install(ctx, logE, findResult, policyConfigs); err != nil {
+		if err := c.install(ctx, logE, findResult, policyConfigs); err != nil {
 			return err
 		}
 	}
 
-	if err := ctrl.copy(logE, param, findResult, exeName); err != nil {
+	if err := c.copy(logE, param, findResult, exeName); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/controller/cp/copy.go
+++ b/pkg/controller/cp/copy.go
@@ -9,16 +9,16 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func (ctrl *Controller) copy(logE *logrus.Entry, param *config.Param, findResult *which.FindResult, exeName string) error {
+func (c *Controller) copy(logE *logrus.Entry, param *config.Param, findResult *which.FindResult, exeName string) error {
 	p := filepath.Join(param.Dest, exeName)
-	if ctrl.runtime.GOOS == "windows" && filepath.Ext(exeName) == "" {
+	if c.runtime.GOOS == "windows" && filepath.Ext(exeName) == "" {
 		p += ".exe"
 	}
 	logE.WithFields(logrus.Fields{
 		"exe_name": exeName,
 		"dest":     p,
 	}).Info("coping a file")
-	if err := ctrl.packageInstaller.Copy(p, findResult.ExePath); err != nil {
+	if err := c.packageInstaller.Copy(p, findResult.ExePath); err != nil {
 		return fmt.Errorf("copy a file: %w", err)
 	}
 	return nil

--- a/pkg/controller/cp/install.go
+++ b/pkg/controller/cp/install.go
@@ -13,32 +13,32 @@ import (
 	"github.com/suzuki-shunsuke/logrus-error/logerr"
 )
 
-func (ctrl *Controller) install(ctx context.Context, logE *logrus.Entry, findResult *which.FindResult, policyConfigs []*policy.Config) error {
+func (c *Controller) install(ctx context.Context, logE *logrus.Entry, findResult *which.FindResult, policyConfigs []*policy.Config) error {
 	var checksums *checksum.Checksums
 	if findResult.Config.ChecksumEnabled() {
 		checksums = checksum.New()
-		checksumFilePath, err := checksum.GetChecksumFilePathFromConfigFilePath(ctrl.fs, findResult.ConfigFilePath)
+		checksumFilePath, err := checksum.GetChecksumFilePathFromConfigFilePath(c.fs, findResult.ConfigFilePath)
 		if err != nil {
 			return err //nolint:wrapcheck
 		}
-		if err := checksums.ReadFile(ctrl.fs, checksumFilePath); err != nil {
+		if err := checksums.ReadFile(c.fs, checksumFilePath); err != nil {
 			return fmt.Errorf("read a checksum JSON: %w", err)
 		}
 		defer func() {
-			if err := checksums.UpdateFile(ctrl.fs, checksumFilePath); err != nil {
+			if err := checksums.UpdateFile(c.fs, checksumFilePath); err != nil {
 				logE.WithError(err).Error("update a checksum file")
 			}
 		}()
 	}
 
-	if err := ctrl.packageInstaller.InstallPackage(ctx, logE, &installpackage.ParamInstallPackage{
+	if err := c.packageInstaller.InstallPackage(ctx, logE, &installpackage.ParamInstallPackage{
 		Pkg:             findResult.Package,
 		Checksums:       checksums,
-		RequireChecksum: findResult.Config.RequireChecksum(ctrl.requireChecksum),
+		RequireChecksum: findResult.Config.RequireChecksum(c.requireChecksum),
 		ConfigFileDir:   filepath.Dir(findResult.ConfigFilePath),
 		PolicyConfigs:   policyConfigs,
 	}); err != nil {
 		return fmt.Errorf("install a package: %w", logerr.WithFields(err, logE.Data))
 	}
-	return ctrl.packageInstaller.WaitExe(ctx, logE, findResult.ExePath) //nolint:wrapcheck
+	return c.packageInstaller.WaitExe(ctx, logE, findResult.ExePath) //nolint:wrapcheck
 }

--- a/pkg/controller/cp/installer.go
+++ b/pkg/controller/cp/installer.go
@@ -15,6 +15,6 @@ type MockInstaller struct {
 	Err error
 }
 
-func (inst *MockInstaller) Install(ctx context.Context, logE *logrus.Entry, param *config.Param) error {
-	return inst.Err
+func (is *MockInstaller) Install(ctx context.Context, logE *logrus.Entry, param *config.Param) error {
+	return is.Err
 }

--- a/pkg/controller/cp/interface.go
+++ b/pkg/controller/cp/interface.go
@@ -1,5 +1,0 @@
-package cp
-
-type ConfigFinder interface {
-	Finds(wd, configFilePath string) []string
-}

--- a/pkg/controller/cp/package_installer.go
+++ b/pkg/controller/cp/package_installer.go
@@ -17,21 +17,21 @@ type PackageInstaller interface {
 
 type MockPackageInstaller struct{}
 
-func (inst *MockPackageInstaller) InstallPackage(ctx context.Context, logE *logrus.Entry, param *installpackage.ParamInstallPackage) error {
+func (is *MockPackageInstaller) InstallPackage(ctx context.Context, logE *logrus.Entry, param *installpackage.ParamInstallPackage) error {
 	return nil
 }
 
-func (inst *MockPackageInstaller) InstallPackages(ctx context.Context, logE *logrus.Entry, param *installpackage.ParamInstallPackages) error {
+func (is *MockPackageInstaller) InstallPackages(ctx context.Context, logE *logrus.Entry, param *installpackage.ParamInstallPackages) error {
 	return nil
 }
 
-func (inst *MockPackageInstaller) SetCopyDir(copyDir string) {
+func (is *MockPackageInstaller) SetCopyDir(copyDir string) {
 }
 
-func (inst *MockPackageInstaller) Copy(dest, src string) error {
+func (is *MockPackageInstaller) Copy(dest, src string) error {
 	return nil
 }
 
-func (inst *MockPackageInstaller) WaitExe(ctx context.Context, logE *logrus.Entry, exePath string) error {
+func (is *MockPackageInstaller) WaitExe(ctx context.Context, logE *logrus.Entry, exePath string) error {
 	return nil
 }

--- a/pkg/controller/denypolicy/controller.go
+++ b/pkg/controller/denypolicy/controller.go
@@ -1,4 +1,4 @@
-package allowpolicy
+package denypolicy
 
 import (
 	"context"
@@ -25,18 +25,18 @@ func New(fs afero.Fs, policyConfigFinder policy.ConfigFinder, policyValidator po
 	}
 }
 
-func (ctrl *Controller) Allow(ctx context.Context, logE *logrus.Entry, param *config.Param, policyFilePath string) error {
-	policyFile, err := ctrl.policyConfigFinder.Find(policyFilePath, param.PWD)
+func (c *Controller) Deny(ctx context.Context, logE *logrus.Entry, param *config.Param, policyFilePath string) error {
+	policyFilePath, err := c.policyConfigFinder.Find(policyFilePath, param.PWD)
 	if err != nil {
 		return fmt.Errorf("find a policy file: %w", err)
 	}
-	if policyFile == "" {
+	if policyFilePath == "" {
 		logE.Info("no policy file is found")
 		return nil
 	}
-	if err := ctrl.policyValidator.Allow(policyFile); err != nil {
-		return logerr.WithFields(fmt.Errorf("allow a policy file: %w", err), logrus.Fields{ //nolint:wrapcheck
-			"policy_file": policyFile,
+	if err := c.policyValidator.Deny(policyFilePath); err != nil {
+		return logerr.WithFields(fmt.Errorf("deny a policy file: %w", err), logrus.Fields{ //nolint:wrapcheck
+			"policy_file": policyFilePath,
 		})
 	}
 	return nil

--- a/pkg/controller/exec/controller.go
+++ b/pkg/controller/exec/controller.go
@@ -1,0 +1,63 @@
+package exec
+
+import (
+	"context"
+	"io"
+	"os"
+	"runtime"
+
+	"github.com/aquaproj/aqua/v2/pkg/config"
+	"github.com/aquaproj/aqua/v2/pkg/controller/which"
+	"github.com/aquaproj/aqua/v2/pkg/installpackage"
+	"github.com/aquaproj/aqua/v2/pkg/policy"
+	"github.com/spf13/afero"
+	"github.com/suzuki-shunsuke/go-osenv/osenv"
+)
+
+type Controller struct {
+	stdin              io.Reader
+	stdout             io.Writer
+	stderr             io.Writer
+	which              which.Controller
+	packageInstaller   installpackage.Installer
+	executor           Executor
+	fs                 afero.Fs
+	policyConfigReader policy.Reader
+	policyConfigFinder policy.ConfigFinder
+	enabledXSysExec    bool
+	requireChecksum    bool
+}
+
+func New(param *config.Param, pkgInstaller installpackage.Installer, whichCtrl which.Controller, executor Executor, osEnv osenv.OSEnv, fs afero.Fs, policyConfigReader policy.Reader, policyConfigFinder policy.ConfigFinder) *Controller {
+	return &Controller{
+		stdin:              os.Stdin,
+		stdout:             os.Stdout,
+		stderr:             os.Stderr,
+		packageInstaller:   pkgInstaller,
+		which:              whichCtrl,
+		executor:           executor,
+		enabledXSysExec:    getEnabledXSysExec(osEnv, runtime.GOOS),
+		fs:                 fs,
+		policyConfigReader: policyConfigReader,
+		policyConfigFinder: policyConfigFinder,
+		requireChecksum:    param.RequireChecksum,
+	}
+}
+
+func getEnabledXSysExec(osEnv osenv.OSEnv, goos string) bool {
+	if goos == "windows" {
+		return false
+	}
+	if osEnv.Getenv("AQUA_EXPERIMENTAL_X_SYS_EXEC") == "false" {
+		return false
+	}
+	if osEnv.Getenv("AQUA_X_SYS_EXEC") == "false" {
+		return false
+	}
+	return true
+}
+
+type Executor interface {
+	Exec(ctx context.Context, exePath string, args ...string) (int, error)
+	ExecXSys(exePath string, args ...string) error
+}

--- a/pkg/controller/exec/interface.go
+++ b/pkg/controller/exec/interface.go
@@ -1,8 +1,0 @@
-package exec
-
-import "context"
-
-type Executor interface {
-	Exec(ctx context.Context, exePath string, args ...string) (int, error)
-	ExecXSys(exePath string, args ...string) error
-}

--- a/pkg/controller/generate-registry/cargo.go
+++ b/pkg/controller/generate-registry/cargo.go
@@ -8,14 +8,14 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func (ctrl *Controller) getCargoPackageInfo(ctx context.Context, logE *logrus.Entry, pkgName string) (*registry.PackageInfo, []string) {
+func (c *Controller) getCargoPackageInfo(ctx context.Context, logE *logrus.Entry, pkgName string) (*registry.PackageInfo, []string) {
 	crate := strings.TrimPrefix(pkgName, "crates.io/")
 	pkgInfo := &registry.PackageInfo{
 		Name:  pkgName,
 		Type:  "cargo",
 		Crate: &crate,
 	}
-	payload, err := ctrl.cargoClient.GetCrate(ctx, crate)
+	payload, err := c.cargoClient.GetCrate(ctx, crate)
 	if err != nil {
 		logE.WithError(err).Warn("get a crate metadata by crates.io API")
 	}

--- a/pkg/controller/generate-registry/insert.go
+++ b/pkg/controller/generate-registry/insert.go
@@ -8,8 +8,8 @@ import (
 	"github.com/spf13/afero"
 )
 
-func (ctrl *Controller) insert(cfgFilePath string, pkgs interface{}) error {
-	b, err := afero.ReadFile(ctrl.fs, cfgFilePath)
+func (c *Controller) insert(cfgFilePath string, pkgs interface{}) error {
+	b, err := afero.ReadFile(c.fs, cfgFilePath)
 	if err != nil {
 		return fmt.Errorf("read a configuration file: %w", err)
 	}
@@ -22,11 +22,11 @@ func (ctrl *Controller) insert(cfgFilePath string, pkgs interface{}) error {
 		return fmt.Errorf("update an AST file: %w", err)
 	}
 
-	stat, err := ctrl.fs.Stat(cfgFilePath)
+	stat, err := c.fs.Stat(cfgFilePath)
 	if err != nil {
 		return fmt.Errorf("get configuration file stat: %w", err)
 	}
-	if err := afero.WriteFile(ctrl.fs, cfgFilePath, []byte(file.String()+"\n"), stat.Mode()); err != nil {
+	if err := afero.WriteFile(c.fs, cfgFilePath, []byte(file.String()+"\n"), stat.Mode()); err != nil {
 		return fmt.Errorf("write the configuration file: %w", err)
 	}
 	return nil

--- a/pkg/controller/generate-registry/version_overrides.go
+++ b/pkg/controller/generate-registry/version_overrides.go
@@ -79,8 +79,8 @@ func getVersionAndPrefix(tag string) (*version.Version, string, error) {
 	return v, a[1], nil
 }
 
-func (ctrl *Controller) getPackageInfoWithVersionOverrides(ctx context.Context, logE *logrus.Entry, pkgName string, pkgInfo *registry.PackageInfo) (*registry.PackageInfo, []string) {
-	ghReleases := ctrl.listReleases(ctx, logE, pkgInfo)
+func (c *Controller) getPackageInfoWithVersionOverrides(ctx context.Context, logE *logrus.Entry, pkgName string, pkgInfo *registry.PackageInfo) (*registry.PackageInfo, []string) {
+	ghReleases := c.listReleases(ctx, logE, pkgInfo)
 	releases := make([]*Release, len(ghReleases))
 	for i, release := range ghReleases {
 		tag := release.GetTagName()
@@ -115,12 +115,12 @@ func (ctrl *Controller) getPackageInfoWithVersionOverrides(ctx context.Context, 
 		if release.VersionPrefix != "" {
 			pkgInfo.VersionPrefix = &release.VersionPrefix
 		}
-		assets := ctrl.listReleaseAssets(ctx, logE, pkgInfo, release.ID)
+		assets := c.listReleaseAssets(ctx, logE, pkgInfo, release.ID)
 		logE.WithField("num_of_assets", len(assets)).Debug("got assets")
 		if len(assets) == 0 {
 			continue
 		}
-		ctrl.patchRelease(logE, pkgInfo, pkgName, release.Tag, assets)
+		c.patchRelease(logE, pkgInfo, pkgName, release.Tag, assets)
 		pkgs = append(pkgs, &Package{
 			Info:    pkgInfo,
 			Version: release.Tag,
@@ -260,7 +260,7 @@ func mergePackages(pkgs []*Package) (*registry.PackageInfo, []string) { //nolint
 	return latestPkgInfo, versions
 }
 
-func (ctrl *Controller) listReleases(ctx context.Context, logE *logrus.Entry, pkgInfo *registry.PackageInfo) []*github.RepositoryRelease {
+func (c *Controller) listReleases(ctx context.Context, logE *logrus.Entry, pkgInfo *registry.PackageInfo) []*github.RepositoryRelease {
 	repoOwner := pkgInfo.RepoOwner
 	repoName := pkgInfo.RepoName
 	opt := &github.ListOptions{
@@ -269,7 +269,7 @@ func (ctrl *Controller) listReleases(ctx context.Context, logE *logrus.Entry, pk
 	var arr []*github.RepositoryRelease
 
 	for i := 0; i < 10; i++ {
-		releases, _, err := ctrl.github.ListReleases(ctx, repoOwner, repoName, opt)
+		releases, _, err := c.github.ListReleases(ctx, repoOwner, repoName, opt)
 		if err != nil {
 			logerr.WithError(logE, err).WithFields(logrus.Fields{
 				"repo_owner": repoOwner,

--- a/pkg/controller/generate/cargo.go
+++ b/pkg/controller/generate/cargo.go
@@ -7,23 +7,23 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func (ctrl *Controller) getCargoVersion(ctx context.Context, logE *logrus.Entry, param *config.Param, pkg *FindingPackage) string {
+func (c *Controller) getCargoVersion(ctx context.Context, logE *logrus.Entry, param *config.Param, pkg *FindingPackage) string {
 	pkgInfo := pkg.PackageInfo
 	if param.SelectVersion {
-		versionStrings, err := ctrl.cargoClient.ListVersions(ctx, *pkgInfo.Crate)
+		versionStrings, err := c.cargoClient.ListVersions(ctx, *pkgInfo.Crate)
 		if err != nil {
 			logE.WithError(err).Warn("list versions")
 			return ""
 		}
 		versions := convertStringsToVersions(versionStrings)
 
-		idx, err := ctrl.versionSelector.Find(versions, false)
+		idx, err := c.versionSelector.Find(versions, false)
 		if err != nil {
 			return ""
 		}
 		return versions[idx].Version
 	}
-	version, err := ctrl.cargoClient.GetLatestVersion(ctx, *pkgInfo.Crate)
+	version, err := c.cargoClient.GetLatestVersion(ctx, *pkgInfo.Crate)
 	if err != nil {
 		logE.WithError(err).Warn("get a latest version")
 		return ""

--- a/pkg/controller/generate/controller.go
+++ b/pkg/controller/generate/controller.go
@@ -1,0 +1,40 @@
+package generate
+
+import (
+	"io"
+	"os"
+
+	"github.com/aquaproj/aqua/v2/pkg/cargo"
+	reader "github.com/aquaproj/aqua/v2/pkg/config-reader"
+	"github.com/aquaproj/aqua/v2/pkg/controller/generate/output"
+	rgst "github.com/aquaproj/aqua/v2/pkg/install-registry"
+	"github.com/spf13/afero"
+)
+
+type Controller struct {
+	stdin             io.Reader
+	github            RepositoriesService
+	registryInstaller rgst.Installer
+	configFinder      ConfigFinder
+	configReader      reader.ConfigReader
+	fuzzyFinder       FuzzyFinder
+	versionSelector   VersionSelector
+	fs                afero.Fs
+	outputter         Outputter
+	cargoClient       cargo.Client
+}
+
+func New(configFinder ConfigFinder, configReader reader.ConfigReader, registInstaller rgst.Installer, gh RepositoriesService, fs afero.Fs, fuzzyFinder FuzzyFinder, versionSelector VersionSelector, cargoClient cargo.Client) *Controller {
+	return &Controller{
+		stdin:             os.Stdin,
+		configFinder:      configFinder,
+		configReader:      configReader,
+		registryInstaller: registInstaller,
+		github:            gh,
+		fs:                fs,
+		fuzzyFinder:       fuzzyFinder,
+		versionSelector:   versionSelector,
+		cargoClient:       cargoClient,
+		outputter:         output.New(os.Stdout, fs),
+	}
+}

--- a/pkg/controller/generate/finder.go
+++ b/pkg/controller/generate/finder.go
@@ -29,11 +29,11 @@ type mockFuzzyFinder struct {
 	err  error
 }
 
-func (finder *mockFuzzyFinder) Find(pkgs []*FindingPackage) ([]int, error) {
-	return finder.idxs, finder.err
+func (f *mockFuzzyFinder) Find(pkgs []*FindingPackage) ([]int, error) {
+	return f.idxs, f.err
 }
 
-func (finder *fuzzyFinder) Find(pkgs []*FindingPackage) ([]int, error) {
+func (f *fuzzyFinder) Find(pkgs []*FindingPackage) ([]int, error) {
 	return fuzzyfinder.FindMulti(pkgs, func(i int) string { //nolint:wrapcheck
 		return find(pkgs[i])
 	},

--- a/pkg/controller/generate/github_release.go
+++ b/pkg/controller/generate/github_release.go
@@ -12,8 +12,8 @@ import (
 	"github.com/suzuki-shunsuke/logrus-error/logerr"
 )
 
-func (ctrl *Controller) selectVersionFromReleases(ctx context.Context, logE *logrus.Entry, pkgInfo *registry.PackageInfo) string {
-	releases := ctrl.listReleases(ctx, logE, pkgInfo)
+func (c *Controller) selectVersionFromReleases(ctx context.Context, logE *logrus.Entry, pkgInfo *registry.PackageInfo) string {
+	releases := c.listReleases(ctx, logE, pkgInfo)
 	versions := make([]*Version, len(releases))
 	for i, release := range releases {
 		versions[i] = &Version{
@@ -23,17 +23,17 @@ func (ctrl *Controller) selectVersionFromReleases(ctx context.Context, logE *log
 			URL:         release.GetHTMLURL(),
 		}
 	}
-	idx, err := ctrl.versionSelector.Find(versions, true)
+	idx, err := c.versionSelector.Find(versions, true)
 	if err != nil {
 		return ""
 	}
 	return versions[idx].Version
 }
 
-func (ctrl *Controller) getVersionFromLatestRelease(ctx context.Context, logE *logrus.Entry, pkgInfo *registry.PackageInfo) string {
+func (c *Controller) getVersionFromLatestRelease(ctx context.Context, logE *logrus.Entry, pkgInfo *registry.PackageInfo) string {
 	repoOwner := pkgInfo.RepoOwner
 	repoName := pkgInfo.RepoName
-	release, _, err := ctrl.github.GetLatestRelease(ctx, repoOwner, repoName)
+	release, _, err := c.github.GetLatestRelease(ctx, repoOwner, repoName)
 	if err != nil {
 		logerr.WithError(logE, err).WithFields(logrus.Fields{
 			"repo_owner": repoOwner,
@@ -88,7 +88,7 @@ func createFilters(pkgInfo *registry.PackageInfo) ([]*Filter, error) {
 	return filters, nil
 }
 
-func (ctrl *Controller) listReleases(ctx context.Context, logE *logrus.Entry, pkgInfo *registry.PackageInfo) []*github.RepositoryRelease {
+func (c *Controller) listReleases(ctx context.Context, logE *logrus.Entry, pkgInfo *registry.PackageInfo) []*github.RepositoryRelease {
 	repoOwner := pkgInfo.RepoOwner
 	repoName := pkgInfo.RepoName
 	opt := &github.ListOptions{
@@ -102,7 +102,7 @@ func (ctrl *Controller) listReleases(ctx context.Context, logE *logrus.Entry, pk
 	}
 
 	for i := 0; i < 10; i++ {
-		releases, _, err := ctrl.github.ListReleases(ctx, repoOwner, repoName, opt)
+		releases, _, err := c.github.ListReleases(ctx, repoOwner, repoName, opt)
 		if err != nil {
 			logerr.WithError(logE, err).WithFields(logrus.Fields{
 				"repo_owner": repoOwner,
@@ -123,7 +123,7 @@ func (ctrl *Controller) listReleases(ctx context.Context, logE *logrus.Entry, pk
 	return arr
 }
 
-func (ctrl *Controller) listAndGetTagName(ctx context.Context, logE *logrus.Entry, pkgInfo *registry.PackageInfo) string {
+func (c *Controller) listAndGetTagName(ctx context.Context, logE *logrus.Entry, pkgInfo *registry.PackageInfo) string {
 	repoOwner := pkgInfo.RepoOwner
 	repoName := pkgInfo.RepoName
 	opt := &github.ListOptions{
@@ -136,7 +136,7 @@ func (ctrl *Controller) listAndGetTagName(ctx context.Context, logE *logrus.Entr
 	}
 
 	for {
-		releases, _, err := ctrl.github.ListReleases(ctx, repoOwner, repoName, opt)
+		releases, _, err := c.github.ListReleases(ctx, repoOwner, repoName, opt)
 		if err != nil {
 			logerr.WithError(logE, err).WithFields(logrus.Fields{
 				"repo_owner": repoOwner,

--- a/pkg/controller/generate/github_tag.go
+++ b/pkg/controller/generate/github_tag.go
@@ -21,7 +21,7 @@ func filterTag(tag *github.RepositoryTag, filters []*Filter) bool {
 }
 
 // listTags lists GitHub Tags by GitHub API and filter them with `version_filter`.
-func (ctrl *Controller) listTags(ctx context.Context, logE *logrus.Entry, pkgInfo *registry.PackageInfo) []*github.RepositoryTag {
+func (c *Controller) listTags(ctx context.Context, logE *logrus.Entry, pkgInfo *registry.PackageInfo) []*github.RepositoryTag {
 	// List GitHub Tags by GitHub API
 	// Filter tags with version_filter
 	repoOwner := pkgInfo.RepoOwner
@@ -37,7 +37,7 @@ func (ctrl *Controller) listTags(ctx context.Context, logE *logrus.Entry, pkgInf
 
 	var arr []*github.RepositoryTag
 	for i := 0; i < 10; i++ {
-		tags, _, err := ctrl.github.ListTags(ctx, repoOwner, repoName, opt)
+		tags, _, err := c.github.ListTags(ctx, repoOwner, repoName, opt)
 		if err != nil {
 			logerr.WithError(logE, err).WithFields(logrus.Fields{
 				"repo_owner": repoOwner,
@@ -58,7 +58,7 @@ func (ctrl *Controller) listTags(ctx context.Context, logE *logrus.Entry, pkgInf
 	return arr
 }
 
-func (ctrl *Controller) listAndGetTagNameFromTag(ctx context.Context, logE *logrus.Entry, pkgInfo *registry.PackageInfo) string {
+func (c *Controller) listAndGetTagNameFromTag(ctx context.Context, logE *logrus.Entry, pkgInfo *registry.PackageInfo) string {
 	// List GitHub Tags by GitHub API
 	// Filter tags with version_filter
 	// Get a tag
@@ -72,7 +72,7 @@ func (ctrl *Controller) listAndGetTagNameFromTag(ctx context.Context, logE *logr
 		return ""
 	}
 	for {
-		tags, _, err := ctrl.github.ListTags(ctx, repoOwner, repoName, opt)
+		tags, _, err := c.github.ListTags(ctx, repoOwner, repoName, opt)
 		if err != nil {
 			logerr.WithError(logE, err).WithFields(logrus.Fields{
 				"repo_owner": repoOwner,
@@ -92,24 +92,24 @@ func (ctrl *Controller) listAndGetTagNameFromTag(ctx context.Context, logE *logr
 	}
 }
 
-func (ctrl *Controller) selectVersionFromGitHubTag(ctx context.Context, logE *logrus.Entry, pkgInfo *registry.PackageInfo) string {
-	tags := ctrl.listTags(ctx, logE, pkgInfo)
+func (c *Controller) selectVersionFromGitHubTag(ctx context.Context, logE *logrus.Entry, pkgInfo *registry.PackageInfo) string {
+	tags := c.listTags(ctx, logE, pkgInfo)
 	versions := make([]*Version, len(tags))
 	for i, tag := range tags {
 		versions[i] = &Version{
 			Version: tag.GetName(),
 		}
 	}
-	idx, err := ctrl.versionSelector.Find(versions, false)
+	idx, err := c.versionSelector.Find(versions, false)
 	if err != nil {
 		return ""
 	}
 	return versions[idx].Version
 }
 
-func (ctrl *Controller) getVersionFromGitHubTag(ctx context.Context, logE *logrus.Entry, param *config.Param, pkgInfo *registry.PackageInfo) string {
+func (c *Controller) getVersionFromGitHubTag(ctx context.Context, logE *logrus.Entry, param *config.Param, pkgInfo *registry.PackageInfo) string {
 	if param.SelectVersion {
-		return ctrl.selectVersionFromGitHubTag(ctx, logE, pkgInfo)
+		return c.selectVersionFromGitHubTag(ctx, logE, pkgInfo)
 	}
-	return ctrl.listAndGetTagNameFromTag(ctx, logE, pkgInfo)
+	return c.listAndGetTagNameFromTag(ctx, logE, pkgInfo)
 }

--- a/pkg/controller/generate/output/insert.go
+++ b/pkg/controller/generate/output/insert.go
@@ -13,8 +13,8 @@ import (
 	"github.com/suzuki-shunsuke/logrus-error/logerr"
 )
 
-func (out *Outputter) generateInsert(cfgFilePath string, pkgs []*aqua.Package) error {
-	b, err := afero.ReadFile(out.fs, cfgFilePath)
+func (o *Outputter) generateInsert(cfgFilePath string, pkgs []*aqua.Package) error {
+	b, err := afero.ReadFile(o.fs, cfgFilePath)
 	if err != nil {
 		return fmt.Errorf("read a configuration file: %w", err)
 	}
@@ -33,11 +33,11 @@ func (out *Outputter) generateInsert(cfgFilePath string, pkgs []*aqua.Package) e
 		return err
 	}
 
-	stat, err := out.fs.Stat(cfgFilePath)
+	stat, err := o.fs.Stat(cfgFilePath)
 	if err != nil {
 		return fmt.Errorf("get configuration file stat: %w", err)
 	}
-	if err := afero.WriteFile(out.fs, cfgFilePath, []byte(file.String()), stat.Mode()); err != nil {
+	if err := afero.WriteFile(o.fs, cfgFilePath, []byte(file.String()), stat.Mode()); err != nil {
 		return fmt.Errorf("write the configuration file: %w", err)
 	}
 	return nil

--- a/pkg/controller/generate/output/output.go
+++ b/pkg/controller/generate/output/output.go
@@ -29,23 +29,23 @@ type Param struct {
 	ConfigFilePath string
 }
 
-func (out *Outputter) Output(param *Param) error {
+func (o *Outputter) Output(param *Param) error {
 	if !param.Insert && param.Dest == "" {
-		if err := yaml.NewEncoder(out.stdout).Encode(param.List); err != nil {
+		if err := yaml.NewEncoder(o.stdout).Encode(param.List); err != nil {
 			return fmt.Errorf("output generated package configuration: %w", err)
 		}
 		return nil
 	}
 
 	if param.Dest == "" {
-		return out.generateInsert(param.ConfigFilePath, param.List)
+		return o.generateInsert(param.ConfigFilePath, param.List)
 	}
 
-	if _, err := out.fs.Stat(param.Dest); err == nil {
-		return out.generateInsert(param.Dest, param.List)
+	if _, err := o.fs.Stat(param.Dest); err == nil {
+		return o.generateInsert(param.Dest, param.List)
 	}
 
-	f, err := out.fs.Create(param.Dest)
+	f, err := o.fs.Create(param.Dest)
 	if err != nil {
 		return fmt.Errorf("create a file: %w", err)
 	}

--- a/pkg/controller/generate/read_pkg_file.go
+++ b/pkg/controller/generate/read_pkg_file.go
@@ -13,12 +13,12 @@ import (
 	"github.com/suzuki-shunsuke/logrus-error/logerr"
 )
 
-func (ctrl *Controller) readGeneratedPkgsFromFile(ctx context.Context, logE *logrus.Entry, param *config.Param, outputPkgs []*aqua.Package, m map[string]*FindingPackage) ([]*aqua.Package, error) {
+func (c *Controller) readGeneratedPkgsFromFile(ctx context.Context, logE *logrus.Entry, param *config.Param, outputPkgs []*aqua.Package, m map[string]*FindingPackage) ([]*aqua.Package, error) {
 	var file io.Reader
 	if param.File == "-" {
-		file = ctrl.stdin
+		file = c.stdin
 	} else {
-		f, err := ctrl.fs.Open(param.File)
+		f, err := c.fs.Open(param.File)
 		if err != nil {
 			return nil, fmt.Errorf("open the package list file: %w", err)
 		}
@@ -34,7 +34,7 @@ func (ctrl *Controller) readGeneratedPkgsFromFile(ctx context.Context, logE *log
 			return nil, logerr.WithFields(errUnknownPkg, logrus.Fields{"package_name": txt}) //nolint:wrapcheck
 		}
 		findingPkg.Version = version
-		outputPkg := ctrl.getOutputtedPkg(ctx, logE, param, findingPkg)
+		outputPkg := c.getOutputtedPkg(ctx, logE, param, findingPkg)
 		outputPkgs = append(outputPkgs, outputPkg)
 	}
 	if err := scanner.Err(); err != nil {

--- a/pkg/controller/generate/version_selector.go
+++ b/pkg/controller/generate/version_selector.go
@@ -35,11 +35,11 @@ type mockVersionSelector struct {
 	err error
 }
 
-func (selector *mockVersionSelector) Find(versions []*Version, hasPreview bool) (int, error) {
-	return selector.idx, selector.err
+func (s *mockVersionSelector) Find(versions []*Version, hasPreview bool) (int, error) {
+	return s.idx, s.err
 }
 
-func (selector *versionSelector) Find(versions []*Version, hasPreview bool) (int, error) {
+func (s *versionSelector) Find(versions []*Version, hasPreview bool) (int, error) {
 	if hasPreview {
 		return fuzzyfinder.Find(versions, func(i int) string { //nolint:wrapcheck
 			return getVersionItem(versions[i])

--- a/pkg/controller/info/info.go
+++ b/pkg/controller/info/info.go
@@ -50,14 +50,14 @@ func maskUser(s, username string) string {
 	return strings.ReplaceAll(s, username, "(USER)")
 }
 
-func (ctrl *Controller) Info(ctx context.Context, logE *logrus.Entry, param *config.Param, cfgFilePath string) error { //nolint:funlen
+func (c *Controller) Info(ctx context.Context, logE *logrus.Entry, param *config.Param, cfgFilePath string) error { //nolint:funlen
 	currentUser, err := user.Current()
 	if err != nil {
 		return fmt.Errorf("get a current user: %w", err)
 	}
 	userName := currentUser.Username
 
-	filePaths := ctrl.finder.Finds(param.PWD, param.ConfigFilePath)
+	filePaths := c.finder.Finds(param.PWD, param.ConfigFilePath)
 	cfgs := make([]*Config, len(filePaths))
 	for i, filePath := range filePaths {
 		cfgs[i] = &Config{
@@ -76,11 +76,11 @@ func (ctrl *Controller) Info(ctx context.Context, logE *logrus.Entry, param *con
 		Env:         map[string]string{},
 	}
 
-	if ctrl.rt.GOOS != runtime.GOOS {
-		info.AquaGOOS = ctrl.rt.GOOS
+	if c.rt.GOOS != runtime.GOOS {
+		info.AquaGOOS = c.rt.GOOS
 	}
-	if ctrl.rt.GOARCH != runtime.GOARCH {
-		info.AquaGOARCH = ctrl.rt.GOARCH
+	if c.rt.GOARCH != runtime.GOARCH {
+		info.AquaGOARCH = c.rt.GOARCH
 	}
 
 	envs := []string{

--- a/pkg/controller/initcmd/init.go
+++ b/pkg/controller/initcmd/init.go
@@ -37,11 +37,11 @@ func New(gh RepositoriesService, fs afero.Fs) *Controller {
 	}
 }
 
-func (ctrl *Controller) Init(ctx context.Context, cfgFilePath string, logE *logrus.Entry) error {
+func (c *Controller) Init(ctx context.Context, cfgFilePath string, logE *logrus.Entry) error {
 	if cfgFilePath == "" {
 		cfgFilePath = "aqua.yaml"
 	}
-	if _, err := ctrl.fs.Stat(cfgFilePath); err == nil {
+	if _, err := c.fs.Stat(cfgFilePath); err == nil {
 		// configuration file already exists, then do nothing.
 		logE.WithFields(logrus.Fields{
 			"configuration_file_path": cfgFilePath,
@@ -50,7 +50,7 @@ func (ctrl *Controller) Init(ctx context.Context, cfgFilePath string, logE *logr
 	}
 
 	registryVersion := "v4.41.1" // renovate: depName=aquaproj/aqua-registry
-	release, _, err := ctrl.github.GetLatestRelease(ctx, "aquaproj", "aqua-registry")
+	release, _, err := c.github.GetLatestRelease(ctx, "aquaproj", "aqua-registry")
 	if err != nil {
 		logerr.WithError(logE, err).WithFields(logrus.Fields{
 			"repo_owner": "aquaproj",
@@ -67,7 +67,7 @@ func (ctrl *Controller) Init(ctx context.Context, cfgFilePath string, logE *logr
 		}
 	}
 	cfgStr := strings.Replace(configTemplate, "%%STANDARD_REGISTRY_VERSION%%", registryVersion, 1)
-	if err := afero.WriteFile(ctrl.fs, cfgFilePath, []byte(cfgStr), util.FilePermission); err != nil {
+	if err := afero.WriteFile(c.fs, cfgFilePath, []byte(cfgStr), util.FilePermission); err != nil {
 		return fmt.Errorf("write a configuration file: %w", logerr.WithFields(err, logrus.Fields{
 			"configuration_file_path": cfgFilePath,
 		}))

--- a/pkg/controller/initpolicy/init.go
+++ b/pkg/controller/initpolicy/init.go
@@ -45,11 +45,11 @@ func New(fs afero.Fs) *Controller {
 	}
 }
 
-func (ctrl *Controller) Init(ctx context.Context, cfgFilePath string, logE *logrus.Entry) error {
+func (c *Controller) Init(ctx context.Context, cfgFilePath string, logE *logrus.Entry) error {
 	if cfgFilePath == "" {
 		cfgFilePath = "aqua-policy.yaml"
 	}
-	if _, err := ctrl.fs.Stat(cfgFilePath); err == nil {
+	if _, err := c.fs.Stat(cfgFilePath); err == nil {
 		// configuration file already exists, then do nothing.
 		logE.WithFields(logrus.Fields{
 			"policy_file_path": cfgFilePath,
@@ -57,7 +57,7 @@ func (ctrl *Controller) Init(ctx context.Context, cfgFilePath string, logE *logr
 		return nil
 	}
 
-	if err := afero.WriteFile(ctrl.fs, cfgFilePath, []byte(configTemplate), util.FilePermission); err != nil {
+	if err := afero.WriteFile(c.fs, cfgFilePath, []byte(configTemplate), util.FilePermission); err != nil {
 		return fmt.Errorf("write a policy file: %w", logerr.WithFields(err, logrus.Fields{
 			"policy_file_path": cfgFilePath,
 		}))

--- a/pkg/controller/install/install.go
+++ b/pkg/controller/install/install.go
@@ -53,23 +53,23 @@ func New(param *config.Param, configFinder ConfigFinder, configReader reader.Con
 	}
 }
 
-func (ctrl *Controller) Install(ctx context.Context, logE *logrus.Entry, param *config.Param) error { //nolint:cyclop
+func (c *Controller) Install(ctx context.Context, logE *logrus.Entry, param *config.Param) error { //nolint:cyclop
 	if param.Dest == "" { //nolint:nestif
-		rootBin := filepath.Join(ctrl.rootDir, "bin")
-		if err := util.MkdirAll(ctrl.fs, rootBin); err != nil {
+		rootBin := filepath.Join(c.rootDir, "bin")
+		if err := util.MkdirAll(c.fs, rootBin); err != nil {
 			return fmt.Errorf("create the directory: %w", err)
 		}
-		if ctrl.runtime.GOOS == "windows" {
-			if err := util.MkdirAll(ctrl.fs, filepath.Join(ctrl.rootDir, "bat")); err != nil {
+		if c.runtime.GOOS == "windows" {
+			if err := util.MkdirAll(c.fs, filepath.Join(c.rootDir, "bat")); err != nil {
 				return fmt.Errorf("create the directory: %w", err)
 			}
 		}
-		if err := ctrl.packageInstaller.InstallProxy(ctx, logE); err != nil {
+		if err := c.packageInstaller.InstallProxy(ctx, logE); err != nil {
 			return fmt.Errorf("install aqua-proxy: %w", err)
 		}
 	}
 
-	policyCfgs, err := ctrl.policyConfigReader.ReadFromEnv(param.PolicyConfigFilePaths)
+	policyCfgs, err := c.policyConfigReader.ReadFromEnv(param.PolicyConfigFilePaths)
 	if err != nil {
 		return fmt.Errorf("read policy files: %w", err)
 	}
@@ -79,78 +79,78 @@ func (ctrl *Controller) Install(ctx context.Context, logE *logrus.Entry, param *
 		globalPolicyPaths[p] = struct{}{}
 	}
 
-	for _, cfgFilePath := range ctrl.configFinder.Finds(param.PWD, param.ConfigFilePath) {
-		policyCfgs, err := ctrl.policyConfigReader.Append(logE, cfgFilePath, policyCfgs, globalPolicyPaths)
+	for _, cfgFilePath := range c.configFinder.Finds(param.PWD, param.ConfigFilePath) {
+		policyCfgs, err := c.policyConfigReader.Append(logE, cfgFilePath, policyCfgs, globalPolicyPaths)
 		if err != nil {
 			return err //nolint:wrapcheck
 		}
-		if err := ctrl.install(ctx, logE, cfgFilePath, policyCfgs); err != nil {
+		if err := c.install(ctx, logE, cfgFilePath, policyCfgs); err != nil {
 			return err
 		}
 	}
 
-	return ctrl.installAll(ctx, logE, param, policyCfgs, globalPolicyPaths)
+	return c.installAll(ctx, logE, param, policyCfgs, globalPolicyPaths)
 }
 
-func (ctrl *Controller) installAll(ctx context.Context, logE *logrus.Entry, param *config.Param, policyConfigs []*policy.Config, globalPolicyPaths map[string]struct{}) error {
+func (c *Controller) installAll(ctx context.Context, logE *logrus.Entry, param *config.Param, policyConfigs []*policy.Config, globalPolicyPaths map[string]struct{}) error {
 	if !param.All {
 		return nil
 	}
 	for _, cfgFilePath := range param.GlobalConfigFilePaths {
-		if _, err := ctrl.fs.Stat(cfgFilePath); err != nil {
+		if _, err := c.fs.Stat(cfgFilePath); err != nil {
 			continue
 		}
-		policyConfigs, err := ctrl.policyConfigReader.Append(logE, cfgFilePath, policyConfigs, globalPolicyPaths)
+		policyConfigs, err := c.policyConfigReader.Append(logE, cfgFilePath, policyConfigs, globalPolicyPaths)
 		if err != nil {
 			return err //nolint:wrapcheck
 		}
-		if err := ctrl.install(ctx, logE, cfgFilePath, policyConfigs); err != nil {
+		if err := c.install(ctx, logE, cfgFilePath, policyConfigs); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (ctrl *Controller) install(ctx context.Context, logE *logrus.Entry, cfgFilePath string, policyConfigs []*policy.Config) error {
+func (c *Controller) install(ctx context.Context, logE *logrus.Entry, cfgFilePath string, policyConfigs []*policy.Config) error {
 	cfg := &aqua.Config{}
 	if cfgFilePath == "" {
 		return finder.ErrConfigFileNotFound
 	}
-	if err := ctrl.configReader.Read(cfgFilePath, cfg); err != nil {
+	if err := c.configReader.Read(cfgFilePath, cfg); err != nil {
 		return err //nolint:wrapcheck
 	}
 
 	var checksums *checksum.Checksums
 	if cfg.ChecksumEnabled() {
 		checksums = checksum.New()
-		checksumFilePath, err := checksum.GetChecksumFilePathFromConfigFilePath(ctrl.fs, cfgFilePath)
+		checksumFilePath, err := checksum.GetChecksumFilePathFromConfigFilePath(c.fs, cfgFilePath)
 		if err != nil {
 			return err //nolint:wrapcheck
 		}
-		if err := checksums.ReadFile(ctrl.fs, checksumFilePath); err != nil {
+		if err := checksums.ReadFile(c.fs, checksumFilePath); err != nil {
 			return fmt.Errorf("read a checksum JSON: %w", err)
 		}
 		defer func() {
-			if err := checksums.UpdateFile(ctrl.fs, checksumFilePath); err != nil {
+			if err := checksums.UpdateFile(c.fs, checksumFilePath); err != nil {
 				logE.WithError(err).Error("update a checksum file")
 			}
 		}()
 	}
 
-	registryContents, err := ctrl.registryInstaller.InstallRegistries(ctx, logE, cfg, cfgFilePath, checksums)
+	registryContents, err := c.registryInstaller.InstallRegistries(ctx, logE, cfg, cfgFilePath, checksums)
 	if err != nil {
 		return err //nolint:wrapcheck
 	}
 
-	return ctrl.packageInstaller.InstallPackages(ctx, logE, &installpackage.ParamInstallPackages{ //nolint:wrapcheck
+	return c.packageInstaller.InstallPackages(ctx, logE, &installpackage.ParamInstallPackages{ //nolint:wrapcheck
 		Config:          cfg,
 		Registries:      registryContents,
 		ConfigFilePath:  cfgFilePath,
-		SkipLink:        ctrl.skipLink,
-		Tags:            ctrl.tags,
-		ExcludedTags:    ctrl.excludedTags,
+		SkipLink:        c.skipLink,
+		Tags:            c.tags,
+		ExcludedTags:    c.excludedTags,
 		PolicyConfigs:   policyConfigs,
 		Checksums:       checksums,
-		RequireChecksum: ctrl.requireChecksum,
+		RequireChecksum: c.requireChecksum,
 	})
 }

--- a/pkg/controller/updateaqua/controller.go
+++ b/pkg/controller/updateaqua/controller.go
@@ -32,20 +32,20 @@ func New(param *config.Param, fs afero.Fs, rt *runtime.Runtime, gh RepositoriesS
 	}
 }
 
-func (ctrl *Controller) UpdateAqua(ctx context.Context, logE *logrus.Entry, param *config.Param) error {
-	rootBin := filepath.Join(ctrl.rootDir, "bin")
-	if err := util.MkdirAll(ctrl.fs, rootBin); err != nil {
+func (c *Controller) UpdateAqua(ctx context.Context, logE *logrus.Entry, param *config.Param) error {
+	rootBin := filepath.Join(c.rootDir, "bin")
+	if err := util.MkdirAll(c.fs, rootBin); err != nil {
 		return fmt.Errorf("create the directory: %w", err)
 	}
 
-	version, err := ctrl.getVersion(ctx, param)
+	version, err := c.getVersion(ctx, param)
 	if err != nil {
 		return err
 	}
 
 	logE = logE.WithField("new_version", version)
 
-	if err := ctrl.installer.InstallAqua(ctx, logE, version); err != nil {
+	if err := c.installer.InstallAqua(ctx, logE, version); err != nil {
 		return fmt.Errorf("download aqua: %w", logerr.WithFields(err, logrus.Fields{
 			"new_version": version,
 		}))
@@ -53,10 +53,10 @@ func (ctrl *Controller) UpdateAqua(ctx context.Context, logE *logrus.Entry, para
 	return nil
 }
 
-func (ctrl *Controller) getVersion(ctx context.Context, param *config.Param) (string, error) {
+func (c *Controller) getVersion(ctx context.Context, param *config.Param) (string, error) {
 	switch len(param.Args) {
 	case 0:
-		release, _, err := ctrl.github.GetLatestRelease(ctx, "aquaproj", "aqua")
+		release, _, err := c.github.GetLatestRelease(ctx, "aquaproj", "aqua")
 		if err != nil {
 			return "", fmt.Errorf("get the latest version of aqua: %w", err)
 		}

--- a/pkg/controller/updatechecksum/config_finder.go
+++ b/pkg/controller/updatechecksum/config_finder.go
@@ -8,6 +8,6 @@ type MockConfigFinder struct {
 	Files []string
 }
 
-func (finder *MockConfigFinder) Finds(wd, configFilePath string) []string {
-	return finder.Files
+func (f *MockConfigFinder) Finds(wd, configFilePath string) []string {
+	return f.Files
 }

--- a/pkg/controller/which/lookpath.go
+++ b/pkg/controller/which/lookpath.go
@@ -12,10 +12,10 @@ import (
 
 const proxyName = "aqua-proxy"
 
-func (ctrl *ControllerImpl) lookPath(envPath, exeName string) string {
+func (c *ControllerImpl) lookPath(envPath, exeName string) string {
 	for _, p := range filepath.SplitList(envPath) {
 		bin := filepath.Join(p, exeName)
-		finfo, err := ctrl.readLink(bin)
+		finfo, err := c.readLink(bin)
 		if err != nil {
 			continue
 		}
@@ -30,8 +30,8 @@ func (ctrl *ControllerImpl) lookPath(envPath, exeName string) string {
 	return ""
 }
 
-func (ctrl *ControllerImpl) readLink(p string) (os.FileInfo, error) {
-	finfo, err := ctrl.linker.Lstat(p)
+func (c *ControllerImpl) readLink(p string) (os.FileInfo, error) {
+	finfo, err := c.linker.Lstat(p)
 	if err != nil {
 		return nil, fmt.Errorf("get a file stat (%s): %w", p, err)
 	}
@@ -39,14 +39,14 @@ func (ctrl *ControllerImpl) readLink(p string) (os.FileInfo, error) {
 		return finfo, nil
 	}
 	if finfo.Mode()&fs.ModeSymlink != 0 {
-		s, err := ctrl.linker.Readlink(p)
+		s, err := c.linker.Readlink(p)
 		if err != nil {
 			return nil, fmt.Errorf("read a symbolic link (%s): %w", p, err)
 		}
 		if filepath.IsAbs(s) {
-			return ctrl.readLink(s)
+			return c.readLink(s)
 		}
-		return ctrl.readLink(filepath.Join(filepath.Dir(p), s))
+		return c.readLink(filepath.Join(filepath.Dir(p), s))
 	}
 	return finfo, nil
 }

--- a/pkg/controller/which/lookpath_windows.go
+++ b/pkg/controller/which/lookpath_windows.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 )
 
-func (ctrl *ControllerImpl) listExts() []string {
-	x := ctrl.osenv.Getenv(`PATHEXT`)
+func (c *ControllerImpl) listExts() []string {
+	x := c.osenv.Getenv(`PATHEXT`)
 	if x == "" {
 		return []string{"", ".com", ".exe", ".bat", ".cmd"}
 	}
@@ -27,10 +27,10 @@ func (ctrl *ControllerImpl) listExts() []string {
 	return exts
 }
 
-func (ctrl *ControllerImpl) lookPath(envPath, exeName string) string {
-	binDir := filepath.Join(ctrl.rootDir, "bin")
-	batDir := filepath.Join(ctrl.rootDir, "bat")
-	exts := ctrl.listExts()
+func (c *ControllerImpl) lookPath(envPath, exeName string) string {
+	binDir := filepath.Join(c.rootDir, "bin")
+	batDir := filepath.Join(c.rootDir, "bat")
+	exts := c.listExts()
 	for _, p := range filepath.SplitList(envPath) {
 		if p == binDir || p == batDir {
 			continue

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -58,12 +58,12 @@ type MockVerifier struct {
 	err error
 }
 
-func (mock *MockVerifier) Verify(ctx context.Context, logE *logrus.Entry, rt *runtime.Runtime, file *download.File, cos *registry.Cosign, art *template.Artifact, verifiedFilePath string) error {
-	return mock.err
+func (v *MockVerifier) Verify(ctx context.Context, logE *logrus.Entry, rt *runtime.Runtime, file *download.File, cos *registry.Cosign, art *template.Artifact, verifiedFilePath string) error {
+	return v.err
 }
 
-func (verifier *VerifierImpl) Verify(ctx context.Context, logE *logrus.Entry, rt *runtime.Runtime, file *download.File, cos *registry.Cosign, art *template.Artifact, verifiedFilePath string) error { //nolint:cyclop,funlen
-	if verifier.disabled {
+func (v *VerifierImpl) Verify(ctx context.Context, logE *logrus.Entry, rt *runtime.Runtime, file *download.File, cos *registry.Cosign, art *template.Artifact, verifiedFilePath string) error { //nolint:cyclop,funlen
+	if v.disabled {
 		logE.Debug("verification with cosign is disabled")
 		return nil
 	}
@@ -73,63 +73,63 @@ func (verifier *VerifierImpl) Verify(ctx context.Context, logE *logrus.Entry, rt
 	}
 
 	if cos.Signature != nil {
-		sigFile, err := afero.TempFile(verifier.fs, "", "")
+		sigFile, err := afero.TempFile(v.fs, "", "")
 		if err != nil {
 			return fmt.Errorf("create a temporal file: %w", err)
 		}
-		defer verifier.fs.Remove(sigFile.Name()) //nolint:errcheck
+		defer v.fs.Remove(sigFile.Name()) //nolint:errcheck
 
 		f, err := download.ConvertDownloadedFileToFile(cos.Signature, file, rt, art)
 		if err != nil {
 			return err //nolint:wrapcheck
 		}
 
-		if err := verifier.downloadCosignFile(ctx, logE, f, sigFile); err != nil {
+		if err := v.downloadCosignFile(ctx, logE, f, sigFile); err != nil {
 			return fmt.Errorf("download a signature: %w", err)
 		}
 		opts = append(opts, "--signature", sigFile.Name())
 	}
 	if cos.Key != nil {
-		keyFile, err := afero.TempFile(verifier.fs, "", "")
+		keyFile, err := afero.TempFile(v.fs, "", "")
 		if err != nil {
 			return fmt.Errorf("create a temporal file: %w", err)
 		}
-		defer verifier.fs.Remove(keyFile.Name()) //nolint:errcheck
+		defer v.fs.Remove(keyFile.Name()) //nolint:errcheck
 
 		f, err := download.ConvertDownloadedFileToFile(cos.Key, file, rt, art)
 		if err != nil {
 			return err //nolint:wrapcheck
 		}
 
-		if err := verifier.downloadCosignFile(ctx, logE, f, keyFile); err != nil {
+		if err := v.downloadCosignFile(ctx, logE, f, keyFile); err != nil {
 			return fmt.Errorf("download a signature: %w", err)
 		}
 
 		opts = append(opts, "--key", keyFile.Name())
 	}
 	if cos.Certificate != nil {
-		certFile, err := afero.TempFile(verifier.fs, "", "")
+		certFile, err := afero.TempFile(v.fs, "", "")
 		if err != nil {
 			return fmt.Errorf("create a temporal file: %w", err)
 		}
-		defer verifier.fs.Remove(certFile.Name()) //nolint:errcheck
+		defer v.fs.Remove(certFile.Name()) //nolint:errcheck
 
 		f, err := download.ConvertDownloadedFileToFile(cos.Certificate, file, rt, art)
 		if err != nil {
 			return err //nolint:wrapcheck
 		}
 
-		if err := verifier.downloadCosignFile(ctx, logE, f, certFile); err != nil {
+		if err := v.downloadCosignFile(ctx, logE, f, certFile); err != nil {
 			return fmt.Errorf("download a signature: %w", err)
 		}
 
-		if err := verifier.downloadCosignFile(ctx, logE, f, certFile); err != nil {
+		if err := v.downloadCosignFile(ctx, logE, f, certFile); err != nil {
 			return fmt.Errorf("download a certificate: %w", err)
 		}
 		opts = append(opts, "--certificate", certFile.Name())
 	}
 
-	if err := verifier.verify(ctx, logE, &ParamVerify{
+	if err := v.verify(ctx, logE, &ParamVerify{
 		Opts:               opts,
 		CosignExperimental: cos.CosignExperimental,
 		Target:             verifiedFilePath,
@@ -156,11 +156,11 @@ type ParamVerify struct {
 
 var errVerify = errors.New("verify with Cosign")
 
-func (verifier *VerifierImpl) exec(ctx context.Context, args, envs []string) (string, error) {
+func (v *VerifierImpl) exec(ctx context.Context, args, envs []string) (string, error) {
 	// https://github.com/aquaproj/aqua/issues/1555
 	mutex.Lock()
 	defer mutex.Unlock()
-	out, _, err := verifier.executor.ExecWithEnvsAndGetCombinedOutput(ctx, verifier.cosignExePath, args, envs)
+	out, _, err := v.executor.ExecWithEnvsAndGetCombinedOutput(ctx, v.cosignExePath, args, envs)
 	return out, err //nolint:wrapcheck
 }
 
@@ -177,7 +177,7 @@ func wait(ctx context.Context, logE *logrus.Entry, retryCount int) error {
 	return nil
 }
 
-func (verifier *VerifierImpl) verify(ctx context.Context, logE *logrus.Entry, param *ParamVerify) error {
+func (v *VerifierImpl) verify(ctx context.Context, logE *logrus.Entry, param *ParamVerify) error {
 	envs := []string{}
 	if param.CosignExperimental {
 		envs = []string{"COSIGN_EXPERIMENTAL=1"}
@@ -185,7 +185,7 @@ func (verifier *VerifierImpl) verify(ctx context.Context, logE *logrus.Entry, pa
 	args := append([]string{"verify-blob"}, append(param.Opts, param.Target)...)
 	for i := 0; i < 5; i++ {
 		// https://github.com/aquaproj/aqua/issues/1554
-		if _, err := verifier.exec(ctx, args, envs); err == nil {
+		if _, err := v.exec(ctx, args, envs); err == nil {
 			return nil
 		}
 		if i == 4 { //nolint:gomnd
@@ -199,8 +199,8 @@ func (verifier *VerifierImpl) verify(ctx context.Context, logE *logrus.Entry, pa
 	return errVerify
 }
 
-func (verifier *VerifierImpl) downloadCosignFile(ctx context.Context, logE *logrus.Entry, f *download.File, tf io.Writer) error {
-	rc, _, err := verifier.downloader.GetReadCloser(ctx, logE, f)
+func (v *VerifierImpl) downloadCosignFile(ctx context.Context, logE *logrus.Entry, f *download.File, tf io.Writer) error {
+	rc, _, err := v.downloader.GetReadCloser(ctx, logE, f)
 	if err != nil {
 		return fmt.Errorf("get a readcloser: %w", err)
 	}

--- a/pkg/domain/cosign.go
+++ b/pkg/domain/cosign.go
@@ -1,1 +1,0 @@
-package domain

--- a/pkg/domain/github_content.go
+++ b/pkg/domain/github_content.go
@@ -22,27 +22,27 @@ type GitHubContentFile struct {
 	String     string
 }
 
-func (file *GitHubContentFile) Reader() io.Reader {
-	if file.String != "" {
-		return strings.NewReader(file.String)
+func (f *GitHubContentFile) Reader() io.Reader {
+	if f.String != "" {
+		return strings.NewReader(f.String)
 	}
-	return file.ReadCloser
+	return f.ReadCloser
 }
 
-func (file *GitHubContentFile) Byte() ([]byte, error) {
-	if file.String != "" {
-		return []byte(file.String), nil
+func (f *GitHubContentFile) Byte() ([]byte, error) {
+	if f.String != "" {
+		return []byte(f.String), nil
 	}
-	cnt, err := io.ReadAll(file.ReadCloser)
+	cnt, err := io.ReadAll(f.ReadCloser)
 	if err != nil {
 		return nil, fmt.Errorf("read the registry configuration file: %w", err)
 	}
 	return cnt, nil
 }
 
-func (file *GitHubContentFile) Close() error {
-	if file.ReadCloser != nil {
-		return file.ReadCloser.Close() //nolint:wrapcheck
+func (f *GitHubContentFile) Close() error {
+	if f.ReadCloser != nil {
+		return f.ReadCloser.Close() //nolint:wrapcheck
 	}
 	return nil
 }
@@ -56,6 +56,6 @@ type MockGitHubContentFileDownloader struct {
 	Err  error
 }
 
-func (mock *MockGitHubContentFileDownloader) DownloadGitHubContentFile(ctx context.Context, logE *logrus.Entry, param *GitHubContentFileParam) (*GitHubContentFile, error) {
-	return mock.File, mock.Err
+func (m *MockGitHubContentFileDownloader) DownloadGitHubContentFile(ctx context.Context, logE *logrus.Entry, param *GitHubContentFileParam) (*GitHubContentFile, error) {
+	return m.File, m.Err
 }

--- a/pkg/domain/which.go
+++ b/pkg/domain/which.go
@@ -1,1 +1,0 @@
-package domain

--- a/pkg/download/checksum.go
+++ b/pkg/download/checksum.go
@@ -43,8 +43,8 @@ type MockChecksumDownloader struct {
 	Err  error
 }
 
-func (chkDL *MockChecksumDownloader) DownloadChecksum(ctx context.Context, logE *logrus.Entry, rt *runtime.Runtime, pkg *config.Package) (io.ReadCloser, int64, error) {
-	return io.NopCloser(strings.NewReader(chkDL.Body)), chkDL.Code, chkDL.Err
+func (dl *MockChecksumDownloader) DownloadChecksum(ctx context.Context, logE *logrus.Entry, rt *runtime.Runtime, pkg *config.Package) (io.ReadCloser, int64, error) {
+	return io.NopCloser(strings.NewReader(dl.Body)), dl.Code, dl.Err
 }
 
 func (dl *ChecksumDownloaderImpl) DownloadChecksum(ctx context.Context, logE *logrus.Entry, rt *runtime.Runtime, pkg *config.Package) (io.ReadCloser, int64, error) {

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -50,14 +50,14 @@ type Mock struct {
 	Err  error
 }
 
-func (mock *Mock) GetReadCloser(ctx context.Context, logE *logrus.Entry, file *File) (io.ReadCloser, int64, error) {
-	return mock.RC, mock.Code, mock.Err
+func (m *Mock) GetReadCloser(ctx context.Context, logE *logrus.Entry, file *File) (io.ReadCloser, int64, error) {
+	return m.RC, m.Code, m.Err
 }
 
-func (downloader *Downloader) GetReadCloser(ctx context.Context, logE *logrus.Entry, file *File) (io.ReadCloser, int64, error) {
+func (dl *Downloader) GetReadCloser(ctx context.Context, logE *logrus.Entry, file *File) (io.ReadCloser, int64, error) {
 	switch file.Type {
 	case config.PkgInfoTypeGitHubRelease:
-		return downloader.ghRelease.DownloadGitHubRelease(ctx, logE, &domain.DownloadGitHubReleaseParam{ //nolint:wrapcheck
+		return dl.ghRelease.DownloadGitHubRelease(ctx, logE, &domain.DownloadGitHubReleaseParam{ //nolint:wrapcheck
 			RepoOwner: file.RepoOwner,
 			RepoName:  file.RepoName,
 			Version:   file.Version,
@@ -65,7 +65,7 @@ func (downloader *Downloader) GetReadCloser(ctx context.Context, logE *logrus.En
 			Private:   file.Private,
 		})
 	case config.PkgInfoTypeGitHubContent:
-		file, err := downloader.ghContent.DownloadGitHubContentFile(ctx, logE, &domain.GitHubContentFileParam{
+		file, err := dl.ghContent.DownloadGitHubContentFile(ctx, logE, &domain.GitHubContentFileParam{
 			RepoOwner: file.RepoOwner,
 			RepoName:  file.RepoName,
 			Ref:       file.Version,
@@ -80,9 +80,9 @@ func (downloader *Downloader) GetReadCloser(ctx context.Context, logE *logrus.En
 		}
 		return io.NopCloser(strings.NewReader(file.String)), 0, nil
 	case config.PkgInfoTypeGitHubArchive:
-		return downloader.getReadCloserFromGitHubArchive(ctx, file)
+		return dl.getReadCloserFromGitHubArchive(ctx, file)
 	case config.PkgInfoTypeHTTP:
-		rc, code, err := downloader.http.Download(ctx, file.URL)
+		rc, code, err := dl.http.Download(ctx, file.URL)
 		if err != nil {
 			return rc, code, fmt.Errorf("download a package: %w", logerr.WithFields(err, logrus.Fields{
 				"download_url": file.URL,

--- a/pkg/download/file.go
+++ b/pkg/download/file.go
@@ -23,69 +23,69 @@ func NewDownloadedFile(fs afero.Fs, body io.ReadCloser, pb *progressbar.Progress
 	}
 }
 
-func (file *DownloadedFile) Close() error {
-	return file.body.Close() //nolint:wrapcheck
+func (f *DownloadedFile) Close() error {
+	return f.body.Close() //nolint:wrapcheck
 }
 
-func (file *DownloadedFile) Remove() error {
-	if file.path == "" {
+func (f *DownloadedFile) Remove() error {
+	if f.path == "" {
 		return nil
 	}
-	return file.fs.Remove(file.path) //nolint:wrapcheck //nolint:errcheck
+	return f.fs.Remove(f.path) //nolint:wrapcheck //nolint:errcheck
 }
 
-func (file *DownloadedFile) GetPath() (string, error) {
-	if file.path != "" {
-		return file.path, nil
+func (f *DownloadedFile) GetPath() (string, error) {
+	if f.path != "" {
+		return f.path, nil
 	}
-	if err := file.copy(); err != nil {
+	if err := f.copy(); err != nil {
 		return "", err
 	}
-	return file.path, nil
+	return f.path, nil
 }
 
-func (file *DownloadedFile) Read() (io.ReadCloser, error) {
-	if file.path == "" {
-		if err := file.copy(); err != nil {
+func (f *DownloadedFile) Read() (io.ReadCloser, error) {
+	if f.path == "" {
+		if err := f.copy(); err != nil {
 			return nil, err
 		}
 	}
-	return file.read()
+	return f.read()
 }
 
-func (file *DownloadedFile) ReadLast() (io.ReadCloser, error) {
-	if file.path == "" {
-		return file.body, nil
+func (f *DownloadedFile) ReadLast() (io.ReadCloser, error) {
+	if f.path == "" {
+		return f.body, nil
 	}
-	return file.read()
+	return f.read()
 }
 
-func (file *DownloadedFile) read() (io.ReadCloser, error) {
-	f, err := file.fs.Open(file.path)
+func (f *DownloadedFile) read() (io.ReadCloser, error) {
+	file, err := f.fs.Open(f.path)
 	if err != nil {
 		return nil, fmt.Errorf("open a file: %w", err)
 	}
-	return f, nil
+	return file, nil
 }
 
-func (file *DownloadedFile) Wrap(w io.Writer) io.Writer {
-	if file.pb != nil && file.path == "" {
-		return io.MultiWriter(w, file.pb)
+func (f *DownloadedFile) Wrap(w io.Writer) io.Writer {
+	if f.pb != nil && f.path == "" {
+		return io.MultiWriter(w, f.pb)
 	}
 	return w
 }
 
-func (file *DownloadedFile) copy() error {
-	tmp, err := afero.TempFile(file.fs, "", "")
+func (f *DownloadedFile) copy() error {
+	tmp, err := afero.TempFile(f.fs, "", "")
 	if err != nil {
 		return fmt.Errorf("create a temporal file: %w", err)
 	}
-	file.path = tmp.Name()
+	f.path = tmp.Name()
 	var w io.Writer = tmp
-	if file.pb != nil {
-		w = io.MultiWriter(tmp, file.pb)
+	if f.pb != nil {
+		w = io.MultiWriter(tmp, f.pb)
 	}
-	if _, err := io.Copy(w, file.body); err != nil {
+	if _, err := io.Copy(w, f.body); err != nil {
 		return fmt.Errorf("copy a file: %w", err)
 	}
 	return nil

--- a/pkg/download/github_archive.go
+++ b/pkg/download/github_archive.go
@@ -8,19 +8,19 @@ import (
 	"github.com/aquaproj/aqua/v2/pkg/github"
 )
 
-func (downloader *Downloader) getReadCloserFromGitHubArchive(ctx context.Context, file *File) (io.ReadCloser, int64, error) {
-	if rc, length, err := downloader.http.Download(ctx, fmt.Sprintf("https://github.com/%s/%s/archive/refs/tags/%s.tar.gz", file.RepoOwner, file.RepoName, file.Version)); err == nil {
+func (dl *Downloader) getReadCloserFromGitHubArchive(ctx context.Context, file *File) (io.ReadCloser, int64, error) {
+	if rc, length, err := dl.http.Download(ctx, fmt.Sprintf("https://github.com/%s/%s/archive/refs/tags/%s.tar.gz", file.RepoOwner, file.RepoName, file.Version)); err == nil {
 		return rc, length, nil
 	}
 	// e.g. https://github.com/anqiansong/github-compare/archive/3972625c74bf6a5da00beb0e17e30e3e8d0c0950.zip
-	if rc, length, err := downloader.http.Download(ctx, fmt.Sprintf("https://github.com/%s/%s/archive/%s.tar.gz", file.RepoOwner, file.RepoName, file.Version)); err == nil {
+	if rc, length, err := dl.http.Download(ctx, fmt.Sprintf("https://github.com/%s/%s/archive/%s.tar.gz", file.RepoOwner, file.RepoName, file.Version)); err == nil {
 		return rc, length, nil
 	}
-	u, _, err := downloader.github.GetArchiveLink(ctx, file.RepoOwner, file.RepoName, github.Tarball, &github.RepositoryContentGetOptions{
+	u, _, err := dl.github.GetArchiveLink(ctx, file.RepoOwner, file.RepoName, github.Tarball, &github.RepositoryContentGetOptions{
 		Ref: file.Version,
 	}, true)
 	if err != nil {
 		return nil, 0, fmt.Errorf("git an archive link with GitHub API: %w", err)
 	}
-	return downloader.http.Download(ctx, u.String()) //nolint:wrapcheck
+	return dl.http.Download(ctx, u.String()) //nolint:wrapcheck
 }

--- a/pkg/download/http.go
+++ b/pkg/download/http.go
@@ -24,12 +24,12 @@ type httpDownloader struct {
 	client *http.Client
 }
 
-func (downloader *httpDownloader) Download(ctx context.Context, u string) (io.ReadCloser, int64, error) {
+func (dl *httpDownloader) Download(ctx context.Context, u string) (io.ReadCloser, int64, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
 		return nil, 0, fmt.Errorf("create a http request: %w", err)
 	}
-	resp, err := downloader.client.Do(req)
+	resp, err := dl.client.Do(req)
 	if err != nil {
 		return nil, 0, fmt.Errorf("send http request: %w", err)
 	}

--- a/pkg/exec/dmg.go
+++ b/pkg/exec/dmg.go
@@ -5,12 +5,12 @@ import (
 	"os/exec"
 )
 
-func (exe *Executor) HdiutilDetach(ctx context.Context, mountPath string) (int, error) {
-	cmd := exe.command(exec.CommandContext(ctx, "hdiutil", "detach", mountPath))
-	return exe.execAndOutputWhenFailure(cmd)
+func (e *Executor) HdiutilDetach(ctx context.Context, mountPath string) (int, error) {
+	cmd := e.command(exec.CommandContext(ctx, "hdiutil", "detach", mountPath))
+	return e.execAndOutputWhenFailure(cmd)
 }
 
-func (exe *Executor) HdiutilAttach(ctx context.Context, dmgPath, mountPoint string) (int, error) {
-	cmd := exe.command(exec.CommandContext(ctx, "hdiutil", "attach", dmgPath, "-mountpoint", mountPoint))
-	return exe.execAndOutputWhenFailure(cmd)
+func (e *Executor) HdiutilAttach(ctx context.Context, dmgPath, mountPoint string) (int, error) {
+	cmd := e.command(exec.CommandContext(ctx, "hdiutil", "attach", dmgPath, "-mountpoint", mountPoint))
+	return e.execAndOutputWhenFailure(cmd)
 }

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -24,34 +24,34 @@ func New() *Executor {
 	}
 }
 
-func (exe *Executor) ExecCommand(cmd *exec.Cmd) (int, error) {
-	return exe.exec(exe.command(cmd))
+func (e *Executor) ExecCommand(cmd *exec.Cmd) (int, error) {
+	return e.exec(e.command(cmd))
 }
 
-func (exe *Executor) Exec(ctx context.Context, exePath string, args ...string) (int, error) {
-	return exe.exec(exe.command(exec.CommandContext(ctx, exePath, args...)))
+func (e *Executor) Exec(ctx context.Context, exePath string, args ...string) (int, error) {
+	return e.exec(e.command(exec.CommandContext(ctx, exePath, args...)))
 }
 
-func (exe *Executor) ExecWithEnvs(ctx context.Context, exePath string, args, envs []string) (int, error) {
+func (e *Executor) ExecWithEnvs(ctx context.Context, exePath string, args, envs []string) (int, error) {
 	cmd := exec.CommandContext(ctx, exePath, args...)
 	cmd.Env = append(os.Environ(), envs...)
-	return exe.exec(exe.command(cmd))
+	return e.exec(e.command(cmd))
 }
 
-func (exe *Executor) ExecWithEnvsAndGetCombinedOutput(ctx context.Context, exePath string, args, envs []string) (string, int, error) {
-	cmd := exe.command(exec.CommandContext(ctx, exePath, args...))
+func (e *Executor) ExecWithEnvsAndGetCombinedOutput(ctx context.Context, exePath string, args, envs []string) (string, int, error) {
+	cmd := e.command(exec.CommandContext(ctx, exePath, args...))
 	cmd.Env = append(os.Environ(), envs...)
 	out := &bytes.Buffer{}
-	cmd.Stdout = io.MultiWriter(exe.stdout, out)
-	cmd.Stderr = io.MultiWriter(exe.stderr, out)
-	code, err := exe.exec(cmd)
+	cmd.Stdout = io.MultiWriter(e.stdout, out)
+	cmd.Stderr = io.MultiWriter(e.stderr, out)
+	code, err := e.exec(cmd)
 	return out.String(), code, err
 }
 
-func (exe *Executor) command(cmd *exec.Cmd) *exec.Cmd {
-	cmd.Stdin = exe.stdin
-	cmd.Stdout = exe.stdout
-	cmd.Stderr = exe.stderr
+func (e *Executor) command(cmd *exec.Cmd) *exec.Cmd {
+	cmd.Stdin = e.stdin
+	cmd.Stdout = e.stdout
+	cmd.Stderr = e.stderr
 	return cmd
 }
 
@@ -64,7 +64,7 @@ func setCancel(cmd *exec.Cmd) {
 	cmd.WaitDelay = waitDelay
 }
 
-func (exe *Executor) exec(cmd *exec.Cmd) (int, error) {
+func (e *Executor) exec(cmd *exec.Cmd) (int, error) {
 	setCancel(cmd)
 	if err := cmd.Run(); err != nil {
 		return cmd.ProcessState.ExitCode(), err
@@ -73,13 +73,13 @@ func (exe *Executor) exec(cmd *exec.Cmd) (int, error) {
 }
 
 // execAndOutputWhenFailure executes a command, and outputs the command output to standard error only when the command failed.
-func (exe *Executor) execAndOutputWhenFailure(cmd *exec.Cmd) (int, error) {
+func (e *Executor) execAndOutputWhenFailure(cmd *exec.Cmd) (int, error) {
 	buf := &bytes.Buffer{}
 	cmd.Stdout = buf
 	cmd.Stderr = buf
 	setCancel(cmd)
 	if err := cmd.Run(); err != nil {
-		fmt.Fprintln(exe.stderr, buf.String())
+		fmt.Fprintln(e.stderr, buf.String())
 		return cmd.ProcessState.ExitCode(), err
 	}
 	return 0, nil

--- a/pkg/exec/mock.go
+++ b/pkg/exec/mock.go
@@ -10,30 +10,30 @@ type Mock struct {
 	Output   string
 }
 
-func (exe *Mock) Exec(ctx context.Context, exePath string, args ...string) (int, error) {
-	return exe.ExitCode, exe.Err
+func (e *Mock) Exec(ctx context.Context, exePath string, args ...string) (int, error) {
+	return e.ExitCode, e.Err
 }
 
-func (exe *Mock) ExecWithEnvs(ctx context.Context, exePath string, args, envs []string) (int, error) {
-	return exe.ExitCode, exe.Err
+func (e *Mock) ExecWithEnvs(ctx context.Context, exePath string, args, envs []string) (int, error) {
+	return e.ExitCode, e.Err
 }
 
-func (exe *Mock) ExecWithEnvsAndGetCombinedOutput(ctx context.Context, exePath string, args, envs []string) (string, int, error) {
-	return exe.Output, exe.ExitCode, exe.Err
+func (e *Mock) ExecWithEnvsAndGetCombinedOutput(ctx context.Context, exePath string, args, envs []string) (string, int, error) {
+	return e.Output, e.ExitCode, e.Err
 }
 
-func (exe *Mock) ExecXSys(exePath string, args ...string) error {
-	return exe.Err
+func (e *Mock) ExecXSys(exePath string, args ...string) error {
+	return e.Err
 }
 
-func (exe *Mock) HdiutilDetach(ctx context.Context, mountPath string) (int, error) {
-	return exe.ExitCode, exe.Err
+func (e *Mock) HdiutilDetach(ctx context.Context, mountPath string) (int, error) {
+	return e.ExitCode, e.Err
 }
 
-func (exe *Mock) HdiutilAttach(ctx context.Context, dmgPath, mountPoint string) (int, error) {
-	return exe.ExitCode, exe.Err
+func (e *Mock) HdiutilAttach(ctx context.Context, dmgPath, mountPoint string) (int, error) {
+	return e.ExitCode, e.Err
 }
 
-func (exe *Mock) UnarchivePkg(ctx context.Context, pkgFilePath, dest string) (int, error) {
-	return exe.ExitCode, exe.Err
+func (e *Mock) UnarchivePkg(ctx context.Context, pkgFilePath, dest string) (int, error) {
+	return e.ExitCode, e.Err
 }

--- a/pkg/exec/pkg.go
+++ b/pkg/exec/pkg.go
@@ -5,6 +5,6 @@ import (
 	"os/exec"
 )
 
-func (exe *Executor) UnarchivePkg(ctx context.Context, pkgFilePath, dest string) (int, error) {
-	return exe.execAndOutputWhenFailure(exe.command(exec.CommandContext(ctx, "pkgutil", "--expand-full", pkgFilePath, dest)))
+func (e *Executor) UnarchivePkg(ctx context.Context, pkgFilePath, dest string) (int, error) {
+	return e.execAndOutputWhenFailure(e.command(exec.CommandContext(ctx, "pkgutil", "--expand-full", pkgFilePath, dest)))
 }

--- a/pkg/exec/xsys.go
+++ b/pkg/exec/xsys.go
@@ -10,6 +10,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func (exe *Executor) ExecXSys(exePath string, args ...string) error {
+func (e *Executor) ExecXSys(exePath string, args ...string) error {
 	return unix.Exec(exePath, append([]string{filepath.Base(exePath)}, args...), os.Environ()) //nolint:wrapcheck
 }

--- a/pkg/exec/xsys_windows.go
+++ b/pkg/exec/xsys_windows.go
@@ -7,6 +7,6 @@ import "errors"
 
 var errXSysNotSuppported = errors.New("Windows doesn't support AQUA_EXPERIMENTAL_X_SYS_EXEC")
 
-func (exe *Executor) ExecXSys(exePath string, args ...string) error {
+func (e *Executor) ExecXSys(exePath string, args ...string) error {
 	return errXSysNotSuppported
 }

--- a/pkg/github/mock.go
+++ b/pkg/github/mock.go
@@ -31,65 +31,65 @@ type MockRepositoriesService struct {
 	URL      *url.URL
 }
 
-func (svc *MockRepositoriesService) GetLatestRelease(ctx context.Context, repoOwner, repoName string) (*github.RepositoryRelease, *github.Response, error) {
-	if len(svc.Releases) == 0 {
+func (m *MockRepositoriesService) GetLatestRelease(ctx context.Context, repoOwner, repoName string) (*github.RepositoryRelease, *github.Response, error) {
+	if len(m.Releases) == 0 {
 		return nil, nil, errReleaseNotFound
 	}
-	return svc.Releases[0], nil, nil
+	return m.Releases[0], nil, nil
 }
 
-func (svc *MockRepositoriesService) GetContents(ctx context.Context, repoOwner, repoName, path string, opt *github.RepositoryContentGetOptions) (*github.RepositoryContent, []*github.RepositoryContent, *github.Response, error) {
-	if svc.Content == nil {
-		return svc.Content, nil, nil, errContentNotFound
+func (m *MockRepositoriesService) GetContents(ctx context.Context, repoOwner, repoName, path string, opt *github.RepositoryContentGetOptions) (*github.RepositoryContent, []*github.RepositoryContent, *github.Response, error) {
+	if m.Content == nil {
+		return m.Content, nil, nil, errContentNotFound
 	}
-	return svc.Content, nil, nil, nil
+	return m.Content, nil, nil, nil
 }
 
-func (svc *MockRepositoriesService) GetReleaseByTag(ctx context.Context, owner, repoName, version string) (*github.RepositoryRelease, *github.Response, error) {
-	if len(svc.Releases) == 0 {
+func (m *MockRepositoriesService) GetReleaseByTag(ctx context.Context, owner, repoName, version string) (*github.RepositoryRelease, *github.Response, error) {
+	if len(m.Releases) == 0 {
 		return nil, nil, errReleaseNotFound
 	}
-	return svc.Releases[0], nil, nil
+	return m.Releases[0], nil, nil
 }
 
-func (svc *MockRepositoriesService) DownloadReleaseAsset(ctx context.Context, owner, repoName string, assetID int64, httpClient *http.Client) (io.ReadCloser, string, error) {
-	if svc.Asset == "" {
+func (m *MockRepositoriesService) DownloadReleaseAsset(ctx context.Context, owner, repoName string, assetID int64, httpClient *http.Client) (io.ReadCloser, string, error) {
+	if m.Asset == "" {
 		return nil, "", errAssetNotFound
 	}
-	return io.NopCloser(strings.NewReader(svc.Asset)), "", nil
+	return io.NopCloser(strings.NewReader(m.Asset)), "", nil
 }
 
-func (svc *MockRepositoriesService) ListReleases(ctx context.Context, owner, repo string, opts *github.ListOptions) ([]*github.RepositoryRelease, *github.Response, error) {
-	if svc.Releases == nil {
+func (m *MockRepositoriesService) ListReleases(ctx context.Context, owner, repo string, opts *github.ListOptions) ([]*github.RepositoryRelease, *github.Response, error) {
+	if m.Releases == nil {
 		return nil, nil, errReleaseNotFound
 	}
-	return svc.Releases, nil, nil
+	return m.Releases, nil, nil
 }
 
-func (svc *MockRepositoriesService) ListTags(ctx context.Context, owner string, repo string, opts *github.ListOptions) ([]*github.RepositoryTag, *github.Response, error) {
-	if svc.Tags == nil {
+func (m *MockRepositoriesService) ListTags(ctx context.Context, owner string, repo string, opts *github.ListOptions) ([]*github.RepositoryTag, *github.Response, error) {
+	if m.Tags == nil {
 		return nil, nil, errTagNotFound
 	}
-	return svc.Tags, nil, nil
+	return m.Tags, nil, nil
 }
 
-func (svc *MockRepositoriesService) GetArchiveLink(ctx context.Context, owner, repo string, archiveformat github.ArchiveFormat, opts *github.RepositoryContentGetOptions, followRedirects bool) (*url.URL, *github.Response, error) {
-	if svc.URL == nil {
+func (m *MockRepositoriesService) GetArchiveLink(ctx context.Context, owner, repo string, archiveformat github.ArchiveFormat, opts *github.RepositoryContentGetOptions, followRedirects bool) (*url.URL, *github.Response, error) {
+	if m.URL == nil {
 		return nil, nil, errGetTar
 	}
-	return svc.URL, nil, nil
+	return m.URL, nil, nil
 }
 
-func (svc *MockRepositoriesService) Get(ctx context.Context, owner, repo string) (*github.Repository, *github.Response, error) {
-	if svc.Repo == nil {
+func (m *MockRepositoriesService) Get(ctx context.Context, owner, repo string) (*github.Repository, *github.Response, error) {
+	if m.Repo == nil {
 		return nil, nil, errGetRepo
 	}
-	return svc.Repo, nil, nil
+	return m.Repo, nil, nil
 }
 
-func (svc *MockRepositoriesService) ListReleaseAssets(ctx context.Context, owner, repo string, id int64, opts *github.ListOptions) ([]*github.ReleaseAsset, *github.Response, error) {
-	if svc.Assets == nil {
+func (m *MockRepositoriesService) ListReleaseAssets(ctx context.Context, owner, repo string, id int64, opts *github.ListOptions) ([]*github.ReleaseAsset, *github.Response, error) {
+	if m.Assets == nil {
 		return nil, nil, errListAssets
 	}
-	return svc.Assets, nil, nil
+	return m.Assets, nil, nil
 }

--- a/pkg/installpackage/aqua.go
+++ b/pkg/installpackage/aqua.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func (inst *InstallerImpl) InstallAqua(ctx context.Context, logE *logrus.Entry, version string) error { //nolint:funlen
+func (is *InstallerImpl) InstallAqua(ctx context.Context, logE *logrus.Entry, version string) error { //nolint:funlen
 	assetTemplate := `aqua_{{.OS}}_{{.Arch}}.tar.gz`
 	provTemplate := "multiple.intoto.jsonl"
 	disabled := false
@@ -79,13 +79,13 @@ func (inst *InstallerImpl) InstallAqua(ctx context.Context, logE *logrus.Entry, 
 		},
 	}
 
-	pkgInfo, err := pkg.PackageInfo.Override(logE, pkg.Package.Version, inst.runtime)
+	pkgInfo, err := pkg.PackageInfo.Override(logE, pkg.Package.Version, is.runtime)
 	if err != nil {
 		return fmt.Errorf("evaluate version constraints: %w", err)
 	}
 	pkg.PackageInfo = pkgInfo
 
-	if err := inst.InstallPackage(ctx, logE, &ParamInstallPackage{
+	if err := is.InstallPackage(ctx, logE, &ParamInstallPackage{
 		Checksums:     checksum.New(), // Check aqua's checksum but not update aqua-checksums.json
 		Pkg:           pkg,
 		DisablePolicy: true,
@@ -98,22 +98,22 @@ func (inst *InstallerImpl) InstallAqua(ctx context.Context, logE *logrus.Entry, 
 		"package_version": pkg.Package.Version,
 	})
 
-	exePath, err := pkg.GetExePath(inst.rootDir, &registry.File{
+	exePath, err := pkg.GetExePath(is.rootDir, &registry.File{
 		Name: "aqua",
-	}, inst.runtime)
+	}, is.runtime)
 	if err != nil {
 		return fmt.Errorf("get the executable file path: %w", err)
 	}
 
-	if inst.runtime.GOOS == "windows" {
-		return inst.Copy(filepath.Join(inst.rootDir, "bin", "aqua.exe"), exePath)
+	if is.runtime.GOOS == "windows" {
+		return is.Copy(filepath.Join(is.rootDir, "bin", "aqua.exe"), exePath)
 	}
 
 	// create a symbolic link
-	a, err := filepath.Rel(filepath.Join(inst.rootDir, "bin"), exePath)
+	a, err := filepath.Rel(filepath.Join(is.rootDir, "bin"), exePath)
 	if err != nil {
 		return fmt.Errorf("get a relative path: %w", err)
 	}
 
-	return inst.createLink(filepath.Join(inst.rootDir, "bin", "aqua"), a, logE)
+	return is.createLink(filepath.Join(is.rootDir, "bin", "aqua"), a, logE)
 }

--- a/pkg/installpackage/cargo.go
+++ b/pkg/installpackage/cargo.go
@@ -19,8 +19,8 @@ type MockCargoPackageInstaller struct {
 	Err error
 }
 
-func (mock *MockCargoPackageInstaller) Install(ctx context.Context, logE *logrus.Entry, crate, version, root string, opts *registry.Cargo) error {
-	return mock.Err
+func (m *MockCargoPackageInstaller) Install(ctx context.Context, logE *logrus.Entry, crate, version, root string, opts *registry.Cargo) error {
+	return m.Err
 }
 
 type CargoPackageInstallerImpl struct {
@@ -51,13 +51,13 @@ func getCargoArgs(version string, opts *registry.Cargo) []string {
 	return args
 }
 
-func (inst *CargoPackageInstallerImpl) Install(ctx context.Context, logE *logrus.Entry, crate, version, root string, opts *registry.Cargo) error {
+func (is *CargoPackageInstallerImpl) Install(ctx context.Context, logE *logrus.Entry, crate, version, root string, opts *registry.Cargo) error {
 	args := getCargoArgs(version, opts)
-	if _, err := inst.exec.Exec(ctx, "cargo", append(args, "--root", root, crate)...); err != nil {
+	if _, err := is.exec.Exec(ctx, "cargo", append(args, "--root", root, crate)...); err != nil {
 		// Clean up root
 		logE := logE.WithField("install_dir", root)
 		logE.Info("removing the install directory because the installation failed")
-		if err := inst.cleaner.RemoveAll(root); err != nil {
+		if err := is.cleaner.RemoveAll(root); err != nil {
 			logE.WithError(err).Error("aqua tried to remove the install directory because the installation failed, but it failed")
 		}
 		return fmt.Errorf("install a crate: %w", logerr.WithFields(err, logrus.Fields{
@@ -68,7 +68,7 @@ func (inst *CargoPackageInstallerImpl) Install(ctx context.Context, logE *logrus
 	return nil
 }
 
-func (inst *InstallerImpl) downloadCargo(ctx context.Context, logE *logrus.Entry, pkg *config.Package, root string) error {
+func (is *InstallerImpl) downloadCargo(ctx context.Context, logE *logrus.Entry, pkg *config.Package, root string) error {
 	cargoOpts := pkg.PackageInfo.Cargo
 	if cargoOpts != nil {
 		if cargoOpts.AllFeatures {
@@ -80,7 +80,7 @@ func (inst *InstallerImpl) downloadCargo(ctx context.Context, logE *logrus.Entry
 	logE.Info("Installing a crate")
 	crate := *pkg.PackageInfo.Crate
 	version := pkg.Package.Version
-	if err := inst.cargoPackageInstaller.Install(ctx, logE, crate, version, root, cargoOpts); err != nil {
+	if err := is.cargoPackageInstaller.Install(ctx, logE, crate, version, root, cargoOpts); err != nil {
 		return fmt.Errorf("cargo install: %w", err)
 	}
 	return nil

--- a/pkg/installpackage/copy.go
+++ b/pkg/installpackage/copy.go
@@ -10,13 +10,13 @@ const (
 	executableFilePermission os.FileMode = 0o755
 )
 
-func (inst *InstallerImpl) Copy(dest, src string) error {
-	dst, err := inst.fs.OpenFile(dest, os.O_RDWR|os.O_CREATE|os.O_TRUNC, executableFilePermission) //nolint:nosnakecase
+func (is *InstallerImpl) Copy(dest, src string) error {
+	dst, err := is.fs.OpenFile(dest, os.O_RDWR|os.O_CREATE|os.O_TRUNC, executableFilePermission) //nolint:nosnakecase
 	if err != nil {
 		return fmt.Errorf("create a file: %w", err)
 	}
 	defer dst.Close()
-	srcFile, err := inst.fs.Open(src)
+	srcFile, err := is.fs.Open(src)
 	if err != nil {
 		return fmt.Errorf("open a file: %w", err)
 	}

--- a/pkg/installpackage/cosign.go
+++ b/pkg/installpackage/cosign.go
@@ -18,9 +18,9 @@ type Cosign struct {
 	mutex     *sync.Mutex
 }
 
-func (cos *Cosign) installCosign(ctx context.Context, logE *logrus.Entry, version string) error {
-	cos.mutex.Lock()
-	defer cos.mutex.Unlock()
+func (c *Cosign) installCosign(ctx context.Context, logE *logrus.Entry, version string) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	assetTemplate := `cosign-{{.OS}}-{{.Arch}}`
 	pkg := &config.Package{
 		Package: &aqua.Package{
@@ -40,13 +40,13 @@ func (cos *Cosign) installCosign(ctx context.Context, logE *logrus.Entry, versio
 		},
 	}
 
-	chksum := cosign.Checksums()[cos.installer.runtime.Env()]
+	chksum := cosign.Checksums()[c.installer.runtime.Env()]
 
-	pkgInfo, err := pkg.PackageInfo.Override(logE, pkg.Package.Version, cos.installer.runtime)
+	pkgInfo, err := pkg.PackageInfo.Override(logE, pkg.Package.Version, c.installer.runtime)
 	if err != nil {
 		return fmt.Errorf("evaluate version constraints: %w", err)
 	}
-	supported, err := pkgInfo.CheckSupported(cos.installer.runtime, cos.installer.runtime.Env())
+	supported, err := pkgInfo.CheckSupported(c.installer.runtime, c.installer.runtime.Env())
 	if err != nil {
 		return fmt.Errorf("check if cosign is supported: %w", err)
 	}
@@ -57,7 +57,7 @@ func (cos *Cosign) installCosign(ctx context.Context, logE *logrus.Entry, versio
 
 	pkg.PackageInfo = pkgInfo
 
-	if err := cos.installer.InstallPackage(ctx, logE, &ParamInstallPackage{
+	if err := c.installer.InstallPackage(ctx, logE, &ParamInstallPackage{
 		Checksums: checksum.New(), // Check cosign's checksum but not update aqua-checksums.json
 		Pkg:       pkg,
 		Checksum: &checksum.Checksum{

--- a/pkg/installpackage/find_src.go
+++ b/pkg/installpackage/find_src.go
@@ -14,7 +14,7 @@ func containPath(p string) bool {
 	return true
 }
 
-func (inst *InstallerImpl) walk(pkgPath string) ([]string, error) {
+func (is *InstallerImpl) walk(pkgPath string) ([]string, error) {
 	paths := []string{}
 	if err := filepath.WalkDir(pkgPath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {

--- a/pkg/installpackage/go_build.go
+++ b/pkg/installpackage/go_build.go
@@ -14,8 +14,8 @@ type MockGoBuildInstaller struct {
 	Err error
 }
 
-func (mock *MockGoBuildInstaller) Install(ctx context.Context, exePath, exeDir, src string) error {
-	return mock.Err
+func (m *MockGoBuildInstaller) Install(ctx context.Context, exePath, exeDir, src string) error {
+	return m.Err
 }
 
 type GoBuildInstallerImpl struct {

--- a/pkg/installpackage/go_build.go
+++ b/pkg/installpackage/go_build.go
@@ -28,10 +28,10 @@ func NewGoBuildInstallerImpl(exec Executor) *GoBuildInstallerImpl {
 	}
 }
 
-func (inst *GoBuildInstallerImpl) Install(ctx context.Context, exePath, exeDir, src string) error {
+func (is *GoBuildInstallerImpl) Install(ctx context.Context, exePath, exeDir, src string) error {
 	cmd := exec.CommandContext(ctx, "go", "build", "-o", exePath, src)
 	cmd.Dir = exeDir
-	if _, err := inst.exec.ExecCommand(cmd); err != nil {
+	if _, err := is.exec.ExecCommand(cmd); err != nil {
 		return fmt.Errorf("build a go package: %w", err)
 	}
 	return nil

--- a/pkg/installpackage/go_install.go
+++ b/pkg/installpackage/go_install.go
@@ -16,8 +16,8 @@ type MockGoInstallInstaller struct {
 	Err error
 }
 
-func (mock *MockGoInstallInstaller) Install(ctx context.Context, path, gobin string) error {
-	return mock.Err
+func (m *MockGoInstallInstaller) Install(ctx context.Context, path, gobin string) error {
+	return m.Err
 }
 
 type GoInstallInstallerImpl struct {

--- a/pkg/installpackage/go_install.go
+++ b/pkg/installpackage/go_install.go
@@ -30,15 +30,15 @@ func NewGoInstallInstallerImpl(exec Executor) *GoInstallInstallerImpl {
 	}
 }
 
-func (inst *GoInstallInstallerImpl) Install(ctx context.Context, path, gobin string) error {
-	_, err := inst.exec.ExecWithEnvs(ctx, "go", []string{"install", path}, []string{fmt.Sprintf("GOBIN=%s", gobin)})
+func (is *GoInstallInstallerImpl) Install(ctx context.Context, path, gobin string) error {
+	_, err := is.exec.ExecWithEnvs(ctx, "go", []string{"install", path}, []string{fmt.Sprintf("GOBIN=%s", gobin)})
 	if err != nil {
 		return fmt.Errorf("install a go package: %w", err)
 	}
 	return nil
 }
 
-func (inst *InstallerImpl) downloadGoInstall(ctx context.Context, pkg *config.Package, dest string, logE *logrus.Entry) error {
+func (is *InstallerImpl) downloadGoInstall(ctx context.Context, pkg *config.Package, dest string, logE *logrus.Entry) error {
 	p, err := pkg.RenderPath()
 	if err != nil {
 		return fmt.Errorf("render Go Module Path: %w", err)
@@ -48,7 +48,7 @@ func (inst *InstallerImpl) downloadGoInstall(ctx context.Context, pkg *config.Pa
 		"gobin":           dest,
 		"go_package_path": goPkgPath,
 	}).Info("Installing a Go tool")
-	if err := inst.goInstallInstaller.Install(ctx, goPkgPath, dest); err != nil {
+	if err := is.goInstallInstaller.Install(ctx, goPkgPath, dest); err != nil {
 		return fmt.Errorf("build Go tool: %w", err)
 	}
 	return nil

--- a/pkg/installpackage/mock_internal_test.go
+++ b/pkg/installpackage/mock_internal_test.go
@@ -7,6 +7,6 @@ type MockChecksumCalculator struct {
 	Err      error
 }
 
-func (calc *MockChecksumCalculator) Calculate(fs afero.Fs, filename, algorithm string) (string, error) {
-	return calc.Checksum, calc.Err
+func (m *MockChecksumCalculator) Calculate(fs afero.Fs, filename, algorithm string) (string, error) {
+	return m.Checksum, m.Err
 }

--- a/pkg/installpackage/proxy.go
+++ b/pkg/installpackage/proxy.go
@@ -25,8 +25,8 @@ func ProxyChecksums() map[string]string {
 	}
 }
 
-func (inst *InstallerImpl) InstallProxy(ctx context.Context, logE *logrus.Entry) error { //nolint:funlen
-	if isWindows(inst.runtime.GOOS) {
+func (is *InstallerImpl) InstallProxy(ctx context.Context, logE *logrus.Entry) error { //nolint:funlen
+	if isWindows(is.runtime.GOOS) {
 		return nil
 	}
 	proxyAssetTemplate := `aqua-proxy_{{.OS}}_{{.Arch}}.tar.gz`
@@ -54,21 +54,21 @@ func (inst *InstallerImpl) InstallProxy(ctx context.Context, logE *logrus.Entry)
 	})
 
 	logE.Debug("install the proxy")
-	assetName, err := pkg.RenderAsset(inst.runtime)
+	assetName, err := pkg.RenderAsset(is.runtime)
 	if err != nil {
 		return err //nolint:wrapcheck
 	}
 
-	pkgPath, err := pkg.GetPkgPath(inst.rootDir, inst.runtime)
+	pkgPath, err := pkg.GetPkgPath(is.rootDir, is.runtime)
 	if err != nil {
 		return err //nolint:wrapcheck
 	}
 	logE.Debug("check if aqua-proxy is already installed")
-	finfo, err := inst.fs.Stat(pkgPath)
+	finfo, err := is.fs.Stat(pkgPath)
 	if err != nil {
 		// file doesn't exist
-		chksum := ProxyChecksums()[inst.runtime.Env()]
-		if err := inst.downloadWithRetry(ctx, logE, &DownloadParam{
+		chksum := ProxyChecksums()[is.runtime.Env()]
+		if err := is.downloadWithRetry(ctx, logE, &DownloadParam{
 			Package: pkg,
 			Dest:    pkgPath,
 			Asset:   assetName,
@@ -87,10 +87,10 @@ func (inst *InstallerImpl) InstallProxy(ctx context.Context, logE *logrus.Entry)
 
 	// create a symbolic link
 	binName := proxyName
-	a, err := filepath.Rel(inst.rootDir, filepath.Join(pkgPath, binName))
+	a, err := filepath.Rel(is.rootDir, filepath.Join(pkgPath, binName))
 	if err != nil {
 		return fmt.Errorf("get a relative path: %w", err)
 	}
 
-	return inst.createLink(filepath.Join(inst.rootDir, proxyName), a, logE)
+	return is.createLink(filepath.Join(is.rootDir, proxyName), a, logE)
 }

--- a/pkg/installpackage/slsa_verifier.go
+++ b/pkg/installpackage/slsa_verifier.go
@@ -18,9 +18,9 @@ type SLSAVerifier struct {
 	mutex     *sync.Mutex
 }
 
-func (slsaVerifier *SLSAVerifier) installSLSAVerifier(ctx context.Context, logE *logrus.Entry, version string) error {
-	slsaVerifier.mutex.Lock()
-	defer slsaVerifier.mutex.Unlock()
+func (sv *SLSAVerifier) installSLSAVerifier(ctx context.Context, logE *logrus.Entry, version string) error {
+	sv.mutex.Lock()
+	defer sv.mutex.Unlock()
 	assetTemplate := `slsa-verifier-{{.OS}}-{{.Arch}}`
 	pkg := &config.Package{
 		Package: &aqua.Package{
@@ -35,13 +35,13 @@ func (slsaVerifier *SLSAVerifier) installSLSAVerifier(ctx context.Context, logE 
 		},
 	}
 
-	chksum := slsa.Checksums()[slsaVerifier.installer.runtime.Env()]
+	chksum := slsa.Checksums()[sv.installer.runtime.Env()]
 
-	pkgInfo, err := pkg.PackageInfo.Override(logE, pkg.Package.Version, slsaVerifier.installer.runtime)
+	pkgInfo, err := pkg.PackageInfo.Override(logE, pkg.Package.Version, sv.installer.runtime)
 	if err != nil {
 		return fmt.Errorf("evaluate version constraints: %w", err)
 	}
-	supported, err := pkgInfo.CheckSupported(slsaVerifier.installer.runtime, slsaVerifier.installer.runtime.Env())
+	supported, err := pkgInfo.CheckSupported(sv.installer.runtime, sv.installer.runtime.Env())
 	if err != nil {
 		return fmt.Errorf("check if slsa-verifier is supported: %w", err)
 	}
@@ -52,7 +52,7 @@ func (slsaVerifier *SLSAVerifier) installSLSAVerifier(ctx context.Context, logE 
 
 	pkg.PackageInfo = pkgInfo
 
-	if err := slsaVerifier.installer.InstallPackage(ctx, logE, &ParamInstallPackage{
+	if err := sv.installer.InstallPackage(ctx, logE, &ParamInstallPackage{
 		Checksums: checksum.New(), // Check slsa-verifier's checksum but not update aqua-checksums.json
 		Pkg:       pkg,
 		Checksum: &checksum.Checksum{

--- a/pkg/installpackage/validate.go
+++ b/pkg/installpackage/validate.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func (inst *InstallerImpl) validatePackage(logE *logrus.Entry, param *ParamInstallPackage) error {
+func (is *InstallerImpl) validatePackage(logE *logrus.Entry, param *ParamInstallPackage) error {
 	pkg := param.Pkg
 	pkgInfo := pkg.PackageInfo
 
@@ -24,7 +24,7 @@ func (inst *InstallerImpl) validatePackage(logE *logrus.Entry, param *ParamInsta
 	}
 
 	if !param.DisablePolicy {
-		if err := inst.policyChecker.ValidatePackage(logE, param.Pkg, param.PolicyConfigs); err != nil {
+		if err := is.policyChecker.ValidatePackage(logE, param.Pkg, param.PolicyConfigs); err != nil {
 			return err //nolint:wrapcheck
 		}
 	}

--- a/pkg/installpackage/verify_cosign.go
+++ b/pkg/installpackage/verify_cosign.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func (inst *InstallerImpl) verifyWithCosign(ctx context.Context, logE *logrus.Entry, bodyFile *download.DownloadedFile, param *DownloadParam) error {
+func (is *InstallerImpl) verifyWithCosign(ctx context.Context, logE *logrus.Entry, bodyFile *download.DownloadedFile, param *DownloadParam) error {
 	ppkg := param.Package
 
 	cos := ppkg.PackageInfo.Cosign
@@ -17,16 +17,16 @@ func (inst *InstallerImpl) verifyWithCosign(ctx context.Context, logE *logrus.En
 		return nil
 	}
 
-	art := ppkg.GetTemplateArtifact(inst.runtime, param.Asset)
+	art := ppkg.GetTemplateArtifact(is.runtime, param.Asset)
 	logE.Info("verify a package with Cosign")
-	if err := inst.cosignInstaller.installCosign(ctx, logE, cosign.Version); err != nil {
+	if err := is.cosignInstaller.installCosign(ctx, logE, cosign.Version); err != nil {
 		return fmt.Errorf("install sigstore/cosign: %w", err)
 	}
 	tempFilePath, err := bodyFile.GetPath()
 	if err != nil {
 		return fmt.Errorf("get a temporal file path: %w", err)
 	}
-	if err := inst.cosign.Verify(ctx, logE, inst.runtime, &download.File{
+	if err := is.cosign.Verify(ctx, logE, is.runtime, &download.File{
 		RepoOwner: ppkg.PackageInfo.RepoOwner,
 		RepoName:  ppkg.PackageInfo.RepoName,
 		Version:   ppkg.Package.Version,

--- a/pkg/installpackage/verify_slsa.go
+++ b/pkg/installpackage/verify_slsa.go
@@ -9,23 +9,23 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func (inst *InstallerImpl) verifyWithSLSA(ctx context.Context, logE *logrus.Entry, bodyFile *download.DownloadedFile, param *DownloadParam) error {
+func (is *InstallerImpl) verifyWithSLSA(ctx context.Context, logE *logrus.Entry, bodyFile *download.DownloadedFile, param *DownloadParam) error {
 	ppkg := param.Package
 	pkgInfo := param.Package.PackageInfo
 	sp := ppkg.PackageInfo.SLSAProvenance
 	if !sp.GetEnabled() {
 		return nil
 	}
-	art := ppkg.GetTemplateArtifact(inst.runtime, param.Asset)
+	art := ppkg.GetTemplateArtifact(is.runtime, param.Asset)
 	logE.Info("verify a package with slsa-verifier")
-	if err := inst.slsaVerifierInstaller.installSLSAVerifier(ctx, logE, slsa.Version); err != nil {
+	if err := is.slsaVerifierInstaller.installSLSAVerifier(ctx, logE, slsa.Version); err != nil {
 		return fmt.Errorf("install slsa-verifier: %w", err)
 	}
 	tempFilePath, err := bodyFile.GetPath()
 	if err != nil {
 		return fmt.Errorf("get a temporal file path: %w", err)
 	}
-	if err := inst.slsaVerifier.Verify(ctx, logE, inst.runtime, sp, art, &download.File{
+	if err := is.slsaVerifier.Verify(ctx, logE, is.runtime, sp, art, &download.File{
 		RepoOwner: ppkg.PackageInfo.RepoOwner,
 		RepoName:  ppkg.PackageInfo.RepoName,
 		Version:   ppkg.Package.Version,

--- a/pkg/installpackage/wait_exe.go
+++ b/pkg/installpackage/wait_exe.go
@@ -10,10 +10,10 @@ import (
 	"github.com/suzuki-shunsuke/logrus-error/logerr"
 )
 
-func (inst *InstallerImpl) WaitExe(ctx context.Context, logE *logrus.Entry, exePath string) error {
+func (is *InstallerImpl) WaitExe(ctx context.Context, logE *logrus.Entry, exePath string) error {
 	for i := 0; i < 10; i++ {
 		logE.Debug("check if exec file exists")
-		if fi, err := inst.fs.Stat(exePath); err == nil {
+		if fi, err := is.fs.Stat(exePath); err == nil {
 			if util.IsOwnerExecutable(fi.Mode()) {
 				break
 			}

--- a/pkg/policy/checker.go
+++ b/pkg/policy/checker.go
@@ -21,15 +21,3 @@ func NewChecker(param *config.Param) *Checker {
 		disabled: param.DisablePolicy,
 	}
 }
-
-// type Checker interface {
-// 	ValidatePackage(pkg *config.Package, policies []*Config) error
-// }
-//
-// type MockChecker struct {
-// 	Err error
-// }
-//
-// func (pc *MockChecker) ValidatePackage(pkg *config.Package, policies []*Config) error {
-// 	return pc.Err
-// }

--- a/pkg/policy/config.go
+++ b/pkg/policy/config.go
@@ -43,9 +43,9 @@ type Package struct {
 	Registry     *Registry `yaml:"-" json:"-"`
 }
 
-func (cfg *Config) Init() error {
-	m := make(map[string]*Registry, len(cfg.YAML.Registries))
-	for _, rgst := range cfg.YAML.Registries {
+func (c *Config) Init() error {
+	m := make(map[string]*Registry, len(c.YAML.Registries))
+	for _, rgst := range c.YAML.Registries {
 		if rgst.Type == registryTypeStandard {
 			rgst.Type = "github_content"
 			rgst.RepoOwner = "aquaproj"
@@ -61,11 +61,11 @@ func (cfg *Config) Init() error {
 			if rgst.Path == "" {
 				return errLocalPathIsRequired
 			}
-			rgst.Path = util.Abs(filepath.Dir(cfg.Path), rgst.Path)
+			rgst.Path = util.Abs(filepath.Dir(c.Path), rgst.Path)
 		}
 		m[rgst.Name] = rgst
 	}
-	for _, pkg := range cfg.YAML.Packages {
+	for _, pkg := range c.YAML.Packages {
 		if pkg.RegistryName == "" {
 			pkg.RegistryName = registryTypeStandard
 		}

--- a/pkg/policy/config_finder.go
+++ b/pkg/policy/config_finder.go
@@ -17,8 +17,8 @@ type MockConfigFinder struct {
 	err  error
 }
 
-func (finder *MockConfigFinder) Find(policyFilePath, wd string) (string, error) {
-	return finder.path, finder.err
+func (f *MockConfigFinder) Find(policyFilePath, wd string) (string, error) {
+	return f.path, f.err
 }
 
 type ConfigFinderImpl struct {
@@ -40,9 +40,9 @@ func configFileNames() []string {
 	}
 }
 
-func (finder *ConfigFinderImpl) Find(policyFilePath, wd string) (string, error) {
+func (f *ConfigFinderImpl) Find(policyFilePath, wd string) (string, error) {
 	if policyFilePath != "" {
-		f, err := afero.Exists(finder.fs, policyFilePath)
+		f, err := afero.Exists(f.fs, policyFilePath)
 		if err != nil {
 			return "", fmt.Errorf("check if a policy file exists: %w", err)
 		}
@@ -55,13 +55,13 @@ func (finder *ConfigFinderImpl) Find(policyFilePath, wd string) (string, error) 
 		return filepath.Join(wd, policyFilePath), nil
 	}
 
-	gitDir := findconfig.Find(wd, finder.exist, ".git")
+	gitDir := findconfig.Find(wd, f.exist, ".git")
 	if gitDir == "" {
 		return "", nil
 	}
 	gitParentDir := filepath.Dir(gitDir)
 	for _, p := range configFileNames() {
-		if _, err := finder.fs.Stat(filepath.Join(gitParentDir, p)); err != nil {
+		if _, err := f.fs.Stat(filepath.Join(gitParentDir, p)); err != nil {
 			continue
 		}
 		return filepath.Join(gitParentDir, p), nil
@@ -69,8 +69,8 @@ func (finder *ConfigFinderImpl) Find(policyFilePath, wd string) (string, error) 
 	return "", nil
 }
 
-func (finder *ConfigFinderImpl) exist(p string) bool {
-	b, err := afero.IsDir(finder.fs, p)
+func (f *ConfigFinderImpl) exist(p string) bool {
+	b, err := afero.IsDir(f.fs, p)
 	if err != nil {
 		return false
 	}

--- a/pkg/policy/config_reader.go
+++ b/pkg/policy/config_reader.go
@@ -28,18 +28,18 @@ type MockConfigReader struct {
 	Err  error
 }
 
-func (reader *MockConfigReader) Read(files []string) ([]*Config, error) {
-	return reader.Cfgs, reader.Err
+func (r *MockConfigReader) Read(files []string) ([]*Config, error) {
+	return r.Cfgs, r.Err
 }
 
-func (reader *ConfigReaderImpl) Read(files []string) ([]*Config, error) {
+func (r *ConfigReaderImpl) Read(files []string) ([]*Config, error) {
 	policyCfgs := make([]*Config, len(files))
 	for i, cfgFilePath := range files {
 		policyCfg := &Config{
 			Path: cfgFilePath,
 			YAML: &ConfigYAML{},
 		}
-		if err := reader.read(policyCfg); err != nil {
+		if err := r.read(policyCfg); err != nil {
 			return nil, fmt.Errorf("read the policy config file: %w", err)
 		}
 		policyCfgs[i] = policyCfg
@@ -47,19 +47,19 @@ func (reader *ConfigReaderImpl) Read(files []string) ([]*Config, error) {
 	return policyCfgs, nil
 }
 
-func (reader *ConfigReaderImpl) ReadFile(file string) (*Config, error) {
+func (r *ConfigReaderImpl) ReadFile(file string) (*Config, error) {
 	policyCfg := &Config{
 		Path: file,
 		YAML: &ConfigYAML{},
 	}
-	if err := reader.read(policyCfg); err != nil {
+	if err := r.read(policyCfg); err != nil {
 		return nil, fmt.Errorf("read the policy config file: %w", err)
 	}
 	return policyCfg, nil
 }
 
-func (reader *ConfigReaderImpl) read(cfg *Config) error {
-	file, err := reader.fs.Open(cfg.Path)
+func (r *ConfigReaderImpl) read(cfg *Config) error {
+	file, err := r.fs.Open(cfg.Path)
 	if err != nil {
 		return err //nolint:wrapcheck
 	}

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -25,20 +25,20 @@ type MockValidator struct {
 	Err error
 }
 
-func (validator *MockValidator) Allow(p string) error {
-	return validator.Err
+func (v *MockValidator) Allow(p string) error {
+	return v.Err
 }
 
-func (validator *MockValidator) Deny(p string) error {
-	return validator.Err
+func (v *MockValidator) Deny(p string) error {
+	return v.Err
 }
 
-func (validator *MockValidator) Validate(p string) error {
-	return validator.Err
+func (v *MockValidator) Validate(p string) error {
+	return v.Err
 }
 
-func (validator *MockValidator) Warn(logE *logrus.Entry, policyFilePath string, updated bool) error {
-	return validator.Err
+func (v *MockValidator) Warn(logE *logrus.Entry, policyFilePath string, updated bool) error {
+	return v.Err
 }
 
 type ValidatorImpl struct {
@@ -71,11 +71,11 @@ func normalizePath(p string) string {
 	return p
 }
 
-func (validator *ValidatorImpl) Allow(p string) error {
+func (v *ValidatorImpl) Allow(p string) error {
 	normalizedP := normalizePath(p)
-	policyPath := filepath.Join(validator.rootDir, "policies", normalizedP)
+	policyPath := filepath.Join(v.rootDir, "policies", normalizedP)
 	dir := filepath.Dir(policyPath)
-	fs := validator.fs
+	fs := v.fs
 	if err := util.MkdirAll(fs, dir); err != nil {
 		return fmt.Errorf("create a directory where the policy file is stored: %w", err)
 	}
@@ -92,7 +92,7 @@ func (validator *ValidatorImpl) Allow(p string) error {
 	if _, err := io.Copy(f2, f1); err != nil {
 		return fmt.Errorf("copy a policy file: %w", err)
 	}
-	warnFilePath := filepath.Join(validator.rootDir, "policy-warnings", normalizedP)
+	warnFilePath := filepath.Join(v.rootDir, "policy-warnings", normalizedP)
 	warnExist, err := afero.Exists(fs, warnFilePath)
 	if err != nil {
 		return fmt.Errorf("check if a warn file exists: %w", err)
@@ -106,10 +106,10 @@ func (validator *ValidatorImpl) Allow(p string) error {
 	return nil
 }
 
-func (validator *ValidatorImpl) Deny(p string) error {
+func (v *ValidatorImpl) Deny(p string) error {
 	normalizedP := normalizePath(p)
-	policyPath := filepath.Join(validator.rootDir, "policies", normalizedP)
-	fs := validator.fs
+	policyPath := filepath.Join(v.rootDir, "policies", normalizedP)
+	fs := v.fs
 
 	// remove allow file
 	policyExist, err := afero.Exists(fs, policyPath)
@@ -122,12 +122,12 @@ func (validator *ValidatorImpl) Deny(p string) error {
 		}
 	}
 
-	warnFilePath := filepath.Join(validator.rootDir, "policy-warnings", normalizedP)
+	warnFilePath := filepath.Join(v.rootDir, "policy-warnings", normalizedP)
 	warnFileDir := filepath.Dir(warnFilePath)
 	if err := util.MkdirAll(fs, warnFileDir); err != nil {
 		return fmt.Errorf("create a directory where the policy warning file is stored: %w", err)
 	}
-	warnFile, err := validator.fs.Create(warnFilePath)
+	warnFile, err := v.fs.Create(warnFilePath)
 	if err != nil {
 		return fmt.Errorf("create a policy warn file: %w", err)
 	}
@@ -135,9 +135,9 @@ func (validator *ValidatorImpl) Deny(p string) error {
 	return nil
 }
 
-func (validator *ValidatorImpl) Warn(logE *logrus.Entry, policyFilePath string, updated bool) error {
-	warnFilePath := filepath.Join(validator.rootDir, "policy-warnings", normalizePath(policyFilePath))
-	fs := validator.fs
+func (v *ValidatorImpl) Warn(logE *logrus.Entry, policyFilePath string, updated bool) error {
+	warnFilePath := filepath.Join(v.rootDir, "policy-warnings", normalizePath(policyFilePath))
+	fs := v.fs
 	f, err := afero.Exists(fs, warnFilePath)
 	if err != nil {
 		return fmt.Errorf("find a policy warning file: %w", err)
@@ -164,23 +164,23 @@ $ aqua policy deny "%s"
 	return nil
 }
 
-func (validator *ValidatorImpl) Validate(p string) error {
-	if validator.disabled {
+func (v *ValidatorImpl) Validate(p string) error {
+	if v.disabled {
 		return nil
 	}
-	policyPath := filepath.Join(validator.rootDir, "policies", normalizePath(p))
-	f, err := afero.Exists(validator.fs, policyPath)
+	policyPath := filepath.Join(v.rootDir, "policies", normalizePath(p))
+	f, err := afero.Exists(v.fs, policyPath)
 	if err != nil {
 		return fmt.Errorf("find a policy file: %w", err)
 	}
 	if !f {
 		return errPolicyNotFound
 	}
-	b1, err := afero.ReadFile(validator.fs, p)
+	b1, err := afero.ReadFile(v.fs, p)
 	if err != nil {
 		return fmt.Errorf("read a policy file: %w", err)
 	}
-	b2, err := afero.ReadFile(validator.fs, policyPath)
+	b2, err := afero.ReadFile(v.fs, policyPath)
 	if err != nil {
 		return fmt.Errorf("read a policy file: %w", err)
 	}

--- a/pkg/slsa/exec.go
+++ b/pkg/slsa/exec.go
@@ -42,8 +42,8 @@ type MockExecutor struct {
 	Err error
 }
 
-func (mock *MockExecutor) Verify(ctx context.Context, logE *logrus.Entry, param *ParamVerify, provenancePath string) error {
-	return mock.Err
+func (m *MockExecutor) Verify(ctx context.Context, logE *logrus.Entry, param *ParamVerify, provenancePath string) error {
+	return m.Err
 }
 
 func wait(ctx context.Context, logE *logrus.Entry, retryCount int) error {
@@ -59,17 +59,17 @@ func wait(ctx context.Context, logE *logrus.Entry, retryCount int) error {
 	return nil
 }
 
-func (exe *ExecutorImpl) exec(ctx context.Context, args []string) (string, error) {
+func (e *ExecutorImpl) exec(ctx context.Context, args []string) (string, error) {
 	mutex := cosign.GetMutex()
 	mutex.Lock()
 	defer mutex.Unlock()
-	out, _, err := exe.executor.ExecWithEnvsAndGetCombinedOutput(ctx, exe.verifierExePath, args, nil)
+	out, _, err := e.executor.ExecWithEnvsAndGetCombinedOutput(ctx, e.verifierExePath, args, nil)
 	return out, err //nolint:wrapcheck
 }
 
 var errVerify = errors.New("verify with slsa-verifier")
 
-func (exe *ExecutorImpl) Verify(ctx context.Context, logE *logrus.Entry, param *ParamVerify, provenancePath string) error {
+func (e *ExecutorImpl) Verify(ctx context.Context, logE *logrus.Entry, param *ParamVerify, provenancePath string) error {
 	args := []string{
 		"verify-artifact",
 		param.ArtifactPath,
@@ -81,7 +81,7 @@ func (exe *ExecutorImpl) Verify(ctx context.Context, logE *logrus.Entry, param *
 		param.SourceTag,
 	}
 	for i := 0; i < 5; i++ {
-		if _, err := exe.exec(ctx, args); err == nil {
+		if _, err := e.exec(ctx, args); err == nil {
 			return nil
 		}
 		if i == 4 { //nolint:gomnd

--- a/pkg/unarchive/decompressor.go
+++ b/pkg/unarchive/decompressor.go
@@ -18,12 +18,12 @@ type Decompressor struct {
 	dest         string
 }
 
-func (decompressor *Decompressor) Unarchive(ctx context.Context, logE *logrus.Entry, src *File) error {
-	dest := decompressor.dest
-	if err := util.MkdirAll(decompressor.fs, filepath.Dir(dest)); err != nil {
+func (d *Decompressor) Unarchive(ctx context.Context, logE *logrus.Entry, src *File) error {
+	dest := d.dest
+	if err := util.MkdirAll(d.fs, filepath.Dir(dest)); err != nil {
 		return fmt.Errorf("create a directory (%s): %w", dest, err)
 	}
-	f, err := decompressor.fs.OpenFile(dest, os.O_RDWR|os.O_CREATE, filePermission) //nolint:nosnakecase
+	f, err := d.fs.OpenFile(dest, os.O_RDWR|os.O_CREATE, filePermission) //nolint:nosnakecase
 	if err != nil {
 		return fmt.Errorf("open the file (%s): %w", dest, err)
 	}
@@ -34,5 +34,5 @@ func (decompressor *Decompressor) Unarchive(ctx context.Context, logE *logrus.En
 		return fmt.Errorf("read a file: %w", err)
 	}
 
-	return decompressor.decompressor.Decompress(body, src.Body.Wrap(f)) //nolint:wrapcheck
+	return d.decompressor.Decompress(body, src.Body.Wrap(f)) //nolint:wrapcheck
 }

--- a/pkg/unarchive/pkg.go
+++ b/pkg/unarchive/pkg.go
@@ -18,8 +18,8 @@ type pkgUnarchiver struct {
 	fs       afero.Fs
 }
 
-func (unarchiver *pkgUnarchiver) Unarchive(ctx context.Context, logE *logrus.Entry, src *File) error {
-	if err := util.MkdirAll(unarchiver.fs, filepath.Dir(unarchiver.dest)); err != nil {
+func (u *pkgUnarchiver) Unarchive(ctx context.Context, logE *logrus.Entry, src *File) error {
+	if err := util.MkdirAll(u.fs, filepath.Dir(u.dest)); err != nil {
 		return fmt.Errorf("create a directory: %w", err)
 	}
 
@@ -28,7 +28,7 @@ func (unarchiver *pkgUnarchiver) Unarchive(ctx context.Context, logE *logrus.Ent
 		return fmt.Errorf("get a temporal file path: %w", err)
 	}
 
-	if _, err := unarchiver.executor.UnarchivePkg(ctx, tempFilePath, unarchiver.dest); err != nil {
+	if _, err := u.executor.UnarchivePkg(ctx, tempFilePath, u.dest); err != nil {
 		return fmt.Errorf("unarchive a pkg format file: %w", err)
 	}
 

--- a/pkg/unarchive/raw.go
+++ b/pkg/unarchive/raw.go
@@ -17,12 +17,12 @@ type rawUnarchiver struct {
 	fs   afero.Fs
 }
 
-func (unarchiver *rawUnarchiver) Unarchive(ctx context.Context, logE *logrus.Entry, src *File) error {
-	dest := unarchiver.dest
-	if err := util.MkdirAll(unarchiver.fs, filepath.Dir(dest)); err != nil {
+func (u *rawUnarchiver) Unarchive(ctx context.Context, logE *logrus.Entry, src *File) error {
+	dest := u.dest
+	if err := util.MkdirAll(u.fs, filepath.Dir(dest)); err != nil {
 		return fmt.Errorf("create a directory (%s): %w", dest, err)
 	}
-	f, err := unarchiver.fs.OpenFile(dest, os.O_RDWR|os.O_CREATE, filePermission) //nolint:nosnakecase
+	f, err := u.fs.OpenFile(dest, os.O_RDWR|os.O_CREATE, filePermission) //nolint:nosnakecase
 	if err != nil {
 		return fmt.Errorf("open the file (%s): %w", dest, err)
 	}

--- a/pkg/unarchive/unarchiver.go
+++ b/pkg/unarchive/unarchiver.go
@@ -15,10 +15,10 @@ type unarchiverWithUnarchiver struct {
 	fs         afero.Fs
 }
 
-func (unarchiver *unarchiverWithUnarchiver) Unarchive(ctx context.Context, logE *logrus.Entry, src *File) error {
+func (u *unarchiverWithUnarchiver) Unarchive(ctx context.Context, logE *logrus.Entry, src *File) error {
 	tempFilePath, err := src.Body.GetPath()
 	if err != nil {
 		return fmt.Errorf("get a temporal file: %w", err)
 	}
-	return unarchiver.unarchiver.Unarchive(tempFilePath, unarchiver.dest) //nolint:wrapcheck
+	return u.unarchiver.Unarchive(tempFilePath, u.dest) //nolint:wrapcheck
 }


### PR DESCRIPTION
- https://github.com/aquaproj/aqua/issues/2188

```console
$ git grep -E 'func \([^ ]{3}'           
pkg/checksum/checksum.go:func (*Calculator) Calculate(fs afero.Fs, filename, algorithm string) (string, error) {
pkg/config/aqua/config.go:func (Registries) JSONSchema() *jsonschema.Schema {
pkg/config/registry/package_info.go:func (Replacements) JSONSchema() *jsonschema.Schema {
pkg/config/registry/package_info.go:func (SupportedEnvs) JSONSchema() *jsonschema.Schema {
```