### PR TITLE
fix: improve the logic to get the latest version

### DIFF
--- a/pkg/controller/generate-registry/version_overrides.go
+++ b/pkg/controller/generate-registry/version_overrides.go
@@ -3,12 +3,12 @@ package genrgst
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"sort"
 
 	"github.com/aquaproj/aqua/v2/pkg/config/aqua"
 	"github.com/aquaproj/aqua/v2/pkg/config/registry"
 	"github.com/aquaproj/aqua/v2/pkg/github"
+	"github.com/aquaproj/aqua/v2/pkg/versiongetter"
 	"github.com/hashicorp/go-version"
 	"github.com/sirupsen/logrus"
 	"github.com/suzuki-shunsuke/logrus-error/logerr"
@@ -46,29 +46,12 @@ func listPkgsFromVersions(pkgName string, versions []string) []*aqua.Package {
 	return pkgs
 }
 
-var versionPattern = regexp.MustCompile(`^(.*?)v?((?:\d+)(?:\.\d+)?(?:\.\d+)?(?:(\.|-).+)?)$`)
-
-func GetVersionAndPrefix(tag string) (*version.Version, string, error) {
-	if v, err := version.NewVersion(tag); err == nil {
-		return v, "", nil
-	}
-	a := versionPattern.FindStringSubmatch(tag)
-	if a == nil {
-		return nil, "", nil
-	}
-	v, err := version.NewVersion(a[2])
-	if err != nil {
-		return nil, "", err //nolint:wrapcheck
-	}
-	return v, a[1], nil
-}
-
 func (c *Controller) getPackageInfoWithVersionOverrides(ctx context.Context, logE *logrus.Entry, pkgName string, pkgInfo *registry.PackageInfo, limit int) (*registry.PackageInfo, []string) {
 	ghReleases := c.listReleases(ctx, logE, pkgInfo, limit)
 	releases := make([]*Release, len(ghReleases))
 	for i, release := range ghReleases {
 		tag := release.GetTagName()
-		v, prefix, err := GetVersionAndPrefix(tag)
+		v, prefix, err := versiongetter.GetVersionAndPrefix(tag)
 		if err != nil {
 			logE.WithField("tag_name", tag).WithError(err).Warn("parse a tag as semver")
 		}

--- a/pkg/versiongetter/github_release.go
+++ b/pkg/versiongetter/github_release.go
@@ -85,7 +85,7 @@ func getLatestRelease(releases []*Release) *Release {
 	return latest
 }
 
-func (g *GitHubReleaseVersionGetter) Get(ctx context.Context, logE *logrus.Entry, pkg *registry.PackageInfo, filters []*Filter) (string, error) { //nolint:cyclop
+func (g *GitHubReleaseVersionGetter) Get(ctx context.Context, logE *logrus.Entry, pkg *registry.PackageInfo, filters []*Filter) (string, error) {
 	repoOwner := pkg.RepoOwner
 	repoName := pkg.RepoName
 
@@ -120,18 +120,14 @@ func (g *GitHubReleaseVersionGetter) Get(ctx context.Context, logE *logrus.Entry
 				candidates = append(candidates, convRelease(release))
 			}
 		}
-		if resp.NextPage == 0 {
-			break
-		}
 		if len(candidates) > 0 {
-			break
+			return getLatestRelease(candidates).Tag, nil
+		}
+		if resp.NextPage == 0 {
+			return "", nil
 		}
 		opt.Page = resp.NextPage
 	}
-	if len(candidates) == 0 {
-		return "", nil
-	}
-	return getLatestRelease(candidates).Tag, nil
 }
 
 func (g *GitHubReleaseVersionGetter) List(ctx context.Context, logE *logrus.Entry, pkg *registry.PackageInfo, filters []*Filter, limit int) ([]*fuzzyfinder.Item, error) {


### PR DESCRIPTION
Close #2354

Change the logic to get the latest version as the following.

1. Get a latest release and 30 most recent releases by GitHub API
2. Try to convert them to semver
3. Compare them and get the latest release

prelease versions are ignored unless all releases are prelease versions.