### PR TITLE
feat: support using go_install or go_build if the asset for the platform isn't released in GitHub Releases

### DIFF
--- a/json-schema/registry.json
+++ b/json-schema/registry.json
@@ -15,6 +15,37 @@
         "name"
       ]
     },
+    "Build": {
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "enum=go_install",
+            "go_build"
+          ]
+        },
+        "path": {
+          "type": "string"
+        },
+        "files": {
+          "items": {
+            "$ref": "#/$defs/File"
+          },
+          "type": "array"
+        },
+        "excluded_envs": {
+          "$ref": "#/$defs/SupportedEnvs"
+        },
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type"
+      ]
+    },
     "Cargo": {
       "properties": {
         "features": {
@@ -447,6 +478,12 @@
         "private": {
           "type": "boolean"
         },
+        "build": {
+          "$ref": "#/$defs/Build"
+        },
+        "append_ext": {
+          "type": "boolean"
+        },
         "version_constraint": {
           "type": "string"
         },
@@ -455,9 +492,6 @@
             "$ref": "#/$defs/VersionOverride"
           },
           "type": "array"
-        },
-        "append_ext": {
-          "type": "boolean"
         }
       },
       "additionalProperties": false,
@@ -642,6 +676,9 @@
         },
         "append_ext": {
           "type": "boolean"
+        },
+        "build": {
+          "$ref": "#/$defs/Build"
         }
       },
       "additionalProperties": false,

--- a/pkg/config/registry/package_info.go
+++ b/pkg/config/registry/package_info.go
@@ -68,6 +68,16 @@ type Build struct {
 	Enabled      *bool         `json:"enabled,omitempty" yaml:",omitempty"`
 }
 
