### PR TITLE
fix: fix a bug that aqua stops searching configuration files if files are located in either aqua or .aqua directory

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/spf13/afero v1.10.0
 	github.com/suzuki-shunsuke/flute v1.0.1
 	github.com/suzuki-shunsuke/go-error-with-exit-code v1.0.0
-	github.com/suzuki-shunsuke/go-findconfig v1.1.1
+	github.com/suzuki-shunsuke/go-findconfig v1.2.0
 	github.com/suzuki-shunsuke/go-osenv v0.1.0
 	github.com/suzuki-shunsuke/logrus-error v0.1.4
 	github.com/urfave/cli/v2 v2.25.7

--- a/go.sum
+++ b/go.sum
@@ -297,8 +297,8 @@ github.com/suzuki-shunsuke/flute v1.0.1/go.mod h1:lQKcCgbjiIzH4lar2V2UX1IdEwAB5K
 github.com/suzuki-shunsuke/go-cliutil v0.0.0-20181211154308-176f852d9bca/go.mod h1:Vq3NkhgmA9DT/2UZ08x/3A34xxvzQ/vTMABnTWKoMbY=
 github.com/suzuki-shunsuke/go-error-with-exit-code v1.0.0 h1:oVXrrYNGBq4POyITQNWKzwsYz7B2nUcqtDbeX4BfeEc=
 github.com/suzuki-shunsuke/go-error-with-exit-code v1.0.0/go.mod h1:kDFtLeftDiIUUHXGI3xq5eJ+uAOi50FPrxPENTHktJ0=
-github.com/suzuki-shunsuke/go-findconfig v1.1.1 h1:7jBTjf7RjfvRC6XNpCKCJC6y8hHVYPVVefOQHQPHRVw=
-github.com/suzuki-shunsuke/go-findconfig v1.1.1/go.mod h1:u/0Zz6/GDE6G0gofzVhR9UPOIKLSUoDMjUoFWqOoVlg=
+github.com/suzuki-shunsuke/go-findconfig v1.2.0 h1:PWHIyKZEsVmZVh6+K+rHVw0/XjTFmQEYfa8ZIzIJd0c=
+github.com/suzuki-shunsuke/go-findconfig v1.2.0/go.mod h1:lXzJUZQXrgsMmpHxXMVrWUAQpE4EopgDEJbwslvKbzs=
 github.com/suzuki-shunsuke/go-jsoneq v0.1.2 h1:A4czEbmFqSELTbrEtXVo4dSgfz2e2Z0y6G3OpExUML8=
 github.com/suzuki-shunsuke/go-jsoneq v0.1.2/go.mod h1:ETXAwfruZTqMMKDxc9CYoS34CNSsnzcdcVIAW3+RujI=
 github.com/suzuki-shunsuke/go-osenv v0.1.0 h1:hBQ7yaeO1WBZsEWuDj1wrOWF+N7HSWSOpEiEZqfCjjk=


### PR DESCRIPTION
To fix the bug, update go-findconfig to v1.2.0.

- https://github.com/suzuki-shunsuke/go-findconfig/releases/tag/v1.2.0
- https://github.com/suzuki-shunsuke/go-findconfig/pull/617

## How to reproduce the issue

Directory structure

```
/workspace/
  aqua.yaml
  foo/ # current directory
    aqua/
      aqua.yaml
```

Run `aqua i`.

```sh
aqua i
```

## Expected behaviour

aqua installs packages with `/workspace/aqua.yaml` and `/workspace/foo/aqua/aqua.yaml`.

## Actual behaviour

aqua installs packages with only `/workspace/foo/aqua/aqua.yaml`, and ignores `/workspace/aqua.yaml`.