### PR TITLE
fix: improve handling of broken registry JSON files

### DIFF
--- a/pkg/install-registry/install.go
+++ b/pkg/install-registry/install.go
@@ -147,7 +147,7 @@ func (is *Installer) handleYAMLGitHubContent(ctx context.Context, logE *logrus.E
 		if !errors.Is(err, os.ErrNotExist) {
 			logerr.WithError(logE, err).WithFields(logrus.Fields{
 				"registry_json_path": jsonPath,
-			}).Warn("failed to read a registry JSON file. Will remove the file to recreate it")
+			}).Warn("failed to read a registry JSON file. Will remove and recreate the file")
 			if err := is.fs.Remove(jsonPath); err != nil {
 				logerr.WithError(logE, err).WithFields(logrus.Fields{
 					"registry_json_path": jsonPath,

--- a/pkg/install-registry/install.go
+++ b/pkg/install-registry/install.go
@@ -145,7 +145,18 @@ func (is *Installer) handleYAMLGitHubContent(ctx context.Context, logE *logrus.E
 	registryContent := &registry.Config{}
 	if err := is.readJSONRegistry(jsonPath, registryContent); err != nil { //nolint:nestif
 		if !errors.Is(err, os.ErrNotExist) {
-			return nil, err
+			logerr.WithError(logE, err).WithFields(logrus.Fields{
+				"registry_json_path": jsonPath,
+			}).Debug("read a registry JSON file")
+			if err := is.fs.Remove(jsonPath); err != nil {
+				logerr.WithError(logE, err).WithFields(logrus.Fields{
+					"registry_json_path": jsonPath,
+				}).Debug("failed to remove a registry JSON file")
+			} else {
+				logE.WithFields(logrus.Fields{
+					"registry_json_path": jsonPath,
+				}).Debug("remove a registry JSON file")
+			}
 		}
 		if err := is.readYAMLRegistry(registryFilePath, registryContent); err != nil {
 			if !errors.Is(err, os.ErrNotExist) {

--- a/pkg/install-registry/install.go
+++ b/pkg/install-registry/install.go
@@ -147,11 +147,11 @@ func (is *Installer) handleYAMLGitHubContent(ctx context.Context, logE *logrus.E
 		if !errors.Is(err, os.ErrNotExist) {
 			logerr.WithError(logE, err).WithFields(logrus.Fields{
 				"registry_json_path": jsonPath,
-			}).Debug("read a registry JSON file")
+			}).Warn("failed to read a registry JSON file. Will remove the file to recreate it")
 			if err := is.fs.Remove(jsonPath); err != nil {
 				logerr.WithError(logE, err).WithFields(logrus.Fields{
 					"registry_json_path": jsonPath,
-				}).Debug("failed to remove a registry JSON file")
+				}).Warn("failed to remove a registry JSON file")
 			} else {
 				logE.WithFields(logrus.Fields{
 					"registry_json_path": jsonPath,


### PR DESCRIPTION
Close #2829

If it failed to read a registry JSON file, aqua failed. In that case, users have to remove the file themselves.
This commit improves the behavior so that aqua can handle broken regsistry JSON files well.
If it fails to read a registry JSON file, aqua removes the file, reads a registry YAML file, and recreates a registry JSON file, and continues the process.

## Test

aqua.yaml

```yaml
registries:
- type: standard
  ref: v4.160.0  # renovate: depName=aquaproj/aqua-registry
packages:
```

Break a registry json file.

```sh
echo "" > ~/.local/share/aquaproj-aqua/registries/github_content/github.com/aquaproj/aqua-registry/v4.160.0/registry.yaml.json
```

Without this change, aqua fails.

```console
$ aqua which gh
ERRO[0000] install the registry                          aqua_version=2.27.1 env=darwin/arm64 error="parse the registry configuration as JSON: EOF" exe_name=gh program=aqua registry_name=standard
FATA[0000] aqua failed                                   aqua_version=2.27.1 env=darwin/arm64 error="it failed to install some registries" exe_name=gh program=aqua
```

This change resolves the issue.

```console
$ aqua which gh                                                                                             
WARN[0000] failed to read a registry JSON file. Will remove and recreate the file  aqua_version= env=darwin/arm64 error="parse the registry configuration as JSON: EOF" exe_name=gh program=aqua registry_json_path=/Users/shunsukesuzuki/.local/share/aquaproj-aqua/registries/github_content/github.com/aquaproj/aqua-registry/v4.160.0/registry.yaml.json
/Users/shunsukesuzuki/.local/share/aquaproj-aqua/pkgs/github_release/github.com/cli/cli/v2.48.0/gh_2.48.0_macOS_arm64.zip/gh_2.48.0_macOS_arm64/bin/gh
```