### PR TITLE
fix(yaml): Fix spaces before comments

### DIFF
--- a/pkg/controller/initcmd/init.go
+++ b/pkg/controller/initcmd/init.go
@@ -21,7 +21,7 @@ const configTemplate = `---
 #   - all
 registries:
 - type: standard
-  ref: %%STANDARD_REGISTRY_VERSION%% # renovate: depName=aquaproj/aqua-registry
+  ref: %%STANDARD_REGISTRY_VERSION%%  # renovate: depName=aquaproj/aqua-registry
 packages:
 `
 


### PR DESCRIPTION
Tools like `yamllint` by default set two spaces from content to comment:

https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.comments

Output the yaml comment for renvoate to pass yamllint.