### PR TITLE
feat(list): support outputting installed packages

### DIFF
--- a/.github/workflows/wc-integration-test.yaml
+++ b/.github/workflows/wc-integration-test.yaml
@@ -54,6 +54,9 @@ jobs:
           GITHUB_TOKEN: ${{steps.token.outputs.token}}
 
       - run: aqua list
+      - run: aqua list -installed
+      - run: aqua list -installed -a
+
       - run: aqua update-checksum
         working-directory: tests/main
         env:

--- a/pkg/cli/list.go
+++ b/pkg/cli/list.go
@@ -23,7 +23,30 @@ standard,99designs/aws-vault
 standard,abiosoft/colima
 standard,abs-lang/abs
 ...
+
+If the option -installed is set, the command lists only installed packages.
+
+$ aqua list -installed
+standard,golangci/golangci-lint,v1.56.2
+standard,goreleaser/goreleaser,v1.24.0
+...
+
+By default, the command doesn't list global configuration packages.
+If you want to list global configuration packages too, please set the option -a.
+
+$ aqua list -installed -a
 `,
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "installed",
+				Usage: "List installed packages",
+			},
+			&cli.BoolFlag{
+				Name:    "all",
+				Aliases: []string{"a"},
+				Usage:   "List global configuration packages too",
+			},
+		},
 	}
 }
 

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -56,6 +56,7 @@ func (r *Runner) setParam(c *cli.Context, commandName string, param *config.Para
 	param.SLSADisabled = c.Bool("disable-slsa")
 	param.Limit = c.Int("limit")
 	param.SelectVersion = c.Bool("select-version")
+	param.Installed = c.Bool("installed")
 	param.ShowVersion = c.Bool("version")
 	param.File = c.String("f")
 	if cmd := c.String("cmd"); cmd != "" {

--- a/pkg/config/package.go
+++ b/pkg/config/package.go
@@ -276,6 +276,7 @@ type Param struct {
 	OnlyRegistry          bool
 	CosignDisabled        bool
 	SLSADisabled          bool
+	Installed             bool
 	PolicyConfigFilePaths []string
 	Commands              []string
 }

--- a/pkg/controller/list/interface.go
+++ b/pkg/controller/list/interface.go
@@ -2,4 +2,5 @@ package list
 
 type ConfigFinder interface {
 	Find(wd, configFilePath string, globalConfigFilePaths ...string) (string, error)
+	Finds(wd, configFilePath string) []string
 }

--- a/pkg/controller/list/list.go
+++ b/pkg/controller/list/list.go
@@ -11,6 +11,9 @@ import (
 )
 
 func (c *Controller) List(ctx context.Context, param *config.Param, logE *logrus.Entry) error { //nolint:cyclop
+	if param.Installed {
+		return c.listInstalled(param, logE)
+	}
 	cfg := &aqua.Config{}
 	cfgFilePath, err := c.configFinder.Find(param.PWD, param.ConfigFilePath, param.GlobalConfigFilePaths...)
 	if err != nil {

--- a/pkg/controller/list/list_installed.go
+++ b/pkg/controller/list/list_installed.go
@@ -43,7 +43,7 @@ func (c *Controller) listInstalledByConfig(cfgFilePath string) error {
 		return err //nolint:wrapcheck
 	}
 	for _, pkg := range cfg.Packages {
-		fmt.Fprintln(c.stdout, pkg.Registry+","+pkg.Name+","+pkg.Version)
+		fmt.Fprintln(c.stdout, pkg.Name+"\t"+pkg.Version+"\t"+pkg.Registry)
 	}
 	return nil
 }

--- a/pkg/controller/list/list_installed.go
+++ b/pkg/controller/list/list_installed.go
@@ -1,0 +1,49 @@
+package list
+
+import (
+	"fmt"
+
+	"github.com/aquaproj/aqua/v2/pkg/config"
+	"github.com/aquaproj/aqua/v2/pkg/config/aqua"
+	"github.com/sirupsen/logrus"
+	"github.com/suzuki-shunsuke/logrus-error/logerr"
+)
+
+func (c *Controller) listInstalled(param *config.Param, logE *logrus.Entry) error {
+	for _, cfgFilePath := range c.configFinder.Finds(param.PWD, param.ConfigFilePath) {
+		if err := c.listInstalledByConfig(cfgFilePath); err != nil {
+			return logerr.WithFields(err, logrus.Fields{ //nolint:wrapcheck
+				"config_file_path": cfgFilePath,
+			})
+		}
+	}
+
+	if !param.All {
+		return nil
+	}
+
+	for _, cfgFilePath := range param.GlobalConfigFilePaths {
+		logE := logE.WithField("config_file_path", cfgFilePath)
+		logE.Debug("checking a global configuration file")
+		if _, err := c.fs.Stat(cfgFilePath); err != nil {
+			continue
+		}
+		if err := c.listInstalledByConfig(cfgFilePath); err != nil {
+			return logerr.WithFields(err, logrus.Fields{ //nolint:wrapcheck
+				"config_file_path": cfgFilePath,
+			})
+		}
+	}
+	return nil
+}
+
+func (c *Controller) listInstalledByConfig(cfgFilePath string) error {
+	cfg := &aqua.Config{}
+	if err := c.configReader.Read(cfgFilePath, cfg); err != nil {
+		return err //nolint:wrapcheck
+	}
+	for _, pkg := range cfg.Packages {
+		fmt.Fprintln(c.stdout, pkg.Registry+","+pkg.Name+","+pkg.Version)
+	}
+	return nil
+}


### PR DESCRIPTION
Add command line options `-installed` and `-all (-a)` to the command `list`.

If `-installed` is set, only installed packages are outputted.

```console
$ aqua list -installed
standard,rhysd/actionlint,v1.6.27
standard,suzuki-shunsuke/cmdx,v1.7.4
standard,sigstore/cosign,v1.13.2
standard,suzuki-shunsuke/ghalint,v0.2.9
standard,int128/ghcp,v1.13.2
standard,golangci/golangci-lint,v1.56.2
standard,goreleaser/goreleaser,v1.24.0
standard,reviewdog/reviewdog,v0.17.1
```

By default, global configuration files are ignored.
If `-a` is set, packages in global configuration files are also outputted.

```console
$ aqua list -installed -a
standard,rhysd/actionlint,v1.6.27
standard,suzuki-shunsuke/cmdx,v1.7.4
standard,sigstore/cosign,v1.13.2
standard,suzuki-shunsuke/ghalint,v0.2.9
standard,int128/ghcp,v1.13.2
standard,golangci/golangci-lint,v1.56.2
standard,goreleaser/goreleaser,v1.24.0
standard,reviewdog/reviewdog,v0.17.1
standard,1xyz/pryrite,0.10.20
standard,99designs/aws-vault,v7.2.0
standard,99designs/aws-vault,v6.5.0
standard,99designs/aws-vault,v6.3.0
...
```

⚠️ Note that this command can output the same packages at multiple times.

e.g.

```
standard,99designs/aws-vault,v7.2.0
standard,99designs/aws-vault,v6.5.0
standard,99designs/aws-vault,v6.3.0
```

This is not a bug.
This occurs if one aqua.yaml has the same packages or multiple aqua.yaml have same packages.
If you execute the package on the current directory, the first package's version is used.