### PR TITLE
feat(generate-registry): get all GitHub Releases by default

### DIFF
--- a/pkg/cli/generate_registry.go
+++ b/pkg/cli/generate_registry.go
@@ -44,15 +44,12 @@ e.g.
 
 $ aqua gr cli/cli@v2.0.0
 
-By default, aqua gr doesn't generate version_overrides.
-If --deep is set, aqua generates version_overrides.
+By default, aqua gr gets all GitHub Releases to generate version_overrides.
+You can limit the number of GitHub Releases by --limit.
 
 e.g.
 
-$ aqua gr --deep suzuki-shunsuke/tfcmt
-
-Note that if --deep is set, GitHub API is called per GitHub Release.
-This may cause GitHub API rate limiting.
+$ aqua gr --limit 100 suzuki-shunsuke/tfcmt
 
 If --out-testdata is set, aqua inserts testdata into the specified file.
 
@@ -102,9 +99,14 @@ func (r *Runner) newGenerateRegistryCommand() *cli.Command {
 				Name:  "cmd",
 				Usage: "A list of commands joined with single quotes ','",
 			},
+			&cli.IntFlag{
+				Name:    "limit",
+				Aliases: []string{"l"},
+				Usage:   "the maximum number of versions",
+			},
 			&cli.BoolFlag{
 				Name:  "deep",
-				Usage: "Resolve version_overrides",
+				Usage: "This flag was deprecated and had no meaning from aqua v2.15.0. This flag will be removed in aqua v3.0.0. https://github.com/aquaproj/aqua/issues/2351",
 			},
 		},
 	}

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -52,6 +52,7 @@ func (r *Runner) setParam(c *cli.Context, commandName string, param *config.Para
 	param.All = c.Bool("all")
 	param.Detail = c.Bool("detail")
 	param.Prune = c.Bool("prune")
+	param.Limit = c.Int("limit")
 	param.SelectVersion = c.Bool("select-version")
 	param.File = c.String("f")
 	if cmd := c.String("cmd"); cmd != "" {

--- a/pkg/config/package.go
+++ b/pkg/config/package.go
@@ -249,6 +249,7 @@ type Param struct {
 	Dest                  string
 	HomeDir               string
 	OutTestData           string
+	Limit                 int
 	MaxParallelism        int
 	Args                  []string
 	Tags                  map[string]struct{}

--- a/pkg/controller/generate-registry/generate.go
+++ b/pkg/controller/generate-registry/generate.go
@@ -55,7 +55,7 @@ func (c *Controller) GenerateRegistry(ctx context.Context, param *config.Param, 
 }
 
 func (c *Controller) genRegistry(ctx context.Context, param *config.Param, logE *logrus.Entry, pkgName string) error {
-	pkgInfo, versions := c.getPackageInfo(ctx, logE, pkgName, param.Deep)
+	pkgInfo, versions := c.getPackageInfo(ctx, logE, pkgName, param.Limit)
 	if len(param.Commands) != 0 {
 		files := make([]*registry.File, len(param.Commands))
 		for i, cmd := range param.Commands {
@@ -100,7 +100,7 @@ func (c *Controller) getRelease(ctx context.Context, repoOwner, repoName, versio
 	return release, err //nolint:wrapcheck
 }
 
-func (c *Controller) getPackageInfo(ctx context.Context, logE *logrus.Entry, arg string, deep bool) (*registry.PackageInfo, []string) {
+func (c *Controller) getPackageInfo(ctx context.Context, logE *logrus.Entry, arg string, limit int) (*registry.PackageInfo, []string) {
 	pkgName, version, _ := strings.Cut(arg, "@")
 	if strings.HasPrefix(pkgName, "crates.io/") {
 		return c.getCargoPackageInfo(ctx, logE, pkgName)
@@ -127,8 +127,8 @@ func (c *Controller) getPackageInfo(ctx context.Context, logE *logrus.Entry, arg
 	} else {
 		pkgInfo.Description = strings.TrimRight(strings.TrimSpace(gomoji.RemoveEmojis(repo.GetDescription())), ".!?")
 	}
-	if deep && version == "" {
-		return c.getPackageInfoWithVersionOverrides(ctx, logE, pkgName, pkgInfo)
+	if limit != 1 && version == "" {
+		return c.getPackageInfoWithVersionOverrides(ctx, logE, pkgName, pkgInfo, limit)
 	}
 	release, err := c.getRelease(ctx, pkgInfo.RepoOwner, pkgInfo.RepoName, version)
 	if err != nil {

--- a/pkg/controller/generate-registry/generate.go
+++ b/pkg/controller/generate-registry/generate.go
@@ -2,6 +2,7 @@ package genrgst
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -42,9 +43,14 @@ func NewController(fs afero.Fs, gh RepositoriesService, testdataOutputter Testda
 	}
 }
 
+var errLimitMustBeGreaterEqualThanZero = errors.New("limit must be greater equal than zero")
+
 func (c *Controller) GenerateRegistry(ctx context.Context, param *config.Param, logE *logrus.Entry, args ...string) error {
 	if len(args) == 0 {
 		return nil
+	}
+	if param.Limit < 0 {
+		return errLimitMustBeGreaterEqualThanZero
 	}
 	for _, arg := range args {
 		if err := c.genRegistry(ctx, param, logE, arg); err != nil {

--- a/pkg/controller/generate-registry/generate_internal_test.go
+++ b/pkg/controller/generate-registry/generate_internal_test.go
@@ -137,7 +137,7 @@ func TestController_getPackageInfo(t *testing.T) { //nolint:funlen
 				CratePayload: d.crate,
 			}
 			ctrl := NewController(nil, gh, nil, cargoClient)
-			pkgInfo, _ := ctrl.getPackageInfo(ctx, logE, d.pkgName, true)
+			pkgInfo, _ := ctrl.getPackageInfo(ctx, logE, d.pkgName, 0)
 			if diff := cmp.Diff(d.exp, pkgInfo); diff != "" {
 				t.Fatal(diff)
 			}

--- a/pkg/controller/generate-registry/version_overrides.go
+++ b/pkg/controller/generate-registry/version_overrides.go
@@ -250,7 +250,7 @@ func (c *Controller) listReleases(ctx context.Context, logE *logrus.Entry, pkgIn
 		PerPage: 100, //nolint:gomnd
 	}
 
-	if limit < 100 {
+	if limit < 100 { //nolint:gomnd
 		opt.PerPage = limit
 	}
 

--- a/pkg/controller/generate-registry/version_overrides.go
+++ b/pkg/controller/generate-registry/version_overrides.go
@@ -250,7 +250,7 @@ func (c *Controller) listReleases(ctx context.Context, logE *logrus.Entry, pkgIn
 		PerPage: 100, //nolint:gomnd
 	}
 
-	if limit < 100 { //nolint:gomnd
+	if limit != 0 && limit < 100 {
 		opt.PerPage = limit
 	}
 

--- a/pkg/controller/generate-registry/version_overrides.go
+++ b/pkg/controller/generate-registry/version_overrides.go
@@ -65,8 +65,8 @@ func getVersionAndPrefix(tag string) (*version.Version, string, error) {
 	return v, a[1], nil
 }
 
-func (c *Controller) getPackageInfoWithVersionOverrides(ctx context.Context, logE *logrus.Entry, pkgName string, pkgInfo *registry.PackageInfo) (*registry.PackageInfo, []string) {
-	ghReleases := c.listReleases(ctx, logE, pkgInfo)
+func (c *Controller) getPackageInfoWithVersionOverrides(ctx context.Context, logE *logrus.Entry, pkgName string, pkgInfo *registry.PackageInfo, limit int) (*registry.PackageInfo, []string) {
+	ghReleases := c.listReleases(ctx, logE, pkgInfo, limit)
 	releases := make([]*Release, len(ghReleases))
 	for i, release := range ghReleases {
 		tag := release.GetTagName()
@@ -243,12 +243,17 @@ func mergePackages(pkgs []*Package) (*registry.PackageInfo, []string) { //nolint
 	return latestPkgInfo, versions
 }
 
-func (c *Controller) listReleases(ctx context.Context, logE *logrus.Entry, pkgInfo *registry.PackageInfo) []*github.RepositoryRelease {
+func (c *Controller) listReleases(ctx context.Context, logE *logrus.Entry, pkgInfo *registry.PackageInfo, limit int) []*github.RepositoryRelease {
 	repoOwner := pkgInfo.RepoOwner
 	repoName := pkgInfo.RepoName
 	opt := &github.ListOptions{
 		PerPage: 100, //nolint:gomnd
 	}
+
+	if limit < 100 {
+		opt.PerPage = limit
+	}
+
 	var arr []*github.RepositoryRelease
 
 	for i := 0; i < 10; i++ {
@@ -261,6 +266,9 @@ func (c *Controller) listReleases(ctx context.Context, logE *logrus.Entry, pkgIn
 			return arr
 		}
 		arr = append(arr, releases...)
+		if limit > 0 && len(releases) >= limit {
+			return arr
+		}
 		if len(releases) != opt.PerPage {
 			return arr
 		}


### PR DESCRIPTION
Close https://github.com/aquaproj/aqua/issues/2351

The behaviour of `generate-registry` command was changed.
The command gets all GitHub Releases by default to generate `version_overrides`.

The option `--deep` is deprecated. The option has no meaning anymore. The option is kept only for the compatibility.
The option will be removed at aqua v3.

The option `--limit (-l)` is added. This option takes an integer, which is the maximum number of releases.

e.g.

```sh
aqua gr --limit 100
```