### PR TITLE
fix(info): mask username on Windows

### DIFF
--- a/pkg/controller/info/info.go
+++ b/pkg/controller/info/info.go
@@ -50,12 +50,25 @@ func maskUser(s, username string) string {
 	return strings.ReplaceAll(s, username, "(USER)")
 }
 
-func (c *Controller) Info(_ context.Context, _ *logrus.Entry, param *config.Param) error { //nolint:funlen
+func getCurrentUserName() (string, error) {
 	currentUser, err := user.Current()
 	if err != nil {
-		return fmt.Errorf("get a current user: %w", err)
+		return "", fmt.Errorf("get a current user: %w", err)
 	}
 	userName := currentUser.Username
+	if runtime.GOOS == "windows" {
+		// On Windows, the user name is in the form of "domain\user".
+		const domainUserPartCount = 2
+		userName = strings.SplitN(userName, "\\", domainUserPartCount)[domainUserPartCount-1]
+	}
+	return userName, nil
+}
+
+func (c *Controller) Info(_ context.Context, _ *logrus.Entry, param *config.Param) error { //nolint:funlen
+	userName, err := getCurrentUserName()
+	if err != nil {
+		return fmt.Errorf("get a current user name: %w", err)
+	}
 
 	filePaths := c.finder.Finds(param.PWD, param.ConfigFilePath)
 	cfgs := make([]*Config, len(filePaths))

--- a/pkg/controller/info/info.go
+++ b/pkg/controller/info/info.go
@@ -58,8 +58,11 @@ func getCurrentUserName() (string, error) {
 	userName := currentUser.Username
 	if runtime.GOOS == "windows" {
 		// On Windows, the user name is in the form of "domain\user".
-		const domainUserPartCount = 2
-		userName = strings.SplitN(userName, "\\", domainUserPartCount)[domainUserPartCount-1]
+		domain, userName, ok := strings.Cut(userName, "\\")
+		if ok {
+			return userName, nil
+		}
+		return domain, nil
 	}
 	return userName, nil
 }


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: fixes #2731
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->

On windows, [`user.Current().Username` returns a string with domain and user concatenated](https://github.com/golang/go/blob/1667dbd7be0da5e75a25f14c339c859ed2190b43/src/os/user/lookup_windows.go#L180-L188). This seems to be called as [down-level logon name](https://learn.microsoft.com/en-us/windows/win32/secauthn/user-name-formats#down-level-logon-name).
This PR makes the domain part to be trimmed, so that the username is masked when running the info command.