+func (b *Build) CheckEnabled() bool {
+	if b == nil {
+		return false
+	}
+	if b.Enabled == nil {
+		return true
+	}
+	return *b.Enabled
+}
+
 func (p *PackageInfo) GetAppendExt() bool {
 	if p.AppendExt == nil {
 		return true

--- a/pkg/config/registry/package_info.go
+++ b/pkg/config/registry/package_info.go
@@ -22,40 +22,50 @@ const (
 )
 
 type PackageInfo struct {
-	Name               string             `json:"name,omitempty" yaml:",omitempty"`
-	Aliases            []*Alias           `yaml:",omitempty" json:"aliases,omitempty"`
-	SearchWords        []string           `json:"search_words,omitempty" yaml:"search_words,omitempty"`
-	Type               string             `validate:"required" json:"type" jsonschema:"enum=github_release,enum=github_content,enum=github_archive,enum=http,enum=go,enum=go_install,enum=cargo,enum=go_build"`
-	RepoOwner          string             `yaml:"repo_owner,omitempty" json:"repo_owner,omitempty"`
-	RepoName           string             `yaml:"repo_name,omitempty" json:"repo_name,omitempty"`
-	Description        string             `json:"description,omitempty" yaml:",omitempty"`
-	Link               string             `json:"link,omitempty" yaml:",omitempty"`
-	Asset              string             `json:"asset,omitempty" yaml:",omitempty"`
-	Crate              string             `json:"crate,omitempty" yaml:",omitempty"`
-	Cargo              *Cargo             `json:"cargo,omitempty"`
-	URL                string             `json:"url,omitempty" yaml:",omitempty"`
-	Path               string             `json:"path,omitempty" yaml:",omitempty"`
-	Format             string             `json:"format,omitempty" jsonschema:"example=tar.gz,example=raw,example=zip,example=dmg" yaml:",omitempty"`
-	Overrides          []*Override        `json:"overrides,omitempty" yaml:",omitempty"`
-	FormatOverrides    []*FormatOverride  `yaml:"format_overrides,omitempty" json:"format_overrides,omitempty"`
-	Files              []*File            `json:"files,omitempty" yaml:",omitempty"`
-	Replacements       Replacements       `json:"replacements,omitempty" yaml:",omitempty"`
-	SupportedEnvs      SupportedEnvs      `yaml:"supported_envs,omitempty" json:"supported_envs,omitempty"`
-	VersionFilter      string             `yaml:"version_filter,omitempty" json:"version_filter,omitempty"`
-	VersionPrefix      string             `yaml:"version_prefix,omitempty" json:"version_prefix,omitempty"`
-	Rosetta2           bool               `yaml:",omitempty" json:"rosetta2,omitempty"`
-	NoAsset            bool               `yaml:"no_asset,omitempty" json:"no_asset,omitempty"`
-	VersionSource      string             `json:"version_source,omitempty" yaml:"version_source,omitempty" jsonschema:"enum=github_tag"`
-	CompleteWindowsExt *bool              `json:"complete_windows_ext,omitempty" yaml:"complete_windows_ext,omitempty"`
-	WindowsExt         string             `json:"windows_ext,omitempty" yaml:"windows_ext,omitempty"`
-	Checksum           *Checksum          `json:"checksum,omitempty"`
-	Cosign             *Cosign            `json:"cosign,omitempty"`
-	SLSAProvenance     *SLSAProvenance    `json:"slsa_provenance,omitempty" yaml:"slsa_provenance,omitempty"`
-	Private            bool               `json:"private,omitempty"`
+	Name               string            `json:"name,omitempty" yaml:",omitempty"`
+	Aliases            []*Alias          `yaml:",omitempty" json:"aliases,omitempty"`
+	SearchWords        []string          `json:"search_words,omitempty" yaml:"search_words,omitempty"`
+	Type               string            `validate:"required" json:"type" jsonschema:"enum=github_release,enum=github_content,enum=github_archive,enum=http,enum=go,enum=go_install,enum=cargo,enum=go_build"`
+	RepoOwner          string            `yaml:"repo_owner,omitempty" json:"repo_owner,omitempty"`
+	RepoName           string            `yaml:"repo_name,omitempty" json:"repo_name,omitempty"`
+	Description        string            `json:"description,omitempty" yaml:",omitempty"`
+	Link               string            `json:"link,omitempty" yaml:",omitempty"`
+	Asset              string            `json:"asset,omitempty" yaml:",omitempty"`
+	Crate              string            `json:"crate,omitempty" yaml:",omitempty"`
+	Cargo              *Cargo            `json:"cargo,omitempty"`
+	URL                string            `json:"url,omitempty" yaml:",omitempty"`
+	Path               string            `json:"path,omitempty" yaml:",omitempty"`
+	Format             string            `json:"format,omitempty" jsonschema:"example=tar.gz,example=raw,example=zip,example=dmg" yaml:",omitempty"`
+	Overrides          []*Override       `json:"overrides,omitempty" yaml:",omitempty"`
+	FormatOverrides    []*FormatOverride `yaml:"format_overrides,omitempty" json:"format_overrides,omitempty"`
+	Files              []*File           `json:"files,omitempty" yaml:",omitempty"`
+	Replacements       Replacements      `json:"replacements,omitempty" yaml:",omitempty"`
+	SupportedEnvs      SupportedEnvs     `yaml:"supported_envs,omitempty" json:"supported_envs,omitempty"`
+	VersionFilter      string            `yaml:"version_filter,omitempty" json:"version_filter,omitempty"`
+	VersionPrefix      string            `yaml:"version_prefix,omitempty" json:"version_prefix,omitempty"`
+	Rosetta2           bool              `yaml:",omitempty" json:"rosetta2,omitempty"`
+	NoAsset            bool              `yaml:"no_asset,omitempty" json:"no_asset,omitempty"`
+	VersionSource      string            `json:"version_source,omitempty" yaml:"version_source,omitempty" jsonschema:"enum=github_tag"`
+	CompleteWindowsExt *bool             `json:"complete_windows_ext,omitempty" yaml:"complete_windows_ext,omitempty"`
+	WindowsExt         string            `json:"windows_ext,omitempty" yaml:"windows_ext,omitempty"`
+	Checksum           *Checksum         `json:"checksum,omitempty"`
+	Cosign             *Cosign           `json:"cosign,omitempty"`
+	SLSAProvenance     *SLSAProvenance   `json:"slsa_provenance,omitempty" yaml:"slsa_provenance,omitempty"`
+	Private            bool              `json:"private,omitempty"`
+	Build              *Build            `json:"build,omitempty" yaml:",omitempty"`
+	ErrorMessage       string            `json:"-" yaml:"-"`
+	AppendExt          *bool             `json:"append_ext,omitempty" yaml:"append_ext,omitempty"`
+
 	VersionConstraints string             `yaml:"version_constraint,omitempty" json:"version_constraint,omitempty"`
 	VersionOverrides   []*VersionOverride `yaml:"version_overrides,omitempty" json:"version_overrides,omitempty"`
-	ErrorMessage       string             `json:"-" yaml:"-"`
-	AppendExt          *bool              `json:"append_ext" yaml:"append_ext"`
+}
+
+type Build struct {
+	Type         string        `validate:"required" json:"type" jsonschema:"enum=enum=go_install,enum=go_build"`
+	Path         string        `json:"path,omitempty" yaml:",omitempty"`
+	Files        []*File       `json:"files,omitempty" yaml:",omitempty"`
+	ExcludedEnvs SupportedEnvs `yaml:"excluded_envs,omitempty" json:"excluded_envs,omitempty"`
+	Enabled      *bool         `json:"enabled,omitempty" yaml:",omitempty"`
 }
 
 func (p *PackageInfo) GetAppendExt() bool {
@@ -93,6 +103,7 @@ type VersionOverride struct {
 	ErrorMessage       *string         `json:"error_message,omitempty" yaml:"error_message,omitempty"`
 	NoAsset            *bool           `yaml:"no_asset,omitempty" json:"no_asset,omitempty"`
 	AppendExt          *bool           `json:"append_ext" yaml:"append_ext"`
+	Build              *Build          `json:"build,omitempty" yaml:",omitempty"`
 }
 
 type Override struct {
@@ -150,6 +161,7 @@ func (p *PackageInfo) Copy() *PackageInfo {
 		ErrorMessage:       p.ErrorMessage,
 		NoAsset:            p.NoAsset,
 		AppendExt:          p.AppendExt,
+		Build:              p.Build,
 	}
 	return pkg
 }
@@ -295,6 +307,9 @@ func (p *PackageInfo) overrideVersion(child *VersionOverride) *PackageInfo { //n
 	if child.AppendExt != nil {
 		pkg.AppendExt = child.AppendExt
 	}
+	if child.Build != nil {
+		pkg.Build = child.Build
+	}
 	return pkg
 }
 
@@ -379,6 +394,16 @@ func (p *PackageInfo) OverrideByRuntime(rt *runtime.Runtime) { //nolint:cyclop,f
 
 	if ov.AppendExt != nil {
 		p.AppendExt = ov.AppendExt
+	}
+}
+
+func (p *PackageInfo) OverrideByBuild() {
+	p.Type = p.Build.Type
+	if p.Build.Path != "" {
+		p.Path = p.Build.Path
+	}
+	if p.Build.Files != nil {
+		p.Files = p.Build.Files
 	}
 }
 

--- a/pkg/config/registry/supported_envs.go
+++ b/pkg/config/registry/supported_envs.go
@@ -8,7 +8,7 @@ func (p *PackageInfo) CheckSupported(rt *runtime.Runtime, env string) (bool, err
 	if p.CheckSupportedEnvs(rt.GOOS, rt.GOARCH, env) {
 		return true, nil
 	}
-	if p.Build == nil {
+	if !p.Build.CheckEnabled() {
 		return false, nil
 	}
 	if p.checkExcludedEnvs(rt.GOOS, rt.GOARCH, env) {
@@ -28,9 +28,6 @@ func (p *PackageInfo) CheckSupportedEnvs(goos, goarch, env string) bool {
 func (p *PackageInfo) checkExcludedEnvs(goos, goarch, env string) bool {
 	if p.Build.ExcludedEnvs == nil {
 		return true
-	}
-	if p.Build.Enabled != nil && !*p.Build.Enabled {
-		return false
 	}
 	return !matchEnvs(p.Build.ExcludedEnvs, goos, goarch, env, p.Rosetta2)
 }


### PR DESCRIPTION
Close #2132

## Features

This pull request adds a new field `build` to Registry settings.
This enables to install packages by `go_install` or `go_build` on platforms where prebuilt binaries aren't published.

## Example

This is an example usage of the new field `build`.

```yaml
packages:
  - type: github_release
    repo_owner: suzuki-shunsuke
    repo_name: tfcmt
    asset: tfcmt_{{.OS}}_{{.Arch}}.{{.Format}}
    format: tar.gz
    supported_envs:
      - linux
    build:
      type: go_build
      files:
        - name: tfcmt
          src: ./cmd/tfcmt
          dir: tfcmt-{{trimV .Version}}
```

`supported_envs` is `linux` because prebuilt binaries are published only for linux.
On platforms other than `supported_envs`, aqua installs tfcmt by `go_build`.

`go_install` is also available.

```yaml
    build:
      type: go_install
      path: github.com/suzuki-shunsuke/tfcmt/v4/cmd/tfcmt
```

If `go_build` failed on windows/arm64 and we'd like to exclude windows/arm64, `excluded_envs` is available.

```yaml
    build:
      type: go_build
      excluded_envs:
        - windows/arm64
      files:
        - name: tfcmt
          src: ./cmd/tfcmt
          dir: tfcmt-{{trimV .Version}}
```

If we'd like to disable `build` in version_overrides, `enabled` is available.

```yaml
build:
  enabled: false
```

## Why not `overrides`?

Of course, we can do the same thing with `overrides`.

```yaml
packages:
  - type: go_build
    repo_owner: suzuki-shunsuke
    repo_name: tfcmt
    files:
      - name: tfcmt
        src: ./cmd/tfcmt
        dir: tfcmt-{{trimV .Version}}    
    overrides:
      - goos: linux
        type: github_release
        asset: tfcmt_{{.OS}}_{{.Arch}}.{{.Format}}
        format: tar.gz
        files:
          - name: tfcmt
```

This example has only one element in `overrides`, but if `overrides` has multiple elements, `build` makes the code simpler.
And `build` makes the intension clearer.