### PR TITLE
chore: dark/light mode logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 <p align="center" width="100%">
-<img src="./logo/aqua_horizontal.svg" width="400">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="./logo/aqua_horizontal_white.svg">
+    <img src="./logo/aqua_horizontal.svg" alt="logo" width="400">
+  </picture>
 </p>
 
 #

--- a/logo/README.md
+++ b/logo/README.md
@@ -1,7 +1,10 @@
 # About Logo
 
 <p align="center" width="100%">
-<img src="./aqua_horizontal.svg" width="400">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="./aqua_horizontal_white.svg">
+    <img src="./aqua_horizontal.svg" alt="logo" width="400">
+  </picture>
 </p>
 
 [#403](https://github.com/aquaproj/aqua/pull/403)

--- a/logo/aqua_horizontal_white.svg
+++ b/logo/aqua_horizontal_white.svg
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="253.76715mm"
+   height="72.513992mm"
+   viewBox="0 0 899.17494 256.93934"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="aqua_horizontal.svg"
+   inkscape:export-filename="aqua_horizontal_white.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.70710678"
+     inkscape:cx="603.0438"
+     inkscape:cy="54.852311"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1535"
+     inkscape:window-height="876"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:snap-center="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:object-nodes="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:object-paths="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-68.912959,-520.58562)">
+    <g
+       id="g4405"
+       transform="matrix(3.2797622,0,0,3.2797622,-1259.3761,-1459.208)">
+      <g
+         transform="translate(85.714286,-64.285715)"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:66.9817px;line-height:125%;font-family:Sawasdee;-inkscape-font-specification:Sawasdee;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         id="flowRoot4610-7-7-3-7-0">
+        <path
+           d="m 417.31852,713.39634 h 19.68895 l -9.87718,-23.71179 z m 20.86636,2.94353 h -22.27272 l -6.21412,15.14283 h -3.13977 l 20.4739,-49.41862 20.53931,49.41862 h -3.13977 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Sawasdee;-inkscape-font-specification:Sawasdee;fill:#ffffff;fill-opacity:1"
+           id="path3922"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 484.82351,714.8681 h 3.82659 l 5.20024,6.14871 q 4.9713,-6.01788 4.9713,-13.90001 0,-5.98518 -2.91083,-11.02189 -2.91083,-5.06941 -7.98024,-8.01295 -5.03671,-2.94353 -10.98919,-2.94353 -5.95247,0 -10.98918,2.94353 -5.004,2.94354 -7.91483,8.01295 -2.91083,5.03671 -2.91083,11.02189 0,4.448 1.70071,8.50354 1.73342,4.05553 4.64424,6.99906 2.91083,2.94353 6.96636,4.70965 4.05553,1.73342 8.50353,1.73342 8.47083,0 14.88119,-5.82166 z m 17.75931,16.6146 h -3.99012 l -4.9713,-5.91977 q -3.36871,3.04165 -7.65318,4.74236 -4.28448,1.668 -9.02684,1.668 -5.0367,0 -9.61553,-1.96235 -4.57883,-1.96236 -7.88213,-5.29836 -3.30329,-3.336 -5.26565,-7.91483 -1.96235,-4.61153 -1.96235,-9.68095 0,-5.06941 1.96235,-9.68095 1.96236,-4.61153 5.26565,-7.94753 3.3033,-3.336 7.88213,-5.29836 4.57883,-1.96235 9.61553,-1.96235 5.03671,0 9.61554,1.96235 4.61153,1.96236 7.91483,5.29836 3.336,3.336 5.29836,7.94753 1.96235,4.61154 1.96235,9.68095 0,9.28848 -6.05059,16.25484 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Sawasdee;-inkscape-font-specification:Sawasdee;fill:#ffffff;fill-opacity:1"
+           id="path3924"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 511.21717,682.65278 h 2.94353 v 30.31838 q 0,4.4153 1.99506,8.14377 1.99506,3.72847 5.29836,5.85436 3.336,2.09318 7.1953,2.09318 3.8593,0 7.12989,-2.09318 3.30329,-2.12589 5.23294,-5.82165 1.96236,-3.72848 1.96236,-8.17648 v -30.31838 h 2.94353 v 30.31838 q 0,5.13483 -2.32212,9.51742 -2.28941,4.34988 -6.31224,6.93365 -3.99012,2.55106 -8.73248,2.55106 -4.74235,0 -8.73247,-2.55106 -3.99012,-2.58377 -6.31224,-6.93365 -2.28942,-4.38259 -2.28942,-9.51742 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Sawasdee;-inkscape-font-specification:Sawasdee;fill:#ffffff;fill-opacity:1"
+           id="path3926"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 563.18686,713.39634 h 19.68896 l -9.87719,-23.71179 z m 20.86637,2.94353 h -22.27272 l -6.21412,15.14283 h -3.13977 l 20.4739,-49.41862 20.53931,49.41862 h -3.13977 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Sawasdee;-inkscape-font-specification:Sawasdee;fill:#ffffff;fill-opacity:1"
+           id="path3928"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         id="g4804-5-0-1-6"
+         transform="matrix(0.68128257,0,0,0.68128257,288.64722,220.70483)">
+        <g
+           transform="translate(56.428568,458.57143)"
+           id="g4375-4-4-2-1-9">
+          <path
+             style="opacity:0.187;fill:#00ffff;fill-rule:evenodd;stroke:none;stroke-width:0.650281px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 213.93426,132.25502 v 57.49512 l -49.79223,28.74756 -49.79224,-28.74756 v -57.49512 l 49.79224,-28.74756 z"
+             id="path3341-3-36-2-7-7-7-5-9-2"
+             inkscape:connector-curvature="0" />
+          <path
+             style="fill:#00ffff;stroke:none"
+             d="m 182.3354,155.43228 a 17.857143,17.857143 0 0 1 -17.85714,17.85714 17.857143,17.857143 0 0 1 -17.85715,-17.85714 17.857143,17.857143 0 0 1 17.85715,-17.85714 17.857143,17.857143 0 0 1 17.85714,17.85714 z"
+             id="path3358-0-0-5-8-4-8-0-1"
+             inkscape:connector-curvature="0" />
+          <path
+             style="fill:#00ffff;stroke:none"
+             d="m 154.09072,181.90416 a 3.6200135,3.6200135 0 0 1 -3.62002,3.62001 3.6200135,3.6200135 0 0 1 -3.62001,-3.62001 3.6200135,3.6200135 0 0 1 3.62001,-3.62001 3.6200135,3.6200135 0 0 1 3.62002,3.62001 z"
+             id="path3358-6-62-2-9-4-4-9-8-7"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="translate(143.44614,478.14025)"
+           id="g4375-4-2-3-5-9-7">
+          <path
+             style="opacity:0.187;fill:#00ffff;fill-rule:evenodd;stroke:none;stroke-width:0.650281px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 113.77167,120.27549 v 42.31655 L 77.124458,183.75031 40.47725,162.59204 V 120.27549 L 77.124458,99.11721 Z"
+             id="path3341-3-36-2-7-7-0-0-0-8-9"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Display README logo optimized for dark/light backgrounds.
This is particularly helpful for transparent PNG/SVG images.

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to

If appreciated, I can make the same changes to main `README.md`  of the project.