### PR TITLE
feat: add an option `go-version-file`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/aquaproj/aqua/v2
 
 go 1.22.3
 
-toolchain go1.22.3
-
 require (
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/adrg/xdg v0.4.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aquaproj/aqua/v2
 
-go 1.22
+go 1.22.3
 
 toolchain go1.22.3
 

--- a/pkg/config-reader/go_version_file.go
+++ b/pkg/config-reader/go_version_file.go
@@ -1,0 +1,30 @@
+package reader
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"regexp"
+
+	"github.com/aquaproj/aqua/v2/pkg/config/aqua"
+	"github.com/spf13/afero"
+)
+
+var goVersionPattern = regexp.MustCompile(`(?m)^go (\d+\.\d+.\d+)$`)
+
+func readGoVersionFile(fs afero.Fs, filePath string, pkg *aqua.Package) error {
+	if pkg.GoVersionFile == "" {
+		return nil
+	}
+	p := filepath.Join(filepath.Dir(filePath), pkg.GoVersionFile)
+	b, err := afero.ReadFile(fs, p)
+	if err != nil {
+		return fmt.Errorf("open a go version file: %w", err)
+	}
+	matches := goVersionPattern.FindSubmatch(b)
+	if len(matches) == 0 {
+		return errors.New("invalid go version file. No go directive is found. The version must be a semver x.y.z")
+	}
+	pkg.Version = string(matches[1])
+	return nil
+}

--- a/pkg/config-reader/reader.go
+++ b/pkg/config-reader/reader.go
@@ -68,6 +68,9 @@ func (r *ConfigReader) readImports(configFilePath string, cfg *aqua.Config) erro
 			continue
 		}
 		if pkg.Import == "" {
+			if err := readGoVersionFile(r.fs, configFilePath, pkg); err != nil {
+				return err
+			}
 			pkgs = append(pkgs, pkg)
 			continue
 		}
@@ -84,6 +87,9 @@ func (r *ConfigReader) readImports(configFilePath string, cfg *aqua.Config) erro
 			}
 			for _, pkg := range subCfg.Packages {
 				pkg.FilePath = filePath
+				if err := readGoVersionFile(r.fs, filePath, pkg); err != nil {
+					return err
+				}
 				pkgs = append(pkgs, pkg)
 			}
 		}

--- a/pkg/config/aqua/config.go
+++ b/pkg/config/aqua/config.go
@@ -7,15 +7,16 @@ import (
 )
 
 type Package struct {
-	Name        string   `validate:"required" json:"name,omitempty"`
-	Registry    string   `validate:"required" yaml:",omitempty" json:"registry,omitempty" jsonschema:"description=Registry name,example=foo,example=local,default=standard"`
-	Version     string   `validate:"required" yaml:",omitempty" json:"version,omitempty"`
-	Import      string   `yaml:",omitempty" json:"import,omitempty"`
-	Tags        []string `yaml:",omitempty" json:"tags,omitempty"`
-	Description string   `yaml:",omitempty" json:"description,omitempty"`
-	Link        string   `yaml:",omitempty" json:"link,omitempty"`
-	Update      *Update  `yaml:",omitempty" json:"update,omitempty"`
-	FilePath    string   `json:"-" yaml:"-"`
+	Name          string   `validate:"required" json:"name,omitempty"`
+	Registry      string   `validate:"required" yaml:",omitempty" json:"registry,omitempty" jsonschema:"description=Registry name,example=foo,example=local,default=standard"`
+	Version       string   `validate:"required" yaml:",omitempty" json:"version,omitempty"`
+	Import        string   `yaml:",omitempty" json:"import,omitempty"`
+	Tags          []string `yaml:",omitempty" json:"tags,omitempty"`
+	Description   string   `yaml:",omitempty" json:"description,omitempty"`
+	Link          string   `yaml:",omitempty" json:"link,omitempty"`
+	Update        *Update  `yaml:",omitempty" json:"update,omitempty"`
+	FilePath      string   `json:"-" yaml:"-"`
+	GoVersionFile string   `json:"go_version_file,omitempty" yaml:"go_version_file,omitempty"`
 }
 
 type Update struct {

--- a/tests/main/aqua.yaml
+++ b/tests/main/aqua.yaml
@@ -16,3 +16,5 @@ packages:
 - name: cycloidio/terracognita@v0.8.4 # update-checksum -deep
 - name: dlvhdr/gh-dash
   version: v3.8.0 # rename files on Windows
+- name: golang/go
+  go_version_file: ../../go.mod


### PR DESCRIPTION
- https://github.com/orgs/aquaproj/discussions/2609#discussioncomment-8066126

Close #2730

From Go 1.21, the version of Go is decided by go directive in go.mod or go.work.

e.g.

```
module github.com/aquaproj/aqua/v2

go 1.22.3
```

This can cause an issue that the version of Go may be different from the version defined in aqua.yaml.
And we need to define go version in two places.

To solve the issue, this pull request enables aqua to get the version of go from go directive in go.mod or go.work.
You can specify the path to go.mod or go.work by a field `go_version_file`.

e.g.

```yaml
packages:
- name: golang/go
  go_version_file: go.mod
```

Then you can define go version only in go.mod or go.work.

> [!CAUTION]
> The version of Go must be a semver x.y.z.
> You can't omit a patch version.