### PR TITLE
fix: fix a bug that supported_envs gets true even if darwin isn't supported on darwin/arm64

### DIFF
--- a/pkg/config/registry/supported_envs.go
+++ b/pkg/config/registry/supported_envs.go
@@ -15,13 +15,18 @@ func (p *PackageInfo) CheckSupportedEnvs(goos, goarch, env string) bool {
 	if p.SupportedEnvs == nil {
 		return true
 	}
-	if goos == "darwin" && goarch == "arm64" && p.Rosetta2 {
-		return true
-	}
 	for _, supportedEnv := range p.SupportedEnvs {
 		switch supportedEnv {
 		case goos, goarch, env, "all":
 			return true
+		}
+	}
+	if goos == "darwin" && goarch == "arm64" && p.Rosetta2 {
+		for _, supportedEnv := range p.SupportedEnvs {
+			switch supportedEnv {
+			case "amd64", "darwin/amd64":
+				return true
+			}
 		}
 	}
 	return false


### PR DESCRIPTION
This bug was introduced in aqua v1.30.0.

- https://github.com/aquaproj/aqua-registry/pull/15753#issuecomment-1736716809

I found an original issue and a pull request.

- https://github.com/aquaproj/aqua/issues/1512
- https://github.com/aquaproj/aqua/pull/1514

> Add darwin/arm64 to supported_envs if rosetta2 is enabled.
> Currently, we have to add darwin/arm64 explicitly even if rosetta2 is enabled.

I remembered the intention.
But this should be applied only if darwin/amd64 is included in `supported_envs`.