### PR TITLE
fix(checksum): fix a bug that a checksum id of go_build type package is empty

### DIFF
--- a/pkg/config/checksum.go
+++ b/pkg/config/checksum.go
@@ -20,7 +20,7 @@ func (p *Package) ChecksumID(rt *runtime.Runtime) (string, error) {
 	pkgInfo := p.PackageInfo
 	pkg := p.Package
 	switch pkgInfo.Type {
-	case PkgInfoTypeGitHubArchive:
+	case PkgInfoTypeGitHubArchive, PkgInfoTypeGoBuild:
 		return path.Join(pkgInfo.Type, "github.com", pkgInfo.RepoOwner, pkgInfo.RepoName, pkg.Version), nil
 	case PkgInfoTypeGitHubContent, PkgInfoTypeGitHubRelease:
 		return path.Join(pkgInfo.Type, "github.com", pkgInfo.RepoOwner, pkgInfo.RepoName, pkg.Version, assetName), nil


### PR DESCRIPTION
- https://github.com/aquaproj/aqua-registry/issues/22170#issuecomment-2073573908

## Test

I've confirmed the bug was solved.

- https://github.com/aquaproj/aqua-registry/issues/22170#issuecomment-2073573908

```
aqua upc
```

```json
{
  "checksums": [
    {
      "id": "go_build/github.com/alpkeskin/mosint/v2.3.1",
      "checksum": "C4D72E482B85570A1A73776EEF47E993B5F8FA6C204E0B1CAA794E4DF4F13521",
      "algorithm": "sha256"
    },
    {
      "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.164.0/registry.yaml",
      "checksum": "FA1425688665781E57A2DDED9F1695D7BD4D90439D3A00BE78DE8CF2F90BF54D",
      "algorithm": "sha256"
    }
  ]
}
```