### PR TITLE
Feat: Log enhancement for command generate and update

### DIFF
--- a/pkg/versiongetter/cargo.go
+++ b/pkg/versiongetter/cargo.go
@@ -3,6 +3,7 @@ package versiongetter
 import (
 	"context"
 	"fmt"
+	"github.com/sirupsen/logrus"
 
 	"github.com/aquaproj/aqua/v2/pkg/config/registry"
 	"github.com/aquaproj/aqua/v2/pkg/fuzzyfinder"
@@ -27,7 +28,7 @@ func (c *CargoVersionGetter) Get(ctx context.Context, pkg *registry.PackageInfo,
 	return c.client.GetLatestVersion(ctx, pkg.Crate) //nolint:wrapcheck
 }
 
-func (c *CargoVersionGetter) List(ctx context.Context, pkg *registry.PackageInfo, filters []*Filter, limit int) ([]*fuzzyfinder.Item, error) {
+func (c *CargoVersionGetter) List(ctx context.Context, _ *logrus.Entry, pkg *registry.PackageInfo, filters []*Filter, limit int) ([]*fuzzyfinder.Item, error) {
 	versionStrings, err := c.client.ListVersions(ctx, pkg.Crate)
 	if err != nil {
 		return nil, fmt.Errorf("list versions of the crate: %w", err)

--- a/pkg/versiongetter/cargo.go
+++ b/pkg/versiongetter/cargo.go
@@ -24,7 +24,7 @@ func NewCargo(client CargoClient) *CargoVersionGetter {
 	}
 }
 
-func (c *CargoVersionGetter) Get(ctx context.Context, pkg *registry.PackageInfo, filters []*Filter) (string, error) {
+func (c *CargoVersionGetter) Get(ctx context.Context, _ *logrus.Entry, pkg *registry.PackageInfo, filters []*Filter) (string, error) {
 	return c.client.GetLatestVersion(ctx, pkg.Crate) //nolint:wrapcheck
 }
 

--- a/pkg/versiongetter/cargo.go
+++ b/pkg/versiongetter/cargo.go
@@ -3,10 +3,10 @@ package versiongetter
 import (
 	"context"
 	"fmt"
-	"github.com/sirupsen/logrus"
 
 	"github.com/aquaproj/aqua/v2/pkg/config/registry"
 	"github.com/aquaproj/aqua/v2/pkg/fuzzyfinder"
+	"github.com/sirupsen/logrus"
 )
 
 type CargoClient interface {

--- a/pkg/versiongetter/cargo_test.go
+++ b/pkg/versiongetter/cargo_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/aquaproj/aqua/v2/pkg/config/registry"
 	"github.com/aquaproj/aqua/v2/pkg/fuzzyfinder"
+	"github.com/aquaproj/aqua/v2/pkg/log"
+	"github.com/aquaproj/aqua/v2/pkg/runtime"
 	"github.com/aquaproj/aqua/v2/pkg/versiongetter"
 	"github.com/google/go-cmp/cmp"
 )
@@ -46,7 +48,7 @@ func TestCargoVersionGetter_Get(t *testing.T) {
 			t.Parallel()
 			cargoClient := versiongetter.NewMockCargoClient(d.versions)
 			cargoGetter := versiongetter.NewCargo(cargoClient)
-			version, err := cargoGetter.Get(ctx, d.pkg, d.filters)
+			version, err := cargoGetter.Get(ctx, log.New(runtime.New(), ""), d.pkg, d.filters)
 			if err != nil {
 				if d.isErr {
 					return
@@ -109,7 +111,7 @@ func TestCargoVersionGetter_List(t *testing.T) {
 			t.Parallel()
 			cargoClient := versiongetter.NewMockCargoClient(d.versions)
 			cargoGetter := versiongetter.NewCargo(cargoClient)
-			items, err := cargoGetter.List(ctx, d.pkg, d.filters, -1)
+			items, err := cargoGetter.List(ctx, log.New(runtime.New(), ""), d.pkg, d.filters, -1)
 			if err != nil {
 				if d.isErr {
 					return

--- a/pkg/versiongetter/fuzzy_getter.go
+++ b/pkg/versiongetter/fuzzy_getter.go
@@ -33,8 +33,11 @@ func (g *FuzzyGetter) Get(ctx context.Context, logE *logrus.Entry, pkg *registry
 		return ""
 	}
 
-	const getVerTimeInfo string = "Retrieve pkg version(s) in "
-	const getVerErrWarn string = "Version retrieving err"
+	const ( // log message
+		getVerTimeInfo = "Retrieve pkg version(s) in "
+		getVerErrWarn  = "Version retrieving error"
+	)
+
 	repoName := pkg.RepoOwner + "/" + pkg.RepoName
 	logE = logE.WithField("repo", repoName)
 	start := time.Now()
@@ -59,7 +62,7 @@ func (g *FuzzyGetter) Get(ctx context.Context, logE *logrus.Entry, pkg *registry
 			}
 		}
 		idx, err := g.fuzzyFinder.Find(versions, true)
-		logE.Info(getVerTimeInfo, elapsed) // finder's output will overwrite log, so log after it
+		logE.Debug(getVerTimeInfo, elapsed) // finder's output will overwrite log, so log after it
 		if err != nil {
 			return ""
 		}
@@ -70,7 +73,7 @@ func (g *FuzzyGetter) Get(ctx context.Context, logE *logrus.Entry, pkg *registry
 	}
 
 	version, err := g.getter.Get(ctx, logE, pkg, filters)
-	logE.Info(getVerTimeInfo, time.Since(start))
+	logE.Debug(getVerTimeInfo, time.Since(start))
 	if err != nil {
 		logE.WithError(err).Warn(getVerErrWarn)
 		return ""

--- a/pkg/versiongetter/fuzzy_getter.go
+++ b/pkg/versiongetter/fuzzy_getter.go
@@ -69,7 +69,7 @@ func (g *FuzzyGetter) Get(ctx context.Context, logE *logrus.Entry, pkg *registry
 		return versions[idx].Item
 	}
 
-	version, err := g.getter.Get(ctx, pkg, filters)
+	version, err := g.getter.Get(ctx, logE, pkg, filters)
 	logE.Info(getVerTimeInfo, time.Since(start))
 	if err != nil {
 		logE.WithError(err).Warn(getVerErrWarn)

--- a/pkg/versiongetter/fuzzy_getter.go
+++ b/pkg/versiongetter/fuzzy_getter.go
@@ -39,7 +39,7 @@ func (g *FuzzyGetter) Get(ctx context.Context, logE *logrus.Entry, pkg *registry
 	logE = logE.WithField("repo", repoName)
 	start := time.Now()
 	if useFinder { //nolint:nestif
-		versions, err := g.getter.List(ctx, pkg, filters, limit)
+		versions, err := g.getter.List(ctx, logE, pkg, filters, limit)
 		elapsed := time.Since(start)
 		if err != nil {
 			logE.WithError(err).Warn(getVerErrWarn)

--- a/pkg/versiongetter/general.go
+++ b/pkg/versiongetter/general.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/aquaproj/aqua/v2/pkg/config/registry"
 	"github.com/aquaproj/aqua/v2/pkg/fuzzyfinder"
+	"github.com/aquaproj/aqua/v2/pkg/github"
 	"github.com/sirupsen/logrus"
 )
 
@@ -23,12 +24,12 @@ func NewGeneralVersionGetter(cargo *CargoVersionGetter, ghTag *GitHubTagVersionG
 	}
 }
 
-func (g *GeneralVersionGetter) Get(ctx context.Context, pkg *registry.PackageInfo, filters []*Filter) (string, error) {
+func (g *GeneralVersionGetter) Get(ctx context.Context, logE *logrus.Entry, pkg *registry.PackageInfo, filters []*Filter) (string, error) {
 	getter := g.get(pkg)
 	if getter == nil {
 		return "", nil
 	}
-	return getter.Get(ctx, pkg, filters) //nolint:wrapcheck
+	return getter.Get(ctx, logE, pkg, filters) //nolint:wrapcheck
 }
 
 func (g *GeneralVersionGetter) List(ctx context.Context, logE *logrus.Entry, pkg *registry.PackageInfo, filters []*Filter, limit int) ([]*fuzzyfinder.Item, error) {
@@ -64,4 +65,12 @@ func itemNumPerPage(limit, filterNum int) int {
 		return limit
 	}
 	return ghMaxPerPage
+}
+
+// log the GitHub API rate limit info
+func logGHRateLimit(logE *logrus.Entry, resp *github.Response) {
+	logE.WithFields(logrus.Fields{
+		"gh_rate_limit":     resp.Rate.Limit,
+		"gh_rate_remaining": resp.Rate.Remaining,
+	}).Info("GitHub API rate limit info")
 }

--- a/pkg/versiongetter/general.go
+++ b/pkg/versiongetter/general.go
@@ -2,9 +2,9 @@ package versiongetter
 
 import (
 	"context"
-
 	"github.com/aquaproj/aqua/v2/pkg/config/registry"
 	"github.com/aquaproj/aqua/v2/pkg/fuzzyfinder"
+	"github.com/sirupsen/logrus"
 )
 
 const ghMaxPerPage int = 100
@@ -31,12 +31,12 @@ func (g *GeneralVersionGetter) Get(ctx context.Context, pkg *registry.PackageInf
 	return getter.Get(ctx, pkg, filters) //nolint:wrapcheck
 }
 
-func (g *GeneralVersionGetter) List(ctx context.Context, pkg *registry.PackageInfo, filters []*Filter, limit int) ([]*fuzzyfinder.Item, error) {
+func (g *GeneralVersionGetter) List(ctx context.Context, logE *logrus.Entry, pkg *registry.PackageInfo, filters []*Filter, limit int) ([]*fuzzyfinder.Item, error) {
 	getter := g.get(pkg)
 	if getter == nil {
 		return nil, nil
 	}
-	return getter.List(ctx, pkg, filters, limit) //nolint:wrapcheck
+	return getter.List(ctx, logE, pkg, filters, limit) //nolint:wrapcheck
 }
 
 func (g *GeneralVersionGetter) get(pkg *registry.PackageInfo) VersionGetter {

--- a/pkg/versiongetter/general.go
+++ b/pkg/versiongetter/general.go
@@ -2,6 +2,7 @@ package versiongetter
 
 import (
 	"context"
+
 	"github.com/aquaproj/aqua/v2/pkg/config/registry"
 	"github.com/aquaproj/aqua/v2/pkg/fuzzyfinder"
 	"github.com/aquaproj/aqua/v2/pkg/github"

--- a/pkg/versiongetter/general.go
+++ b/pkg/versiongetter/general.go
@@ -70,8 +70,10 @@ func itemNumPerPage(limit, filterNum int) int {
 
 // log the GitHub API rate limit info
 func logGHRateLimit(logE *logrus.Entry, resp *github.Response) {
-	logE = addRateLimitInfo(logE, resp)
-	logE.Debug("GitHub API Rate Limit info")
+	if resp != nil {
+		logE = addRateLimitInfo(logE, resp)
+		logE.Debug("GitHub API Rate Limit info")
+	}
 }
 
 func addRateLimitInfo(logE *logrus.Entry, resp *github.Response) *logrus.Entry {

--- a/pkg/versiongetter/general.go
+++ b/pkg/versiongetter/general.go
@@ -74,3 +74,11 @@ func logGHRateLimit(logE *logrus.Entry, resp *github.Response) {
 		"gh_rate_remaining": resp.Rate.Remaining,
 	}).Info("GitHub API rate limit info")
 }
+
+// fuzzy-finder's output will overwrite the log, add fields to original logE
+func addRteLimitInfo(logE *logrus.Entry, resp *github.Response) {
+	*logE = *logE.WithFields(logrus.Fields{
+		"gh_rate_limit":     resp.Rate.Limit,
+		"gh_rate_remaining": resp.Rate.Remaining,
+	})
+}

--- a/pkg/versiongetter/general.go
+++ b/pkg/versiongetter/general.go
@@ -70,16 +70,16 @@ func itemNumPerPage(limit, filterNum int) int {
 
 // log the GitHub API rate limit info
 func logGHRateLimit(logE *logrus.Entry, resp *github.Response) {
-	logE.WithFields(logrus.Fields{
-		"gh_rate_limit":     resp.Rate.Limit,
-		"gh_rate_remaining": resp.Rate.Remaining,
-	}).Info("GitHub API rate limit info")
+	logE = addRateLimitInfo(logE, resp)
+	logE.Debug("GitHub API Rate Limit info")
 }
 
-// fuzzy-finder's output will overwrite the log, add fields to original logE
-func addRteLimitInfo(logE *logrus.Entry, resp *github.Response) {
-	*logE = *logE.WithFields(logrus.Fields{
-		"gh_rate_limit":     resp.Rate.Limit,
-		"gh_rate_remaining": resp.Rate.Remaining,
-	})
+func addRateLimitInfo(logE *logrus.Entry, resp *github.Response) *logrus.Entry {
+	if resp != nil {
+		return logE.WithFields(logrus.Fields{
+			"gh_rate_limit":     resp.Rate.Limit,
+			"gh_rate_remaining": resp.Rate.Remaining,
+		})
+	}
+	return logE
 }

--- a/pkg/versiongetter/github_release.go
+++ b/pkg/versiongetter/github_release.go
@@ -74,17 +74,12 @@ func (g *GitHubReleaseVersionGetter) List(ctx context.Context, logE *logrus.Entr
 		PerPage: itemNumPerPage(limit, len(filters)),
 	}
 
-	var respToLog *github.Response
-	defer func() {
-		addRteLimitInfo(logE, respToLog)
-	}()
-
 	var items []*fuzzyfinder.Item
 	tags := map[string]struct{}{}
 	for {
 		releases, resp, err := g.gh.ListReleases(ctx, repoOwner, repoName, opt)
-		respToLog = resp
 		if err != nil {
+			*logE = *addRateLimitInfo(logE, resp)
 			return nil, fmt.Errorf("list tags: %w", err)
 		}
 		for _, release := range releases {

--- a/pkg/versiongetter/github_release_test.go
+++ b/pkg/versiongetter/github_release_test.go
@@ -7,7 +7,9 @@ import (
 	"github.com/aquaproj/aqua/v2/pkg/config/registry"
 	"github.com/aquaproj/aqua/v2/pkg/fuzzyfinder"
 	"github.com/aquaproj/aqua/v2/pkg/github"
+	"github.com/aquaproj/aqua/v2/pkg/log"
 	"github.com/aquaproj/aqua/v2/pkg/ptr"
+	"github.com/aquaproj/aqua/v2/pkg/runtime"
 	"github.com/aquaproj/aqua/v2/pkg/versiongetter"
 	"github.com/google/go-cmp/cmp"
 )
@@ -55,7 +57,7 @@ func TestGitHubReleaseVersionGetter_Get(t *testing.T) { //nolint:dupl
 			t.Parallel()
 			ghReleaseClient := versiongetter.NewMockGitHubReleaseClient(d.releases)
 			ghReleaseGetter := versiongetter.NewGitHubRelease(ghReleaseClient)
-			version, err := ghReleaseGetter.Get(ctx, d.pkg, d.filters)
+			version, err := ghReleaseGetter.Get(ctx, log.New(runtime.New(), ""), d.pkg, d.filters)
 			if err != nil {
 				if d.isErr {
 					return
@@ -143,7 +145,7 @@ body(v1)`,
 			t.Parallel()
 			ghReleaseClient := versiongetter.NewMockGitHubReleaseClient(d.releases)
 			ghReleaseGetter := versiongetter.NewGitHubRelease(ghReleaseClient)
-			items, err := ghReleaseGetter.List(ctx, d.pkg, d.filters, -1)
+			items, err := ghReleaseGetter.List(ctx, log.New(runtime.New(), ""), d.pkg, d.filters, -1)
 			if err != nil {
 				if d.isErr {
 					return

--- a/pkg/versiongetter/github_tag.go
+++ b/pkg/versiongetter/github_tag.go
@@ -33,7 +33,7 @@ func (g *GitHubTagVersionGetter) Get(ctx context.Context, logE *logrus.Entry, pk
 
 	var respToLog *github.Response
 	defer func() {
-		addRteLimitInfo(logE, respToLog)
+		logGHRateLimit(logE, respToLog)
 	}()
 
 	for {
@@ -61,17 +61,12 @@ func (g *GitHubTagVersionGetter) List(ctx context.Context, logE *logrus.Entry, p
 		PerPage: itemNumPerPage(limit, len(filters)),
 	}
 
-	var respToLog *github.Response
-	defer func() {
-		addRteLimitInfo(logE, respToLog)
-	}()
-
 	var versions []string
 	tagNames := map[string]struct{}{}
 	for {
 		tags, resp, err := g.gh.ListTags(ctx, repoOwner, repoName, opt)
-		respToLog = resp
 		if err != nil {
+			*logE = *addRateLimitInfo(logE, resp)
 			return nil, fmt.Errorf("list tags: %w", err)
 		}
 		for _, tag := range tags {

--- a/pkg/versiongetter/github_tag.go
+++ b/pkg/versiongetter/github_tag.go
@@ -24,26 +24,29 @@ type GitHubTagClient interface {
 	ListTags(ctx context.Context, owner string, repo string, opts *github.ListOptions) ([]*github.RepositoryTag, *github.Response, error)
 }
 
-func (g *GitHubTagVersionGetter) Get(ctx context.Context, pkg *registry.PackageInfo, filters []*Filter) (string, error) {
+func (g *GitHubTagVersionGetter) Get(ctx context.Context, logE *logrus.Entry, pkg *registry.PackageInfo, filters []*Filter) (string, error) {
 	repoOwner := pkg.RepoOwner
 	repoName := pkg.RepoName
 	opt := &github.ListOptions{
 		PerPage: 30, //nolint:gomnd
 	}
 	for {
-		tags, _, err := g.gh.ListTags(ctx, repoOwner, repoName, opt)
+		tags, resp, err := g.gh.ListTags(ctx, repoOwner, repoName, opt)
 		if err != nil {
+			logGHRateLimit(logE, resp)
 			return "", fmt.Errorf("list tags: %w", err)
 		}
 		for _, tag := range tags {
 			if filterTag(tag, filters) {
+				logGHRateLimit(logE, resp)
 				return tag.GetName(), nil
 			}
 		}
-		if len(tags) != opt.PerPage {
+		if resp.NextPage == 0 {
+			logGHRateLimit(logE, resp)
 			return "", nil
 		}
-		opt.Page++
+		opt.Page = resp.NextPage
 	}
 }
 

--- a/pkg/versiongetter/github_tag.go
+++ b/pkg/versiongetter/github_tag.go
@@ -3,11 +3,11 @@ package versiongetter
 import (
 	"context"
 	"fmt"
-	"github.com/sirupsen/logrus"
 
 	"github.com/aquaproj/aqua/v2/pkg/config/registry"
 	"github.com/aquaproj/aqua/v2/pkg/fuzzyfinder"
 	"github.com/aquaproj/aqua/v2/pkg/github"
+	"github.com/sirupsen/logrus"
 )
 
 type GitHubTagVersionGetter struct {

--- a/pkg/versiongetter/github_tag_test.go
+++ b/pkg/versiongetter/github_tag_test.go
@@ -7,7 +7,9 @@ import (
 	"github.com/aquaproj/aqua/v2/pkg/config/registry"
 	"github.com/aquaproj/aqua/v2/pkg/fuzzyfinder"
 	"github.com/aquaproj/aqua/v2/pkg/github"
+	"github.com/aquaproj/aqua/v2/pkg/log"
 	"github.com/aquaproj/aqua/v2/pkg/ptr"
+	"github.com/aquaproj/aqua/v2/pkg/runtime"
 	"github.com/aquaproj/aqua/v2/pkg/versiongetter"
 	"github.com/google/go-cmp/cmp"
 )
@@ -55,7 +57,7 @@ func TestGitHubTagVersionGetter_Get(t *testing.T) { //nolint:dupl
 			t.Parallel()
 			ghTagClient := versiongetter.NewMockGitHubTagClient(d.tags)
 			ghTagGetter := versiongetter.NewGitHubTag(ghTagClient)
-			version, err := ghTagGetter.Get(ctx, d.pkg, d.filters)
+			version, err := ghTagGetter.Get(ctx, log.New(runtime.New(), ""), d.pkg, d.filters)
 			if err != nil {
 				if d.isErr {
 					return
@@ -125,7 +127,7 @@ func TestGitHubTagVersionGetter_List(t *testing.T) { //nolint:funlen
 			t.Parallel()
 			ghTagClient := versiongetter.NewMockGitHubTagClient(d.tags)
 			ghTagGetter := versiongetter.NewGitHubTag(ghTagClient)
-			items, err := ghTagGetter.List(ctx, d.pkg, d.filters, -1)
+			items, err := ghTagGetter.List(ctx, log.New(runtime.New(), ""), d.pkg, d.filters, -1)
 			if err != nil {
 				if d.isErr {
 					return

--- a/pkg/versiongetter/mock_github_release.go
+++ b/pkg/versiongetter/mock_github_release.go
@@ -23,7 +23,8 @@ func (g *MockGitHubReleaseClient) GetLatestRelease(ctx context.Context, repoOwne
 	if !ok {
 		return nil, nil, errors.New("repository isn't found")
 	}
-	return releases[0], nil, nil
+	resp := &github.Response{}
+	return releases[0], resp, nil
 }
 
 func (g *MockGitHubReleaseClient) ListReleases(ctx context.Context, owner, repo string, opts *github.ListOptions) ([]*github.RepositoryRelease, *github.Response, error) {

--- a/pkg/versiongetter/mock_version_getter.go
+++ b/pkg/versiongetter/mock_version_getter.go
@@ -19,7 +19,7 @@ func NewMockVersionGetter(versions map[string][]*fuzzyfinder.Item) *MockVersionG
 	}
 }
 
-func (g *MockVersionGetter) Get(ctx context.Context, pkg *registry.PackageInfo, filters []*Filter) (string, error) {
+func (g *MockVersionGetter) Get(ctx context.Context, _ *logrus.Entry, pkg *registry.PackageInfo, filters []*Filter) (string, error) {
 	versions, ok := g.versions[pkg.GetName()]
 	if !ok {
 		return "", errors.New("version isn't found")

--- a/pkg/versiongetter/mock_version_getter.go
+++ b/pkg/versiongetter/mock_version_getter.go
@@ -3,6 +3,7 @@ package versiongetter
 import (
 	"context"
 	"errors"
+	"github.com/sirupsen/logrus"
 
 	"github.com/aquaproj/aqua/v2/pkg/config/registry"
 	"github.com/aquaproj/aqua/v2/pkg/fuzzyfinder"
@@ -26,7 +27,7 @@ func (g *MockVersionGetter) Get(ctx context.Context, pkg *registry.PackageInfo, 
 	return versions[0].Item, nil
 }
 
-func (g *MockVersionGetter) List(ctx context.Context, pkg *registry.PackageInfo, filters []*Filter, limit int) ([]*fuzzyfinder.Item, error) {
+func (g *MockVersionGetter) List(ctx context.Context, _ *logrus.Entry, pkg *registry.PackageInfo, filters []*Filter, limit int) ([]*fuzzyfinder.Item, error) {
 	versions, ok := g.versions[pkg.GetName()]
 	if !ok {
 		return nil, errors.New("version isn't found")

--- a/pkg/versiongetter/mock_version_getter.go
+++ b/pkg/versiongetter/mock_version_getter.go
@@ -3,10 +3,10 @@ package versiongetter
 import (
 	"context"
 	"errors"
-	"github.com/sirupsen/logrus"
 
 	"github.com/aquaproj/aqua/v2/pkg/config/registry"
 	"github.com/aquaproj/aqua/v2/pkg/fuzzyfinder"
+	"github.com/sirupsen/logrus"
 )
 
 type MockVersionGetter struct {

--- a/pkg/versiongetter/version_getter.go
+++ b/pkg/versiongetter/version_getter.go
@@ -5,9 +5,10 @@ import (
 
 	"github.com/aquaproj/aqua/v2/pkg/config/registry"
 	"github.com/aquaproj/aqua/v2/pkg/fuzzyfinder"
+	"github.com/sirupsen/logrus"
 )
 
 type VersionGetter interface {
 	Get(ctx context.Context, pkg *registry.PackageInfo, filters []*Filter) (string, error)
-	List(ctx context.Context, pkg *registry.PackageInfo, filters []*Filter, limit int) ([]*fuzzyfinder.Item, error)
+	List(ctx context.Context, logE *logrus.Entry, pkg *registry.PackageInfo, filters []*Filter, limit int) ([]*fuzzyfinder.Item, error)
 }

--- a/pkg/versiongetter/version_getter.go
+++ b/pkg/versiongetter/version_getter.go
@@ -9,6 +9,6 @@ import (
 )
 
 type VersionGetter interface {
-	Get(ctx context.Context, pkg *registry.PackageInfo, filters []*Filter) (string, error)
+	Get(ctx context.Context, logE *logrus.Entry, pkg *registry.PackageInfo, filters []*Filter) (string, error)
 	List(ctx context.Context, logE *logrus.Entry, pkg *registry.PackageInfo, filters []*Filter, limit int) ([]*fuzzyfinder.Item, error)
 }


### PR DESCRIPTION
Solve issue mentioned in #2460 

### Description

- Log processing time for GitHub API
- Log GitHub API Rate Limit info after retrieving the version.
- Log errors when command encounters err.

### Test cases

#### generate

```sh
# get latest version
$ aqua g cli/cli
INFO[0003] GitHub API rate limit info                    aqua_version= env=linux/amd64 gh_rate_limit=60 gh_rate_remaining=59 program=aqua repo=cli/cli
INFO[0003] Retrieve pkg version(s) in 3.734309466s       aqua_version= env=linux/amd64 program=aqua repo=cli/cli
- name: cli/cli@v2.38.0

# get multiple versions
$ aqua g -s cli/cli
INFO[0007] Retrieve pkg version(s) in 5.211403407s       aqua_version= env=linux/amd64 gh_rate_limit=60 gh_rate_remaining=58 program=aqua repo=cli/cli
- name: cli/cli@v2.38.0

$ aqua g -s -l -1 cli/cli
INFO[0011] Retrieve pkg version(s) in 5.069310084s       aqua_version= env=linux/amd64 gh_rate_limit=60 gh_rate_remaining=56 program=aqua repo=cli/cli
- name: cli/cli@v2.38.0

# Reach the Rate Limit
$ INFO[0000] GitHub API rate limit info                    aqua_version= env=linux/amd64 gh_rate_limit=60 gh_rate_remaining=0 program=aqua repo=cli/cli
INFO[0000] Retrieve pkg version(s) in 539.007192ms       aqua_version= env=linux/amd64 program=aqua repo=cli/cli
WARN[0000] Ver retrieving err                            aqua_version= env=linux/amd64 error="get the latest GitHub Release: GET https://api.github.com/repos/cli/cli/releases/latest: 403 API rate limit exceeded for xxx. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) [rate reset in 49m54s]" program=aqua repo=cli/cli
- name: cli/cli
  version: '[SET PACKAGE VERSION]'
```

#### update

```sh
$ aqua up pryrite 
INFO[0000] GitHub API rate limit info                    aqua_version= env=linux/amd64 gh_rate_limit=60 gh_rate_remaining=57 program=aqua repo=1xyz/pryrite
INFO[0000] Retrieve pkg version(s) in 908.514298ms       aqua_version= env=linux/amd64 program=aqua repo=1xyz/pryrite

$ aqua up -s pryrite
INFO[0002] Retrieve pkg version(s) in 803.870181ms       aqua_version= env=linux/amd64 gh_rate_limit=60 gh_rate_remaining=56 program=aqua repo=1xyz/pryrite

$ aqua up -s -l -1 pryrite
INFO[0002] Retrieve pkg version(s) in 899.726603ms       aqua_version= env=linux/amd64 gh_rate_limit=60 gh_rate_remaining=55 program=aqua repo=1xyz/pryrite


# Reach the Rate Limit
$ aqua up pryrite  
INFO[0000] GitHub API rate limit info                    aqua_version= env=linux/amd64 gh_rate_limit=60 gh_rate_remaining=0 program=aqua repo=1xyz/pryrite
INFO[0000] Retrieve pkg version(s) in 453.074916ms       aqua_version= env=linux/amd64 program=aqua repo=1xyz/pryrite
WARN[0000] Version retrieving err                        aqua_version= env=linux/amd64 error="get the latest GitHub Release: GET https://api.github.com/repos/1xyz/pryrite/releases/latest: 403 API rate limit exceeded for xxx. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) [rate reset in 9m47s]" program=aqua repo=1xyz/pryrit
```



