### PR TITLE
feat(update-aqua): add an alias `upa` to the command `update-aqua`

### DIFF
--- a/pkg/cli/update_aqua.go
+++ b/pkg/cli/update_aqua.go
@@ -11,7 +11,10 @@ import (
 
 func (r *Runner) newUpdateAquaCommand() *cli.Command {
 	return &cli.Command{
-		Name:  "update-aqua",
+		Name: "update-aqua",
+		Aliases: []string{
+			"upa",
+		},
 		Usage: "Update aqua",
 		Description: `Update aqua.
 


### PR DESCRIPTION
`update-aqua` is too long.

```
aqua update-aqua
```

So I add an alias `upa`.

```
aqua upa
```