### PR TITLE
feat(remove): support selecting packages with fuzzy finder

### DIFF
--- a/pkg/cli/remove.go
+++ b/pkg/cli/remove.go
@@ -21,6 +21,10 @@ func (r *Runner) newRemoveCommand() *cli.Command {
 				Aliases: []string{"a"},
 				Usage:   "uninstall all packages",
 			},
+			&cli.BoolFlag{
+				Name:  "i",
+				Usage: "Select packages with a Fuzzy Finder",
+			},
 		},
 		Description: `Uninstall packages.
 

--- a/pkg/controller/generate/cargo.go
+++ b/pkg/controller/generate/cargo.go
@@ -4,10 +4,11 @@ import (
 	"context"
 
 	"github.com/aquaproj/aqua/v2/pkg/config"
+	"github.com/aquaproj/aqua/v2/pkg/fuzzyfinder"
 	"github.com/sirupsen/logrus"
 )
 
-func (c *Controller) getCargoVersion(ctx context.Context, logE *logrus.Entry, param *config.Param, pkg *FindingPackage) string {
+func (c *Controller) getCargoVersion(ctx context.Context, logE *logrus.Entry, param *config.Param, pkg *fuzzyfinder.Package) string {
 	pkgInfo := pkg.PackageInfo
 	if param.SelectVersion {
 		versionStrings, err := c.cargoClient.ListVersions(ctx, pkgInfo.Crate)
@@ -15,7 +16,7 @@ func (c *Controller) getCargoVersion(ctx context.Context, logE *logrus.Entry, pa
 			logE.WithError(err).Warn("list versions")
 			return ""
 		}
-		versions := convertStringsToVersions(versionStrings)
+		versions := fuzzyfinder.ConvertStringsToVersions(versionStrings)
 
 		idx, err := c.versionSelector.Find(versions, false)
 		if err != nil {

--- a/pkg/controller/generate/controller.go
+++ b/pkg/controller/generate/controller.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aquaproj/aqua/v2/pkg/cargo"
 	reader "github.com/aquaproj/aqua/v2/pkg/config-reader"
 	"github.com/aquaproj/aqua/v2/pkg/controller/generate/output"
+	"github.com/aquaproj/aqua/v2/pkg/fuzzyfinder"
 	rgst "github.com/aquaproj/aqua/v2/pkg/install-registry"
 	"github.com/spf13/afero"
 )
@@ -22,6 +23,14 @@ type Controller struct {
 	fs                afero.Fs
 	outputter         Outputter
 	cargoClient       cargo.Client
+}
+
+type VersionSelector interface {
+	Find(versions []*fuzzyfinder.Version, hasPreview bool) (int, error)
+}
+
+type FuzzyFinder interface {
+	Find(pkgs []*fuzzyfinder.Package) ([]int, error)
 }
 
 func New(configFinder ConfigFinder, configReader reader.ConfigReader, registInstaller rgst.Installer, gh RepositoriesService, fs afero.Fs, fuzzyFinder FuzzyFinder, versionSelector VersionSelector, cargoClient cargo.Client) *Controller {

--- a/pkg/controller/generate/generate_test.go
+++ b/pkg/controller/generate/generate_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aquaproj/aqua/v2/pkg/cosign"
 	"github.com/aquaproj/aqua/v2/pkg/domain"
 	"github.com/aquaproj/aqua/v2/pkg/download"
+	"github.com/aquaproj/aqua/v2/pkg/fuzzyfinder"
 	"github.com/aquaproj/aqua/v2/pkg/github"
 	registry "github.com/aquaproj/aqua/v2/pkg/install-registry"
 	"github.com/aquaproj/aqua/v2/pkg/runtime"
@@ -403,8 +404,8 @@ packages:
 			downloader := download.NewGitHubContentFileDownloader(gh, download.NewHTTPDownloader(http.DefaultClient))
 			registryInstaller := registry.New(d.param, downloader, fs, d.rt, &cosign.MockVerifier{}, &slsa.MockVerifier{})
 			configReader := reader.New(fs, d.param)
-			fuzzyFinder := generate.NewMockFuzzyFinder(d.idxs, d.fuzzyFinderErr)
-			versionSelector := generate.NewMockVersionSelector(d.idx, d.versionSelectorErr)
+			fuzzyFinder := fuzzyfinder.NewMock(d.idxs, d.fuzzyFinderErr)
+			versionSelector := fuzzyfinder.NewMockVersionSelector(d.idx, d.versionSelectorErr)
 			cargoClient := &cargo.MockClient{}
 			ctrl := generate.New(configFinder, configReader, registryInstaller, gh, fs, fuzzyFinder, versionSelector, cargoClient)
 			if err := ctrl.Generate(ctx, logE, d.param, d.args...); err != nil {

--- a/pkg/controller/generate/github_release.go
+++ b/pkg/controller/generate/github_release.go
@@ -7,6 +7,7 @@ import (
 	"github.com/antonmedv/expr/vm"
 	"github.com/aquaproj/aqua/v2/pkg/config/registry"
 	"github.com/aquaproj/aqua/v2/pkg/expr"
+	"github.com/aquaproj/aqua/v2/pkg/fuzzyfinder"
 	"github.com/aquaproj/aqua/v2/pkg/github"
 	"github.com/sirupsen/logrus"
 	"github.com/suzuki-shunsuke/logrus-error/logerr"
@@ -14,9 +15,9 @@ import (
 
 func (c *Controller) selectVersionFromReleases(ctx context.Context, logE *logrus.Entry, pkgInfo *registry.PackageInfo) string {
 	releases := c.listReleases(ctx, logE, pkgInfo)
-	versions := make([]*Version, len(releases))
+	versions := make([]*fuzzyfinder.Version, len(releases))
 	for i, release := range releases {
-		versions[i] = &Version{
+		versions[i] = &fuzzyfinder.Version{
 			Name:        release.GetName(),
 			Version:     release.GetTagName(),
 			Description: release.GetBody(),

--- a/pkg/controller/generate/github_tag.go
+++ b/pkg/controller/generate/github_tag.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aquaproj/aqua/v2/pkg/config"
 	"github.com/aquaproj/aqua/v2/pkg/config/registry"
+	"github.com/aquaproj/aqua/v2/pkg/fuzzyfinder"
 	"github.com/aquaproj/aqua/v2/pkg/github"
 	"github.com/sirupsen/logrus"
 	"github.com/suzuki-shunsuke/logrus-error/logerr"
@@ -94,9 +95,9 @@ func (c *Controller) listAndGetTagNameFromTag(ctx context.Context, logE *logrus.
 
 func (c *Controller) selectVersionFromGitHubTag(ctx context.Context, logE *logrus.Entry, pkgInfo *registry.PackageInfo) string {
 	tags := c.listTags(ctx, logE, pkgInfo)
-	versions := make([]*Version, len(tags))
+	versions := make([]*fuzzyfinder.Version, len(tags))
 	for i, tag := range tags {
-		versions[i] = &Version{
+		versions[i] = &fuzzyfinder.Version{
 			Version: tag.GetName(),
 		}
 	}

--- a/pkg/controller/generate/read_pkg_file.go
+++ b/pkg/controller/generate/read_pkg_file.go
@@ -9,11 +9,12 @@ import (
 
 	"github.com/aquaproj/aqua/v2/pkg/config"
 	"github.com/aquaproj/aqua/v2/pkg/config/aqua"
+	"github.com/aquaproj/aqua/v2/pkg/fuzzyfinder"
 	"github.com/sirupsen/logrus"
 	"github.com/suzuki-shunsuke/logrus-error/logerr"
 )
 
-func (c *Controller) readGeneratedPkgsFromFile(ctx context.Context, logE *logrus.Entry, param *config.Param, outputPkgs []*aqua.Package, m map[string]*FindingPackage) ([]*aqua.Package, error) {
+func (c *Controller) readGeneratedPkgsFromFile(ctx context.Context, logE *logrus.Entry, param *config.Param, outputPkgs []*aqua.Package, m map[string]*fuzzyfinder.Package) ([]*aqua.Package, error) {
 	var file io.Reader
 	if param.File == "-" {
 		file = c.stdin

--- a/pkg/controller/remove/controller.go
+++ b/pkg/controller/remove/controller.go
@@ -3,6 +3,7 @@ package remove
 import (
 	"github.com/aquaproj/aqua/v2/pkg/config"
 	reader "github.com/aquaproj/aqua/v2/pkg/config-reader"
+	"github.com/aquaproj/aqua/v2/pkg/fuzzyfinder"
 	rgst "github.com/aquaproj/aqua/v2/pkg/install-registry"
 	"github.com/aquaproj/aqua/v2/pkg/runtime"
 	"github.com/spf13/afero"
@@ -15,9 +16,14 @@ type Controller struct {
 	configFinder      ConfigFinder
 	configReader      reader.ConfigReader
 	registryInstaller rgst.Installer
+	fuzzyFinder       FuzzyFinder
 }
 
-func New(param *config.Param, fs afero.Fs, rt *runtime.Runtime, configFinder ConfigFinder, configReader reader.ConfigReader, registryInstaller rgst.Installer) *Controller {
+type FuzzyFinder interface {
+	Find(pkgs []*fuzzyfinder.Package) ([]int, error)
+}
+
+func New(param *config.Param, fs afero.Fs, rt *runtime.Runtime, configFinder ConfigFinder, configReader reader.ConfigReader, registryInstaller rgst.Installer, fuzzyFinder FuzzyFinder) *Controller {
 	return &Controller{
 		rootDir:           param.RootDir,
 		fs:                fs,
@@ -25,6 +31,7 @@ func New(param *config.Param, fs afero.Fs, rt *runtime.Runtime, configFinder Con
 		configFinder:      configFinder,
 		configReader:      configReader,
 		registryInstaller: registryInstaller,
+		fuzzyFinder:       fuzzyFinder,
 	}
 }
 

--- a/pkg/controller/wire.go
+++ b/pkg/controller/wire.go
@@ -33,6 +33,7 @@ import (
 	"github.com/aquaproj/aqua/v2/pkg/domain"
 	"github.com/aquaproj/aqua/v2/pkg/download"
 	"github.com/aquaproj/aqua/v2/pkg/exec"
+	"github.com/aquaproj/aqua/v2/pkg/fuzzyfinder"
 	"github.com/aquaproj/aqua/v2/pkg/github"
 	registry "github.com/aquaproj/aqua/v2/pkg/install-registry"
 	"github.com/aquaproj/aqua/v2/pkg/installpackage"
@@ -164,8 +165,14 @@ func InitializeGenerateCommandController(ctx context.Context, param *config.Para
 			wire.Bind(new(reader.ConfigReader), new(*reader.ConfigReaderImpl)),
 		),
 		afero.NewOsFs,
-		generate.NewFuzzyFinder,
-		generate.NewVersionSelector,
+		wire.NewSet(
+			fuzzyfinder.New,
+			wire.Bind(new(generate.FuzzyFinder), new(*fuzzyfinder.Finder)),
+		),
+		wire.NewSet(
+			fuzzyfinder.NewVersionSelector,
+			wire.Bind(new(generate.VersionSelector), new(*fuzzyfinder.VersionSelector)),
+		),
 		download.NewHTTPDownloader,
 		wire.NewSet(
 			cosign.NewVerifier,
@@ -804,6 +811,10 @@ func InitializeRemoveCommandController(ctx context.Context, param *config.Param,
 		wire.NewSet(
 			slsa.NewExecutor,
 			wire.Bind(new(slsa.Executor), new(*slsa.ExecutorImpl)),
+		),
+		wire.NewSet(
+			fuzzyfinder.New,
+			wire.Bind(new(remove.FuzzyFinder), new(*fuzzyfinder.Finder)),
 		),
 	)
 	return &remove.Controller{}

--- a/pkg/controller/wire_gen.go
+++ b/pkg/controller/wire_gen.go
@@ -32,6 +32,7 @@ import (
 	"github.com/aquaproj/aqua/v2/pkg/cosign"
 	"github.com/aquaproj/aqua/v2/pkg/download"
 	"github.com/aquaproj/aqua/v2/pkg/exec"
+	"github.com/aquaproj/aqua/v2/pkg/fuzzyfinder"
 	"github.com/aquaproj/aqua/v2/pkg/github"
 	"github.com/aquaproj/aqua/v2/pkg/install-registry"
 	"github.com/aquaproj/aqua/v2/pkg/installpackage"
@@ -100,10 +101,10 @@ func InitializeGenerateCommandController(ctx context.Context, param *config.Para
 	executorImpl := slsa.NewExecutor(executor, param)
 	slsaVerifierImpl := slsa.New(downloader, fs, executorImpl)
 	installerImpl := registry.New(param, gitHubContentFileDownloader, fs, rt, verifierImpl, slsaVerifierImpl)
-	fuzzyFinder := generate.NewFuzzyFinder()
-	versionSelector := generate.NewVersionSelector()
+	fuzzyfinderFinder := fuzzyfinder.New()
+	versionSelector := fuzzyfinder.NewVersionSelector()
 	clientImpl := cargo.NewClientImpl(httpClient)
-	controller := generate.New(configFinder, configReaderImpl, installerImpl, repositoriesService, fs, fuzzyFinder, versionSelector, clientImpl)
+	controller := generate.New(configFinder, configReaderImpl, installerImpl, repositoriesService, fs, fuzzyfinderFinder, versionSelector, clientImpl)
 	return controller
 }
 
@@ -297,6 +298,7 @@ func InitializeRemoveCommandController(ctx context.Context, param *config.Param,
 	executorImpl := slsa.NewExecutor(executor, param)
 	slsaVerifierImpl := slsa.New(downloader, fs, executorImpl)
 	installerImpl := registry.New(param, gitHubContentFileDownloader, fs, rt, verifierImpl, slsaVerifierImpl)
-	controller := remove.New(param, fs, rt, configFinder, configReaderImpl, installerImpl)
+	fuzzyfinderFinder := fuzzyfinder.New()
+	controller := remove.New(param, fs, rt, configFinder, configReaderImpl, installerImpl, fuzzyfinderFinder)
 	return controller
 }

--- a/pkg/fuzzyfinder/const.go
+++ b/pkg/fuzzyfinder/const.go
@@ -1,0 +1,3 @@
+package fuzzyfinder
+
+const registryStandard = "standard"

--- a/pkg/fuzzyfinder/finder_internal_test.go
+++ b/pkg/fuzzyfinder/finder_internal_test.go
@@ -1,4 +1,4 @@
-package generate
+package fuzzyfinder
 
 import (
 	"testing"
@@ -10,12 +10,12 @@ func Test_find(t *testing.T) { //nolint:funlen
 	t.Parallel()
 	data := []struct {
 		name string
-		pkg  *FindingPackage
+		pkg  *Package
 		exp  string
 	}{
 		{
 			name: "normal",
-			pkg: &FindingPackage{
+			pkg: &Package{
 				PackageInfo: &registry.PackageInfo{
 					RepoOwner: "suzuki-shunsuke",
 					RepoName:  "ci-info",
@@ -26,7 +26,7 @@ func Test_find(t *testing.T) { //nolint:funlen
 		},
 		{
 			name: "search words",
-			pkg: &FindingPackage{
+			pkg: &Package{
 				PackageInfo: &registry.PackageInfo{
 					RepoOwner:   "suzuki-shunsuke",
 					RepoName:    "ci-info",
@@ -38,7 +38,7 @@ func Test_find(t *testing.T) { //nolint:funlen
 		},
 		{
 			name: "search words, registry",
-			pkg: &FindingPackage{
+			pkg: &Package{
 				PackageInfo: &registry.PackageInfo{
 					RepoOwner:   "suzuki-shunsuke",
 					RepoName:    "ci-info",
@@ -50,7 +50,7 @@ func Test_find(t *testing.T) { //nolint:funlen
 		},
 		{
 			name: "search words, alias, registry",
-			pkg: &FindingPackage{
+			pkg: &Package{
 				PackageInfo: &registry.PackageInfo{
 					RepoOwner:   "suzuki-shunsuke",
 					RepoName:    "ci-info",
@@ -67,7 +67,7 @@ func Test_find(t *testing.T) { //nolint:funlen
 		},
 		{
 			name: "search words, alias, command, registry",
-			pkg: &FindingPackage{
+			pkg: &Package{
 				PackageInfo: &registry.PackageInfo{
 					RepoOwner:   "suzuki-shunsuke",
 					RepoName:    "ci-info",
@@ -107,14 +107,14 @@ func Test_getPreview(t *testing.T) {
 	t.Parallel()
 	data := []struct {
 		name string
-		pkg  *FindingPackage
+		pkg  *Package
 		i    int
 		w    int
 		exp  string
 	}{
 		{
 			name: "normal",
-			pkg: &FindingPackage{
+			pkg: &Package{
 				PackageInfo: &registry.PackageInfo{
 					RepoOwner:   "suzuki-shunsuke",
 					RepoName:    "ci-info",

--- a/pkg/fuzzyfinder/version_selector.go
+++ b/pkg/fuzzyfinder/version_selector.go
@@ -1,4 +1,4 @@
-package generate
+package fuzzyfinder
 
 import (
 	"fmt"
@@ -13,33 +13,29 @@ type Version struct {
 	URL         string
 }
 
-type VersionSelector interface {
-	Find(versions []*Version, hasPreview bool) (int, error)
+type VersionSelector struct{}
+
+func NewVersionSelector() *VersionSelector {
+	return &VersionSelector{}
 }
 
-type versionSelector struct{}
-
-func NewVersionSelector() VersionSelector {
-	return &versionSelector{}
-}
-
-func NewMockVersionSelector(idx int, err error) VersionSelector {
-	return &mockVersionSelector{
+func NewMockVersionSelector(idx int, err error) *MockVersionSelector {
+	return &MockVersionSelector{
 		idx: idx,
 		err: err,
 	}
 }
 
-type mockVersionSelector struct {
+type MockVersionSelector struct {
 	idx int
 	err error
 }
 
-func (s *mockVersionSelector) Find(versions []*Version, hasPreview bool) (int, error) {
+func (s *MockVersionSelector) Find(versions []*Version, hasPreview bool) (int, error) {
 	return s.idx, s.err
 }
 
-func (s *versionSelector) Find(versions []*Version, hasPreview bool) (int, error) {
+func (s *VersionSelector) Find(versions []*Version, hasPreview bool) (int, error) {
 	if hasPreview {
 		return fuzzyfinder.Find(versions, func(i int) string { //nolint:wrapcheck
 			return getVersionItem(versions[i])
@@ -80,7 +76,7 @@ func getVersionPreview(version *Version, i, w int) string {
 	return s
 }
 
-func convertStringsToVersions(arr []string) []*Version {
+func ConvertStringsToVersions(arr []string) []*Version {
 	versions := make([]*Version, len(arr))
 	for i, a := range arr {
 		versions[i] = &Version{

--- a/pkg/fuzzyfinder/version_selector_internal_test.go
+++ b/pkg/fuzzyfinder/version_selector_internal_test.go
@@ -1,4 +1,4 @@
-package generate
+package fuzzyfinder
 
 import (
 	"testing"


### PR DESCRIPTION
Close #2251

## Features

Added a command line option `-i` to the command `remove`.

```console
$ aqua rm -i
```

If this option is set, you can select packages with a fuzzy finder to uninstall packages.

## ⚠️ Limitation

The fuzzy finder shows all packages, which include not installed packages.