### PR TITLE
Added `-i` alias for aqua list --installed

### DIFF
--- a/pkg/cli/list.go
+++ b/pkg/cli/list.go
@@ -38,8 +38,9 @@ $ aqua list -installed -a
 `,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
-				Name:  "installed",
-				Usage: "List installed packages",
+				Name:    "installed",
+				Aliases: []string{"i"},
+				Usage:   "List installed packages",
 			},
 			&cli.BoolFlag{
 				Name:    "all",


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: https://github.com/aquaproj/aqua/issues/2952
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

## Description

Currently, `aqua list -i` is missing whereas `aqua list --installed` exist.
This PR add `-i` for shorthand for `--installed`.
