### PR TITLE
fix: set GOOS=windows when building go_install package with AQUA_GOOS=windows

### DIFF
--- a/pkg/config/package.go
+++ b/pkg/config/package.go
@@ -189,7 +189,7 @@ func getArch(rosetta2, windowsARMEmulation bool, replacements registry.Replaceme
 		// Rosetta 2
 		return replace("amd64", replacements)
 	}
-	if windowsARMEmulation && rt.GOOS == "windows" && rt.GOARCH == "arm64" {
+	if windowsARMEmulation && rt.IsWindows() && rt.GOARCH == "arm64" {
 		// Windows ARM Emulation
 		return replace("amd64", replacements)
 	}

--- a/pkg/controller/cp/copy.go
+++ b/pkg/controller/cp/copy.go
@@ -11,7 +11,7 @@ import (
 
 func (c *Controller) copy(logE *logrus.Entry, param *config.Param, findResult *which.FindResult, exeName string) error {
 	p := filepath.Join(param.Dest, exeName)
-	if c.runtime.GOOS == "windows" && filepath.Ext(exeName) == "" {
+	if c.runtime.IsWindows() && filepath.Ext(exeName) == "" {
 		p += ".exe"
 	}
 	logE.WithFields(logrus.Fields{

--- a/pkg/controller/install/install.go
+++ b/pkg/controller/install/install.go
@@ -58,7 +58,7 @@ func (c *Controller) mkBinBatDir() error {
 	if err := osfile.MkdirAll(c.fs, rootBin); err != nil {
 		return fmt.Errorf("create the directory: %w", err)
 	}
-	if c.runtime.GOOS == "windows" {
+	if c.runtime.IsWindows() {
 		if err := osfile.MkdirAll(c.fs, filepath.Join(c.rootDir, "bat")); err != nil {
 			return fmt.Errorf("create the directory: %w", err)
 		}

--- a/pkg/cosign/exe_path.go
+++ b/pkg/cosign/exe_path.go
@@ -14,7 +14,7 @@ type ParamExePath struct {
 
 func ExePath(param *ParamExePath) string {
 	assetName := fmt.Sprintf("cosign-%s-%s", param.Runtime.GOOS, param.Runtime.GOARCH)
-	if param.Runtime.GOOS == "windows" {
+	if param.Runtime.IsWindows() {
 		assetName += ".exe"
 	}
 	return filepath.Join(param.RootDir, "pkgs", "github_release", "github.com", "sigstore", "cosign", Version, assetName, assetName)

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -46,7 +46,7 @@ func NewVerifier(executor Executor, fs afero.Fs, downloader download.ClientAPI, 
 			Runtime: rt,
 		}),
 		// assets for windows/arm64 aren't released.
-		disabled: rt.GOOS == "windows" && rt.GOARCH == "arm64",
+		disabled: rt.IsWindows() && rt.GOARCH == "arm64",
 	}
 }
 

--- a/pkg/installpackage/aqua.go
+++ b/pkg/installpackage/aqua.go
@@ -28,7 +28,7 @@ func (is *Installer) InstallAqua(ctx context.Context, logE *logrus.Entry, versio
 			Format:    "tar.gz",
 			Overrides: []*registry.Override{
 				{
-					GOOS:   "windows",
+					GOOS:   osWindows,
 					Format: "zip",
 				},
 			},
@@ -132,7 +132,7 @@ func (is *Installer) InstallAqua(ctx context.Context, logE *logrus.Entry, versio
 		return fmt.Errorf("get the executable file path: %w", err)
 	}
 
-	if is.runtime.GOOS == "windows" {
+	if is.runtime.IsWindows() {
 		return is.Copy(filepath.Join(is.rootDir, "bin", "aqua.exe"), exePath)
 	}
 

--- a/pkg/installpackage/const.go
+++ b/pkg/installpackage/const.go
@@ -1,0 +1,5 @@
+package installpackage
+
+const (
+	osWindows = "windows"
+)

--- a/pkg/installpackage/download.go
+++ b/pkg/installpackage/download.go
@@ -57,7 +57,7 @@ func (is *Installer) download(ctx context.Context, logE *logrus.Entry, param *Do
 	pkgInfo := param.Package.PackageInfo
 
 	if pkgInfo.Type == "go_install" {
-		return is.downloadGoInstall(ctx, ppkg, param.Dest, logE)
+		return is.downloadGoInstall(ctx, logE, ppkg, param.Dest, is.runtime.GOOS)
 	}
 
 	if pkgInfo.Type == "cargo" {

--- a/pkg/installpackage/go_install.go
+++ b/pkg/installpackage/go_install.go
@@ -9,7 +9,7 @@ import (
 )
 
 type GoInstallInstaller interface {
-	Install(ctx context.Context, path, gobin string) error
+	Install(ctx context.Context, path, gobin, goos string) error
 }
 
 type GoInstallInstallerImpl struct {
@@ -22,15 +22,18 @@ func NewGoInstallInstallerImpl(exec Executor) *GoInstallInstallerImpl {
 	}
 }
 
-func (is *GoInstallInstallerImpl) Install(ctx context.Context, path, gobin string) error {
-	_, err := is.exec.ExecWithEnvs(ctx, "go", []string{"install", path}, []string{"GOBIN=" + gobin})
-	if err != nil {
+func (is *GoInstallInstallerImpl) Install(ctx context.Context, path, gobin, goos string) error {
+	envs := []string{"GOBIN=" + gobin}
+	if goos == "windows" {
+		envs = append(envs, "GOOS=windows")
+	}
+	if _, err := is.exec.ExecWithEnvs(ctx, "go", []string{"install", path}, envs); err != nil {
 		return fmt.Errorf("install a go package: %w", err)
 	}
 	return nil
 }
 
-func (is *Installer) downloadGoInstall(ctx context.Context, pkg *config.Package, dest string, logE *logrus.Entry) error {
+func (is *Installer) downloadGoInstall(ctx context.Context, logE *logrus.Entry, pkg *config.Package, dest, goos string) error {
 	p, err := pkg.RenderPath()
 	if err != nil {
 		return fmt.Errorf("render Go Module Path: %w", err)
@@ -40,7 +43,7 @@ func (is *Installer) downloadGoInstall(ctx context.Context, pkg *config.Package,
 		"gobin":           dest,
 		"go_package_path": goPkgPath,
 	}).Info("Installing a Go tool")
-	if err := is.goInstallInstaller.Install(ctx, goPkgPath, dest); err != nil {
+	if err := is.goInstallInstaller.Install(ctx, goPkgPath, dest, goos); err != nil {
 		return fmt.Errorf("build Go tool: %w", err)
 	}
 	return nil

--- a/pkg/installpackage/mock_go_install.go
+++ b/pkg/installpackage/mock_go_install.go
@@ -8,6 +8,6 @@ type MockGoInstallInstaller struct {
 	Err error
 }
 
-func (m *MockGoInstallInstaller) Install(ctx context.Context, path, gobin string) error {
+func (m *MockGoInstallInstaller) Install(ctx context.Context, path, gobin, goos string) error {
 	return m.Err
 }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -29,6 +29,10 @@ func (rt *Runtime) Env() string {
 	return fmt.Sprintf("%s/%s", rt.GOOS, rt.GOARCH)
 }
 
+func (rt *Runtime) IsWindows() bool {
+	return rt.GOOS == "windows"
+}
+
 func goos() string {
 	if s := os.Getenv("AQUA_GOOS"); s != "" {
 		return s

--- a/pkg/slsa/exe_path.go
+++ b/pkg/slsa/exe_path.go
@@ -14,7 +14,7 @@ type ParamExePath struct {
 
 func ExePath(param *ParamExePath) string {
 	assetName := fmt.Sprintf("slsa-verifier-%s-%s", param.Runtime.GOOS, param.Runtime.GOARCH)
-	if param.Runtime.GOOS == "windows" {
+	if param.Runtime.IsWindows() {
 		assetName += ".exe"
 	}
 	return filepath.Join(param.RootDir, "pkgs", "github_release", "github.com", "slsa-framework", "slsa-verifier", Version, assetName, assetName)


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
  - [ ] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [ ] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue:
- [ ] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [ ] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [ ] Do only one thing in one Pull Request

<!-- Please write the description here -->
