### PR TITLE
feat: add the subcommand `set-shell` to change the environment variable `PATH` for Node.js and Python Support

### DIFF
--- a/.github/workflows/wc-integration-test.yaml
+++ b/.github/workflows/wc-integration-test.yaml
@@ -70,13 +70,14 @@ jobs:
           cd v20.16.0
           aqua i
           eval "$(aqua set-shell bash)"
+          eval "$(aqua output-shell)"
           node -v
           npm -v
           npm i -g renovate
           renovate -v
 
           cd v22.6.0
-          eval "$(aqua set-shell bash)"
+          eval "$(aqua output-shell)"
           node -v
           npm -v
           npm i -g renovate

--- a/.github/workflows/wc-integration-test.yaml
+++ b/.github/workflows/wc-integration-test.yaml
@@ -62,6 +62,27 @@ jobs:
       - run: aqua list -installed
       - run: aqua list -installed -a
 
+      - run: aqua output-shell
+      - run: aqua set-shell bash
+      - run: aqua set-shell zsh
+      - run: |
+          set -eux
+          cd v20.16.0
+          aqua i
+          eval "$(aqua set-shell bash)"
+          node -v
+          npm -v
+          npm i -g renovate
+          renovate -v
+
+          cd v22.6.0
+          eval "$(aqua set-shell bash)"
+          node -v
+          npm -v
+          npm i -g renovate
+          renovate -v
+        working-directory: tests/nodejs
+
       - run: aqua update-checksum
         working-directory: tests/main
         env:

--- a/.github/workflows/wc-integration-test.yaml
+++ b/.github/workflows/wc-integration-test.yaml
@@ -76,7 +76,7 @@ jobs:
           npm i -g renovate
           renovate -v
 
-          cd v22.6.0
+          cd ../v22.6.0
           eval "$(aqua output-shell)"
           node -v
           npm -v

--- a/json-schema/registry.json
+++ b/json-schema/registry.json
@@ -373,6 +373,9 @@
         },
         "envs": {
           "$ref": "#/$defs/SupportedEnvs"
+        },
+        "shell": {
+          "$ref": "#/$defs/Shell"
         }
       },
       "additionalProperties": false,
@@ -530,6 +533,9 @@
             "$ref": "#/$defs/VersionOverride"
           },
           "type": "array"
+        },
+        "shell": {
+          "$ref": "#/$defs/Shell"
         }
       },
       "additionalProperties": false,
@@ -590,6 +596,18 @@
         },
         "source_uri": {
           "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Shell": {
+      "properties": {
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
         }
       },
       "additionalProperties": false,
@@ -724,6 +742,9 @@
         },
         "supported_envs": {
           "$ref": "#/$defs/SupportedEnvs"
+        },
+        "shell": {
+          "$ref": "#/$defs/Shell"
         }
       },
       "additionalProperties": false,

--- a/pkg/cli/output_shell.go
+++ b/pkg/cli/output_shell.go
@@ -12,8 +12,9 @@ import (
 
 func (r *Runner) newOutputShellCommand() *cli.Command {
 	return &cli.Command{
-		Name:  "output-shell",
-		Usage: "Output a script to set the shell",
+		Name:   "output-shell",
+		Hidden: true, // Hide this command from users as it is not intended to be used directly. This command is called by set-shell command.
+		Usage:  "Output a script to set the shell",
 		Description: `Output a script to set the shell
 
 aqua set-shell command executes this command.

--- a/pkg/cli/output_shell.go
+++ b/pkg/cli/output_shell.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/aquaproj/aqua/v2/pkg/config"
+	"github.com/aquaproj/aqua/v2/pkg/controller"
+	"github.com/urfave/cli/v2"
+)
+
+func (r *Runner) newOutputShellCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "output-shell",
+		Usage: "Output a script to set the shell",
+		Description: `Output a script to set the shell
+
+aqua set-shell command executes this command.
+`,
+		Action: r.outputShellAction,
+		Flags:  []cli.Flag{},
+	}
+}
+
+func (r *Runner) outputShellAction(c *cli.Context) error {
+	tracer, err := startTrace(c.String("trace"))
+	if err != nil {
+		return err
+	}
+	defer tracer.Stop()
+
+	cpuProfiler, err := startCPUProfile(c.String("cpu-profile"))
+	if err != nil {
+		return err
+	}
+	defer cpuProfiler.Stop()
+
+	param := &config.Param{
+		Ppid:              os.Getppid(),
+		EnvPath:           os.Getenv("PATH"),
+		PathListSeparator: string(os.PathListSeparator),
+	}
+	if err := r.setParam(c, "output-shell", param); err != nil {
+		return fmt.Errorf("parse the command line arguments: %w", err)
+	}
+	ctrl, err := controller.InitializeOutputShellCommandController(c.Context, param, http.DefaultClient, r.Runtime, r.Stdout)
+	if err != nil {
+		return fmt.Errorf("initialize a OutputShellController: %w", err)
+	}
+	return ctrl.OutputShell(c.Context, r.LogE, param) //nolint:wrapcheck
+}

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -215,6 +215,7 @@ func (r *Runner) Run(ctx context.Context, args ...string) error { //nolint:funle
 			r.newUpdateChecksumCommand(),
 			r.newRemoveCommand(),
 			r.newUpdateCommand(),
+			r.newSetShellCommand(),
 		},
 	}
 

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -216,6 +216,7 @@ func (r *Runner) Run(ctx context.Context, args ...string) error { //nolint:funle
 			r.newRemoveCommand(),
 			r.newUpdateCommand(),
 			r.newSetShellCommand(),
+			r.newOutputShellCommand(),
 		},
 	}
 

--- a/pkg/cli/set_shell.go
+++ b/pkg/cli/set_shell.go
@@ -43,7 +43,7 @@ func (r *Runner) setShellAction(c *cli.Context) error {
 	defer cpuProfiler.Stop()
 
 	param := &config.Param{
-		Pid:               os.Getpid(),
+		Ppid:              os.Getppid(),
 		EnvPath:           os.Getenv("PATH"),
 		PathListSeparator: string(os.PathListSeparator),
 	}

--- a/pkg/cli/set_shell.go
+++ b/pkg/cli/set_shell.go
@@ -54,5 +54,5 @@ func (r *Runner) setShellAction(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("initialize a SetShellController: %w", err)
 	}
-	return ctrl.SetShell(c.Context, r.LogE, param) //nolint:wrapcheck
+	return ctrl.SetShell(c.Context, r.LogE, param, c.Args().First()) //nolint:wrapcheck
 }

--- a/pkg/cli/set_shell.go
+++ b/pkg/cli/set_shell.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/aquaproj/aqua/v2/pkg/config"
+	"github.com/aquaproj/aqua/v2/pkg/controller"
+	"github.com/urfave/cli/v2"
+)
+
+func (r *Runner) newSetShellCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "set-shell",
+		Usage: "Output a script to set the shell",
+		Description: `Output a script to set the shell
+
+Please run this command in the shell script such as .bashrc and .zshrc.
+
+eval "$(aqua set-shell <shell name>)"
+
+The supported shell names are:
+
+- zsh
+`,
+		Action: r.setShellAction,
+		Flags:  []cli.Flag{},
+	}
+}
+
+func (r *Runner) setShellAction(c *cli.Context) error {
+	tracer, err := startTrace(c.String("trace"))
+	if err != nil {
+		return err
+	}
+	defer tracer.Stop()
+
+	cpuProfiler, err := startCPUProfile(c.String("cpu-profile"))
+	if err != nil {
+		return err
+	}
+	defer cpuProfiler.Stop()
+
+	param := &config.Param{
+		Pid:               os.Getpid(),
+		EnvPath:           os.Getenv("PATH"),
+		PathListSeparator: string(os.PathListSeparator),
+	}
+	if err := r.setParam(c, "set-shell", param); err != nil {
+		return fmt.Errorf("parse the command line arguments: %w", err)
+	}
+	ctrl, err := controller.InitializeSetShellCommandController(c.Context, param, http.DefaultClient, r.Runtime, r.Stdout)
+	if err != nil {
+		return fmt.Errorf("initialize a SetShellController: %w", err)
+	}
+	return ctrl.SetShell(c.Context, r.LogE, param) //nolint:wrapcheck
+}

--- a/pkg/config/package.go
+++ b/pkg/config/package.go
@@ -283,7 +283,7 @@ type Param struct {
 	Installed              bool
 	PolicyConfigFilePaths  []string
 	Commands               []string
-	Pid                    int
+	Ppid                   int
 	EnvPath                string
 	PathListSeparator      string
 }

--- a/pkg/config/package.go
+++ b/pkg/config/package.go
@@ -283,6 +283,9 @@ type Param struct {
 	Installed              bool
 	PolicyConfigFilePaths  []string
 	Commands               []string
+	Pid                    int
+	EnvPath                string
+	PathListSeparator      string
 }
 
 func appendExt(s, format string) string {

--- a/pkg/config/registry/package_info.go
+++ b/pkg/config/registry/package_info.go
@@ -257,7 +257,7 @@ func (p *PackageInfo) resetByPkgType(typ string) { //nolint:funlen
 	}
 }
 
-func (p *PackageInfo) overrideVersion(child *VersionOverride) *PackageInfo { //nolint:cyclop,funlen
+func (p *PackageInfo) overrideVersion(child *VersionOverride) *PackageInfo { //nolint:cyclop,funlen,gocyclo
 	pkg := p.Copy()
 	if child.Type != "" {
 		pkg.resetByPkgType(child.Type)

--- a/pkg/config/registry/package_info.go
+++ b/pkg/config/registry/package_info.go
@@ -59,6 +59,11 @@ type PackageInfo struct {
 	Minisign            *Minisign          `json:"minisign,omitempty" yaml:",omitempty"`
 	VersionConstraints  string             `yaml:"version_constraint,omitempty" json:"version_constraint,omitempty"`
 	VersionOverrides    []*VersionOverride `yaml:"version_overrides,omitempty" json:"version_overrides,omitempty"`
+	Shell               *Shell             `json:"shell,omitempty"`
+}
+
+type Shell struct {
+	Env map[string]string `json:"env,omitempty" yaml:",omitempty"`
 }
 
 type Build struct {
@@ -117,6 +122,7 @@ type VersionOverride struct {
 	Build               *Build          `json:"build,omitempty" yaml:",omitempty"`
 	Overrides           Overrides       `yaml:",omitempty" json:"overrides,omitempty"`
 	SupportedEnvs       SupportedEnvs   `yaml:"supported_envs,omitempty" json:"supported_envs,omitempty"`
+	Shell               *Shell          `json:"shell,omitempty"`
 }
 
 type Override struct {
@@ -139,6 +145,7 @@ type Override struct {
 	SLSAProvenance     *SLSAProvenance `json:"slsa_provenance,omitempty" yaml:"slsa_provenance,omitempty"`
 	Minisign           *Minisign       `json:"minisign,omitempty" yaml:",omitempty"`
 	Envs               SupportedEnvs   `yaml:",omitempty" json:"envs,omitempty"`
+	Shell              *Shell          `json:"shell,omitempty"`
 }
 
 func (p *PackageInfo) Copy() *PackageInfo {
@@ -179,6 +186,7 @@ func (p *PackageInfo) Copy() *PackageInfo {
 		NoAsset:             p.NoAsset,
 		AppendExt:           p.AppendExt,
 		Build:               p.Build,
+		Shell:               p.Shell,
 	}
 	return pkg
 }
@@ -339,6 +347,9 @@ func (p *PackageInfo) overrideVersion(child *VersionOverride) *PackageInfo { //n
 	if child.Build != nil {
 		pkg.Build = child.Build
 	}
+	if child.Shell != nil {
+		pkg.Shell = child.Shell
+	}
 	return pkg
 }
 
@@ -427,6 +438,10 @@ func (p *PackageInfo) OverrideByRuntime(rt *runtime.Runtime) { //nolint:cyclop,f
 
 	if ov.AppendExt != nil {
 		p.AppendExt = ov.AppendExt
+	}
+
+	if ov.Shell != nil {
+		p.Shell = ov.Shell
 	}
 }
 

--- a/pkg/controller/outputshell/controller.go
+++ b/pkg/controller/outputshell/controller.go
@@ -1,0 +1,81 @@
+package outputshell
+
+import (
+	"context"
+	"io"
+
+	"github.com/aquaproj/aqua/v2/pkg/checksum"
+	"github.com/aquaproj/aqua/v2/pkg/config"
+	"github.com/aquaproj/aqua/v2/pkg/config/aqua"
+	"github.com/aquaproj/aqua/v2/pkg/config/registry"
+	"github.com/aquaproj/aqua/v2/pkg/runtime"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+)
+
+type Controller struct {
+	rootDir           string
+	configFinder      ConfigFinder
+	configReader      ConfigReader
+	registryInstaller RegistryInstaller
+	fs                afero.Fs
+	runtime           *runtime.Runtime
+	stdout            io.Writer
+}
+
+type ConfigFinder interface {
+	Finds(wd, configFilePath string) []string
+}
+
+type Shell struct {
+	Env *Env `json:"env,omitempty"`
+}
+
+func (s *Shell) GetPaths() []string {
+	if s == nil {
+		return nil
+	}
+	return s.Env.GetPaths()
+}
+
+type Env struct {
+	Path *Path `json:"PATH,omitempty"`
+}
+
+func (e *Env) GetPaths() []string {
+	if e == nil {
+		return nil
+	}
+	return e.Path.GetPaths()
+}
+
+type Path struct {
+	Values []string `json:"values,omitempty"`
+}
+
+func (p *Path) GetPaths() []string {
+	if p == nil {
+		return nil
+	}
+	return p.Values
+}
+
+func New(param *config.Param, configFinder ConfigFinder, configReader ConfigReader, registInstaller RegistryInstaller, fs afero.Fs, rt *runtime.Runtime, stdout io.Writer) *Controller {
+	return &Controller{
+		rootDir:           param.RootDir,
+		configFinder:      configFinder,
+		configReader:      configReader,
+		registryInstaller: registInstaller,
+		fs:                fs,
+		runtime:           rt,
+		stdout:            stdout,
+	}
+}
+
+type ConfigReader interface {
+	Read(logE *logrus.Entry, configFilePath string, cfg *aqua.Config) error
+}
+
+type RegistryInstaller interface {
+	InstallRegistries(ctx context.Context, logE *logrus.Entry, cfg *aqua.Config, cfgFilePath string, checksums *checksum.Checksums) (map[string]*registry.Config, error)
+}

--- a/pkg/controller/outputshell/output_shell.go
+++ b/pkg/controller/outputshell/output_shell.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-func (c *Controller) OutputShell(ctx context.Context, logE *logrus.Entry, param *config.Param) error { //nolint:funlen
+func (c *Controller) OutputShell(ctx context.Context, logE *logrus.Entry, param *config.Param) error {
 	shellPath := filepath.Join(c.rootDir, "shell", strconv.Itoa(param.Ppid), "shell.json")
 
 	oldPaths, err := c.readOldPaths(shellPath)
@@ -147,7 +147,7 @@ func (c *Controller) readShell(shellPath string, shell *Shell) error {
 	return nil
 }
 
-func (c *Controller) handleConfig(ctx context.Context, logE *logrus.Entry, cfgFilePath string, param *config.Param, shell *Shell) error {
+func (c *Controller) handleConfig(ctx context.Context, logE *logrus.Entry, cfgFilePath string, param *config.Param, shell *Shell) error { //nolint:cyclop
 	cfg := &aqua.Config{}
 	if cfgFilePath == "" {
 		return finder.ErrConfigFileNotFound

--- a/pkg/controller/outputshell/output_shell.go
+++ b/pkg/controller/outputshell/output_shell.go
@@ -51,7 +51,6 @@ func (c *Controller) OutputShell(ctx context.Context, logE *logrus.Entry, param 
 	}
 
 	newPS, updated := c.getNewPS(param, shell, oldPaths)
-
 	if updated {
 		fmt.Fprintln(c.stdout, "export PATH="+strings.Join(newPS, param.PathListSeparator))
 	}
@@ -69,8 +68,9 @@ func (c *Controller) readOldPaths(shellPath string) (map[string]struct{}, error)
 		return nil, err
 	}
 
-	oldPaths := make(map[string]struct{}, len(oldShell.GetPaths()))
-	for _, p := range oldShell.GetPaths() {
+	paths := oldShell.GetPaths()
+	oldPaths := make(map[string]struct{}, len(paths))
+	for _, p := range paths {
 		oldPaths[p] = struct{}{}
 	}
 	return oldPaths, nil

--- a/pkg/controller/outputshell/output_shell.go
+++ b/pkg/controller/outputshell/output_shell.go
@@ -50,7 +50,7 @@ func (c *Controller) OutputShell(ctx context.Context, logE *logrus.Entry, param 
 		}
 	}
 
-	newPS, updated := c.getNewPS(param, shell, oldPaths)
+	newPS, updated := getNewPS(param, shell, oldPaths)
 	if updated {
 		fmt.Fprintln(c.stdout, "export PATH="+strings.Join(newPS, param.PathListSeparator))
 	}
@@ -76,7 +76,7 @@ func (c *Controller) readOldPaths(shellPath string) (map[string]struct{}, error)
 	return oldPaths, nil
 }
 
-func (c *Controller) getNewPS(param *config.Param, shell *Shell, oldPaths map[string]struct{}) ([]string, bool) {
+func getNewPS(param *config.Param, shell *Shell, oldPaths map[string]struct{}) ([]string, bool) {
 	paths := make(map[string]struct{}, len(shell.GetPaths()))
 	for _, p := range shell.GetPaths() {
 		paths[p] = struct{}{}

--- a/pkg/controller/outputshell/output_shell.go
+++ b/pkg/controller/outputshell/output_shell.go
@@ -1,0 +1,190 @@
+package outputshell
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/aquaproj/aqua/v2/pkg/checksum"
+	"github.com/aquaproj/aqua/v2/pkg/config"
+	finder "github.com/aquaproj/aqua/v2/pkg/config-finder"
+	"github.com/aquaproj/aqua/v2/pkg/config/aqua"
+	"github.com/aquaproj/aqua/v2/pkg/osfile"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+)
+
+func (c *Controller) OutputShell(ctx context.Context, logE *logrus.Entry, param *config.Param) error {
+	shellPath := filepath.Join(c.rootDir, "shell", strconv.Itoa(param.Ppid), "shell.json")
+
+	oldShell := &Shell{}
+	if err := c.readShell(shellPath, oldShell); err != nil {
+		return err
+	}
+
+	oldPaths := make(map[string]struct{}, len(oldShell.GetPaths()))
+	for _, p := range oldShell.GetPaths() {
+		oldPaths[p] = struct{}{}
+	}
+
+	shell := &Shell{
+		Env: &Env{
+			Path: &Path{
+				Values: []string{},
+			},
+		},
+	}
+	for _, cfgFilePath := range c.configFinder.Finds(param.PWD, param.ConfigFilePath) {
+		if err := c.handleConfig(ctx, logE, cfgFilePath, param, shell); err != nil {
+			return err
+		}
+	}
+
+	for _, cfgFilePath := range param.GlobalConfigFilePaths {
+		if f, err := afero.Exists(c.fs, cfgFilePath); err != nil {
+			return err
+		} else if !f {
+			continue
+		}
+		if err := c.handleConfig(ctx, logE, cfgFilePath, param, shell); err != nil {
+			return err
+		}
+	}
+
+	paths := make(map[string]struct{}, len(shell.GetPaths()))
+	for _, p := range shell.GetPaths() {
+		paths[p] = struct{}{}
+	}
+
+	ps := strings.Split(param.EnvPath, string(param.PathListSeparator))
+	psMap := make(map[string]struct{}, len(ps))
+	for _, p := range ps {
+		psMap[p] = struct{}{}
+	}
+
+	newPS := make([]string, 0, len(ps))
+
+	updated := false
+	for k := range paths {
+		if _, ok := psMap[k]; ok {
+			continue
+		}
+		// Add path to head
+		newPS = append(newPS, k)
+		updated = true
+	}
+
+	for _, p := range ps {
+		if _, ok := paths[p]; ok {
+			newPS = append(newPS, p)
+			continue
+		}
+		if _, ok := oldPaths[p]; ok {
+			// Remove path
+			updated = true
+			continue
+		}
+		newPS = append(newPS, p)
+	}
+
+	if updated {
+		fmt.Fprintln(c.stdout, "export PATH="+strings.Join(newPS, string(param.PathListSeparator)))
+	}
+
+	if err := c.saveShell(shellPath, shell); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Controller) saveShell(shellPath string, shell *Shell) error {
+	if err := osfile.MkdirAll(c.fs, filepath.Dir(shellPath)); err != nil {
+		return err
+	}
+	f, err := c.fs.Create(shellPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if err := json.NewEncoder(f).Encode(shell); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Controller) readShell(shellPath string, shell *Shell) error {
+	if f, err := afero.Exists(c.fs, shellPath); err != nil {
+		return err
+	} else if !f {
+		return nil
+	}
+	f, err := c.fs.Open(shellPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if err := json.NewDecoder(f).Decode(shell); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Controller) handleConfig(ctx context.Context, logE *logrus.Entry, cfgFilePath string, param *config.Param, shell *Shell) error {
+	cfg := &aqua.Config{}
+	if cfgFilePath == "" {
+		return finder.ErrConfigFileNotFound
+	}
+	if err := c.configReader.Read(logE, cfgFilePath, cfg); err != nil {
+		return err //nolint:wrapcheck
+	}
+
+	var checksums *checksum.Checksums
+	if cfg.ChecksumEnabled(param.EnforceChecksum, param.Checksum) {
+		checksums = checksum.New()
+		checksumFilePath, err := checksum.GetChecksumFilePathFromConfigFilePath(c.fs, cfgFilePath)
+		if err != nil {
+			return err //nolint:wrapcheck
+		}
+		if err := checksums.ReadFile(c.fs, checksumFilePath); err != nil {
+			return fmt.Errorf("read a checksum JSON: %w", err)
+		}
+		defer func() {
+			if err := checksums.UpdateFile(c.fs, checksumFilePath); err != nil {
+				logE.WithError(err).Error("update a checksum file")
+			}
+		}()
+	}
+
+	registryContents, err := c.registryInstaller.InstallRegistries(ctx, logE, cfg, cfgFilePath, checksums)
+	if err != nil {
+		return err //nolint:wrapcheck
+	}
+	pkgs, failed := config.ListPackages(logE, cfg, c.runtime, registryContents)
+	if failed {
+		return errors.New("failed to list packages")
+	}
+	for _, pkg := range pkgs {
+		if pkg.PackageInfo.Shell != nil {
+			p, ok := pkg.PackageInfo.Shell.Env["PATH"]
+			if !ok {
+				continue
+			}
+			newP, err := pkg.RenderTemplateString(p, c.runtime)
+			if err != nil {
+				return err
+			}
+			pkgPath, err := pkg.PkgPath(c.rootDir, c.runtime)
+			if err != nil {
+				return err
+			}
+			shell.Env.Path.Values = append(shell.Env.Path.Values, filepath.Join(pkgPath, filepath.FromSlash(newP)))
+		}
+	}
+
+	return nil
+}

--- a/pkg/controller/outputshell/output_shell.go
+++ b/pkg/controller/outputshell/output_shell.go
@@ -104,32 +104,32 @@ func (c *Controller) OutputShell(ctx context.Context, logE *logrus.Entry, param 
 
 func (c *Controller) saveShell(shellPath string, shell *Shell) error {
 	if err := osfile.MkdirAll(c.fs, filepath.Dir(shellPath)); err != nil {
-		return err
+		return fmt.Errorf("create a directory to store shell.json: %w", err)
 	}
 	f, err := c.fs.Create(shellPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("create a shell.json: %w", err)
 	}
 	defer f.Close()
 	if err := json.NewEncoder(f).Encode(shell); err != nil {
-		return err
+		return fmt.Errorf("write shell.json: %w", err)
 	}
 	return nil
 }
 
 func (c *Controller) readShell(shellPath string, shell *Shell) error {
 	if f, err := afero.Exists(c.fs, shellPath); err != nil {
-		return err
+		return fmt.Errorf("check if shell.json exists: %w", err)
 	} else if !f {
 		return nil
 	}
 	f, err := c.fs.Open(shellPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("open a shell.json: %w", err)
 	}
 	defer f.Close()
 	if err := json.NewDecoder(f).Decode(shell); err != nil {
-		return err
+		return fmt.Errorf("read a shell.json: %w", err)
 	}
 	return nil
 }

--- a/pkg/controller/outputshell/output_shell_internal_test.go
+++ b/pkg/controller/outputshell/output_shell_internal_test.go
@@ -1,0 +1,53 @@
+package outputshell
+
+import (
+	"testing"
+
+	"github.com/aquaproj/aqua/v2/pkg/config"
+)
+
+func Test_getNewPS(t *testing.T) {
+	t.Parallel()
+	data := []struct {
+		name     string
+		param    *config.Param
+		shell    *Shell
+		oldPaths map[string]struct{}
+		ps       []string
+		updated  bool
+	}{
+		{
+			name: "normal",
+			param: &config.Param{
+				EnvPath:           "/root/.local/share/aquaproj-aqua/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+				PathListSeparator: ":",
+			},
+			shell: &Shell{
+				Env: &Env{
+					Path: &Path{
+						Values: []string{
+							"/root/.local/share/aquaproj-aqua/pkgs/http/nodejs.org/dist/v20.16.0/node-v20.16.0-linux-arm64.tar.gz/node-v20.16.0-linux-arm64/bin",
+						},
+					},
+				},
+			},
+			oldPaths: map[string]struct{}{},
+			ps: []string{
+				"/root/.local/share/aquaproj-aqua/pkgs/http/nodejs.org/dist/v20.16.0/node-v20.16.0-linux-arm64.tar.gz/node-v20.16.0-linux-arm64/bin",
+				"/root/.local/share/aquaproj-aqua/bin",
+				"/usr/local/sbin",
+				"/usr/local/bin",
+				"/usr/sbin",
+				"/usr/bin",
+				"/sbin",
+				"/bin",
+			},
+			updated: true,
+		},
+	}
+	for _, d := range data {
+		t.Run(d.name, func(t *testing.T) {
+			t.Parallel()
+		})
+	}
+}

--- a/pkg/controller/setshell/bash.sh
+++ b/pkg/controller/setshell/bash.sh
@@ -1,5 +1,5 @@
 if [ -n "${PROMPT_COMMAND:-}" ]; then
-    PROMPT_COMMAND="${PROMPT_COMMAND};eval \"$(aqua output-shell)\""
+    PROMPT_COMMAND="${PROMPT_COMMAND};"'eval "$(aqua output-shell)"'
 else
-    PROMPT_COMMAND="eval \"$(aqua output-shell)\""
+    PROMPT_COMMAND='eval "$(aqua output-shell)"'
 fi

--- a/pkg/controller/setshell/bash.sh
+++ b/pkg/controller/setshell/bash.sh
@@ -1,0 +1,5 @@
+if [ -n "${PROMPT_COMMAND:-}" ]; then
+    PROMPT_COMMAND="${PROMPT_COMMAND};eval \"$(aqua output-shell)\""
+else
+    PROMPT_COMMAND="eval \"$(aqua output-shell)\""
+fi

--- a/pkg/controller/setshell/controller.go
+++ b/pkg/controller/setshell/controller.go
@@ -1,81 +1,25 @@
 package setshell
 
 import (
-	"context"
 	"io"
 
-	"github.com/aquaproj/aqua/v2/pkg/checksum"
 	"github.com/aquaproj/aqua/v2/pkg/config"
-	"github.com/aquaproj/aqua/v2/pkg/config/aqua"
-	"github.com/aquaproj/aqua/v2/pkg/config/registry"
 	"github.com/aquaproj/aqua/v2/pkg/runtime"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 )
 
 type Controller struct {
-	rootDir           string
-	configFinder      ConfigFinder
-	configReader      ConfigReader
-	registryInstaller RegistryInstaller
-	fs                afero.Fs
-	runtime           *runtime.Runtime
-	stdout            io.Writer
+	rootDir string
+	fs      afero.Fs
+	runtime *runtime.Runtime
+	stdout  io.Writer
 }
 
-type ConfigFinder interface {
-	Finds(wd, configFilePath string) []string
-}
-
-type Shell struct {
-	Env *Env `json:"env,omitempty"`
-}
-
-func (s *Shell) GetPaths() []string {
-	if s == nil {
-		return nil
-	}
-	return s.Env.GetPaths()
-}
-
-type Env struct {
-	Path *Path `json:"PATH,omitempty"`
-}
-
-func (e *Env) GetPaths() []string {
-	if e == nil {
-		return nil
-	}
-	return e.Path.GetPaths()
-}
-
-type Path struct {
-	Values []string `json:"values,omitempty"`
-}
-
-func (p *Path) GetPaths() []string {
-	if p == nil {
-		return nil
-	}
-	return p.Values
-}
-
-func New(param *config.Param, configFinder ConfigFinder, configReader ConfigReader, registInstaller RegistryInstaller, fs afero.Fs, rt *runtime.Runtime, stdout io.Writer) *Controller {
+func New(param *config.Param, fs afero.Fs, rt *runtime.Runtime, stdout io.Writer) *Controller {
 	return &Controller{
-		rootDir:           param.RootDir,
-		configFinder:      configFinder,
-		configReader:      configReader,
-		registryInstaller: registInstaller,
-		fs:                fs,
-		runtime:           rt,
-		stdout:            stdout,
+		rootDir: param.RootDir,
+		fs:      fs,
+		runtime: rt,
+		stdout:  stdout,
 	}
-}
-
-type ConfigReader interface {
-	Read(logE *logrus.Entry, configFilePath string, cfg *aqua.Config) error
-}
-
-type RegistryInstaller interface {
-	InstallRegistries(ctx context.Context, logE *logrus.Entry, cfg *aqua.Config, cfgFilePath string, checksums *checksum.Checksums) (map[string]*registry.Config, error)
 }

--- a/pkg/controller/setshell/controller.go
+++ b/pkg/controller/setshell/controller.go
@@ -31,12 +31,33 @@ type Shell struct {
 	Env *Env `json:"env,omitempty"`
 }
 
+func (s *Shell) GetPaths() []string {
+	if s == nil {
+		return nil
+	}
+	return s.Env.GetPaths()
+}
+
 type Env struct {
 	Path *Path `json:"PATH,omitempty"`
 }
 
+func (e *Env) GetPaths() []string {
+	if e == nil {
+		return nil
+	}
+	return e.Path.GetPaths()
+}
+
 type Path struct {
 	Values []string `json:"values,omitempty"`
+}
+
+func (p *Path) GetPaths() []string {
+	if p == nil {
+		return nil
+	}
+	return p.Values
 }
 
 func New(param *config.Param, configFinder ConfigFinder, configReader ConfigReader, registInstaller RegistryInstaller, fs afero.Fs, rt *runtime.Runtime, stdout io.Writer) *Controller {

--- a/pkg/controller/setshell/controller.go
+++ b/pkg/controller/setshell/controller.go
@@ -1,0 +1,60 @@
+package setshell
+
+import (
+	"context"
+	"io"
+
+	"github.com/aquaproj/aqua/v2/pkg/checksum"
+	"github.com/aquaproj/aqua/v2/pkg/config"
+	"github.com/aquaproj/aqua/v2/pkg/config/aqua"
+	"github.com/aquaproj/aqua/v2/pkg/config/registry"
+	"github.com/aquaproj/aqua/v2/pkg/runtime"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+)
+
+type Controller struct {
+	rootDir           string
+	configFinder      ConfigFinder
+	configReader      ConfigReader
+	registryInstaller RegistryInstaller
+	fs                afero.Fs
+	runtime           *runtime.Runtime
+	stdout            io.Writer
+}
+
+type ConfigFinder interface {
+	Finds(wd, configFilePath string) []string
+}
+
+type Shell struct {
+	Env *Env `json:"env,omitempty"`
+}
+
+type Env struct {
+	Path *Path `json:"PATH,omitempty"`
+}
+
+type Path struct {
+	Values []string `json:"values,omitempty"`
+}
+
+func New(param *config.Param, configFinder ConfigFinder, configReader ConfigReader, registInstaller RegistryInstaller, fs afero.Fs, rt *runtime.Runtime, stdout io.Writer) *Controller {
+	return &Controller{
+		rootDir:           param.RootDir,
+		configFinder:      configFinder,
+		configReader:      configReader,
+		registryInstaller: registInstaller,
+		fs:                fs,
+		runtime:           rt,
+		stdout:            stdout,
+	}
+}
+
+type ConfigReader interface {
+	Read(logE *logrus.Entry, configFilePath string, cfg *aqua.Config) error
+}
+
+type RegistryInstaller interface {
+	InstallRegistries(ctx context.Context, logE *logrus.Entry, cfg *aqua.Config, cfgFilePath string, checksums *checksum.Checksums) (map[string]*registry.Config, error)
+}

--- a/pkg/controller/setshell/set_shell.go
+++ b/pkg/controller/setshell/set_shell.go
@@ -1,0 +1,178 @@
+package setshell
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/aquaproj/aqua/v2/pkg/checksum"
+	"github.com/aquaproj/aqua/v2/pkg/config"
+	finder "github.com/aquaproj/aqua/v2/pkg/config-finder"
+	"github.com/aquaproj/aqua/v2/pkg/config/aqua"
+	"github.com/aquaproj/aqua/v2/pkg/osfile"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+)
+
+func (c *Controller) SetShell(ctx context.Context, logE *logrus.Entry, param *config.Param) error {
+	globalPolicyPaths := make(map[string]struct{}, len(param.PolicyConfigFilePaths))
+	for _, p := range param.PolicyConfigFilePaths {
+		globalPolicyPaths[p] = struct{}{}
+	}
+
+	shellPath := filepath.Join(c.rootDir, "shell", strconv.Itoa(param.Pid), "shell.json")
+
+	oldShell := &Shell{}
+	if err := c.readShell(shellPath, oldShell); err != nil {
+		return err
+	}
+
+	oldPaths := make(map[string]struct{}, len(oldShell.Env.Path.Values))
+	for _, p := range oldShell.Env.Path.Values {
+		oldPaths[p] = struct{}{}
+	}
+
+	shell := &Shell{}
+	for _, cfgFilePath := range c.configFinder.Finds(param.PWD, param.ConfigFilePath) {
+		if err := c.handleConfig(ctx, logE, cfgFilePath, param, shell); err != nil {
+			return err
+		}
+	}
+
+	paths := make(map[string]struct{}, len(shell.Env.Path.Values))
+	for _, p := range shell.Env.Path.Values {
+		paths[p] = struct{}{}
+	}
+
+	ps := strings.Split(param.EnvPath, string(param.PathListSeparator))
+	psMap := make(map[string]struct{}, len(ps))
+	for _, p := range ps {
+		psMap[p] = struct{}{}
+	}
+
+	newPS := make([]string, 0, len(ps))
+
+	updated := false
+	for k := range paths {
+		if _, ok := psMap[k]; ok {
+			continue
+		}
+		// Add path to head
+		newPS = append(newPS, k)
+		updated = true
+	}
+
+	for _, p := range ps {
+		if _, ok := paths[p]; ok {
+			newPS = append(newPS, p)
+			continue
+		}
+		if _, ok := oldPaths[p]; ok {
+			// Remove path
+			updated = true
+			continue
+		}
+		newPS = append(newPS, p)
+	}
+
+	if updated {
+		fmt.Fprintf(c.stdout, "export PATH=%s\n", strings.Join(newPS, param.PathListSeparator))
+	}
+
+	if err := c.saveShell(shellPath, shell); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Controller) saveShell(shellPath string, shell *Shell) error {
+	if err := osfile.MkdirAll(c.fs, filepath.Dir(shellPath)); err != nil {
+		return err
+	}
+	f, err := c.fs.Create(shellPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if err := json.NewEncoder(f).Encode(shell); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Controller) readShell(shellPath string, shell *Shell) error {
+	if f, err := afero.Exists(c.fs, shellPath); err != nil {
+		return err
+	} else if !f {
+		return nil
+	}
+	f, err := c.fs.Open(shellPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if err := json.NewDecoder(f).Decode(shell); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Controller) handleConfig(ctx context.Context, logE *logrus.Entry, cfgFilePath string, param *config.Param, oldShell *Shell) error {
+	cfg := &aqua.Config{}
+	if cfgFilePath == "" {
+		return finder.ErrConfigFileNotFound
+	}
+	if err := c.configReader.Read(logE, cfgFilePath, cfg); err != nil {
+		return err //nolint:wrapcheck
+	}
+
+	var checksums *checksum.Checksums
+	if cfg.ChecksumEnabled(param.EnforceChecksum, param.Checksum) {
+		checksums = checksum.New()
+		checksumFilePath, err := checksum.GetChecksumFilePathFromConfigFilePath(c.fs, cfgFilePath)
+		if err != nil {
+			return err //nolint:wrapcheck
+		}
+		if err := checksums.ReadFile(c.fs, checksumFilePath); err != nil {
+			return fmt.Errorf("read a checksum JSON: %w", err)
+		}
+		defer func() {
+			if err := checksums.UpdateFile(c.fs, checksumFilePath); err != nil {
+				logE.WithError(err).Error("update a checksum file")
+			}
+		}()
+	}
+
+	registryContents, err := c.registryInstaller.InstallRegistries(ctx, logE, cfg, cfgFilePath, checksums)
+	if err != nil {
+		return err //nolint:wrapcheck
+	}
+	pkgs, failed := config.ListPackages(logE, cfg, c.runtime, registryContents)
+	if failed {
+		return errors.New("failed to list packages")
+	}
+	for _, pkg := range pkgs {
+		if pkg.PackageInfo.Shell != nil {
+			p, ok := pkg.PackageInfo.Shell.Env["PATH"]
+			if !ok {
+				continue
+			}
+			newP, err := pkg.RenderTemplateString(p, c.runtime)
+			if err != nil {
+				return err
+			}
+			pkgPath, err := pkg.PkgPath(c.rootDir, c.runtime)
+			if err != nil {
+				return err
+			}
+			oldShell.Env.Path.Values = append(oldShell.Env.Path.Values, filepath.Join(pkgPath, filepath.FromSlash(newP)))
+		}
+	}
+
+	return nil
+}

--- a/pkg/controller/setshell/set_shell.go
+++ b/pkg/controller/setshell/set_shell.go
@@ -16,14 +16,14 @@ var zshScript []byte
 //go:embed bash.sh
 var bashScript []byte
 
-func (c *Controller) SetShell(ctx context.Context, logE *logrus.Entry, param *config.Param, shellType string) error {
+func (c *Controller) SetShell(_ context.Context, _ *logrus.Entry, _ *config.Param, shellType string) error {
 	switch shellType {
 	case "":
 		return errors.New("the argument shell type is required")
 	case "bash":
-		fmt.Fprintf(c.stdout, string(bashScript))
+		fmt.Fprintln(c.stdout, string(bashScript))
 	case "zsh":
-		fmt.Fprintf(c.stdout, string(zshScript))
+		fmt.Fprintln(c.stdout, string(zshScript))
 	default:
 		return errors.New(`supported shell types are 'bash' and 'zsh'`)
 	}

--- a/pkg/controller/setshell/set_shell.go
+++ b/pkg/controller/setshell/set_shell.go
@@ -2,201 +2,30 @@ package setshell
 
 import (
 	"context"
-	"encoding/json"
+	_ "embed"
 	"errors"
 	"fmt"
-	"path/filepath"
-	"strconv"
-	"strings"
 
-	"github.com/aquaproj/aqua/v2/pkg/checksum"
 	"github.com/aquaproj/aqua/v2/pkg/config"
-	finder "github.com/aquaproj/aqua/v2/pkg/config-finder"
-	"github.com/aquaproj/aqua/v2/pkg/config/aqua"
-	"github.com/aquaproj/aqua/v2/pkg/osfile"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 )
+
+//go:embed zsh.sh
+var zshScript []byte
+
+//go:embed bash.sh
+var bashScript []byte
 
 func (c *Controller) SetShell(ctx context.Context, logE *logrus.Entry, param *config.Param, shellType string) error {
 	switch shellType {
 	case "":
 		return errors.New("the argument shell type is required")
-	case "bash", "zsh":
+	case "bash":
+		fmt.Fprintf(c.stdout, string(bashScript))
+	case "zsh":
+		fmt.Fprintf(c.stdout, string(zshScript))
 	default:
 		return errors.New(`supported shell types are 'bash' and 'zsh'`)
 	}
-	shellPath := filepath.Join(c.rootDir, "shell", strconv.Itoa(param.Ppid), "shell.json")
-
-	oldShell := &Shell{}
-	if err := c.readShell(shellPath, oldShell); err != nil {
-		return err
-	}
-
-	oldPaths := make(map[string]struct{}, len(oldShell.GetPaths()))
-	for _, p := range oldShell.GetPaths() {
-		oldPaths[p] = struct{}{}
-	}
-
-	shell := &Shell{
-		Env: &Env{
-			Path: &Path{
-				Values: []string{},
-			},
-		},
-	}
-	for _, cfgFilePath := range c.configFinder.Finds(param.PWD, param.ConfigFilePath) {
-		if err := c.handleConfig(ctx, logE, cfgFilePath, param, shell); err != nil {
-			return err
-		}
-	}
-
-	for _, cfgFilePath := range param.GlobalConfigFilePaths {
-		if f, err := afero.Exists(c.fs, cfgFilePath); err != nil {
-			return err
-		} else if !f {
-			continue
-		}
-		if err := c.handleConfig(ctx, logE, cfgFilePath, param, shell); err != nil {
-			return err
-		}
-	}
-
-	paths := make(map[string]struct{}, len(shell.GetPaths()))
-	for _, p := range shell.GetPaths() {
-		paths[p] = struct{}{}
-	}
-
-	ps := strings.Split(param.EnvPath, string(param.PathListSeparator))
-	psMap := make(map[string]struct{}, len(ps))
-	for _, p := range ps {
-		psMap[p] = struct{}{}
-	}
-
-	newPS := make([]string, 0, len(ps))
-
-	updated := false
-	for k := range paths {
-		if _, ok := psMap[k]; ok {
-			continue
-		}
-		// Add path to head
-		newPS = append(newPS, k)
-		updated = true
-	}
-
-	for _, p := range ps {
-		if _, ok := paths[p]; ok {
-			newPS = append(newPS, p)
-			continue
-		}
-		if _, ok := oldPaths[p]; ok {
-			// Remove path
-			updated = true
-			continue
-		}
-		newPS = append(newPS, p)
-	}
-
-	if updated {
-		fmt.Fprintf(c.stdout, `_aqua_env() {
-	export PATH=%s
-}
-autoload -Uz add-zsh-hook
-add-zsh-hook preexec _aqua_env
-`, strings.Join(newPS, param.PathListSeparator))
-	}
-
-	if err := c.saveShell(shellPath, shell); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (c *Controller) saveShell(shellPath string, shell *Shell) error {
-	if err := osfile.MkdirAll(c.fs, filepath.Dir(shellPath)); err != nil {
-		return err
-	}
-	f, err := c.fs.Create(shellPath)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	if err := json.NewEncoder(f).Encode(shell); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (c *Controller) readShell(shellPath string, shell *Shell) error {
-	if f, err := afero.Exists(c.fs, shellPath); err != nil {
-		return err
-	} else if !f {
-		return nil
-	}
-	f, err := c.fs.Open(shellPath)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	if err := json.NewDecoder(f).Decode(shell); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (c *Controller) handleConfig(ctx context.Context, logE *logrus.Entry, cfgFilePath string, param *config.Param, shell *Shell) error {
-	cfg := &aqua.Config{}
-	if cfgFilePath == "" {
-		return finder.ErrConfigFileNotFound
-	}
-	if err := c.configReader.Read(logE, cfgFilePath, cfg); err != nil {
-		return err //nolint:wrapcheck
-	}
-
-	var checksums *checksum.Checksums
-	if cfg.ChecksumEnabled(param.EnforceChecksum, param.Checksum) {
-		checksums = checksum.New()
-		checksumFilePath, err := checksum.GetChecksumFilePathFromConfigFilePath(c.fs, cfgFilePath)
-		if err != nil {
-			return err //nolint:wrapcheck
-		}
-		if err := checksums.ReadFile(c.fs, checksumFilePath); err != nil {
-			return fmt.Errorf("read a checksum JSON: %w", err)
-		}
-		defer func() {
-			if err := checksums.UpdateFile(c.fs, checksumFilePath); err != nil {
-				logE.WithError(err).Error("update a checksum file")
-			}
-		}()
-	}
-
-	registryContents, err := c.registryInstaller.InstallRegistries(ctx, logE, cfg, cfgFilePath, checksums)
-	if err != nil {
-		return err //nolint:wrapcheck
-	}
-	pkgs, failed := config.ListPackages(logE, cfg, c.runtime, registryContents)
-	if failed {
-		return errors.New("failed to list packages")
-	}
-	for _, pkg := range pkgs {
-		if pkg.PackageInfo.Shell != nil {
-			p, ok := pkg.PackageInfo.Shell.Env["PATH"]
-			if !ok {
-				continue
-			}
-			newP, err := pkg.RenderTemplateString(p, c.runtime)
-			if err != nil {
-				return err
-			}
-			pkgPath, err := pkg.PkgPath(c.rootDir, c.runtime)
-			if err != nil {
-				return err
-			}
-			shell.Env.Path.Values = append(shell.Env.Path.Values, filepath.Join(pkgPath, filepath.FromSlash(newP)))
-		}
-	}
-
 	return nil
 }

--- a/pkg/controller/setshell/zsh.sh
+++ b/pkg/controller/setshell/zsh.sh
@@ -1,0 +1,5 @@
+_aqua_env() {
+    eval "$(aqua output-shell)"
+}
+autoload -Uz add-zsh-hook
+add-zsh-hook preexec _aqua_env

--- a/pkg/controller/wire.go
+++ b/pkg/controller/wire.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aquaproj/aqua/v2/pkg/controller/initpolicy"
 	"github.com/aquaproj/aqua/v2/pkg/controller/install"
 	"github.com/aquaproj/aqua/v2/pkg/controller/list"
+	"github.com/aquaproj/aqua/v2/pkg/controller/outputshell"
 	"github.com/aquaproj/aqua/v2/pkg/controller/remove"
 	"github.com/aquaproj/aqua/v2/pkg/controller/setshell"
 	"github.com/aquaproj/aqua/v2/pkg/controller/update"
@@ -998,8 +999,19 @@ func InitializeSetShellCommandController(ctx context.Context, param *config.Para
 	wire.Build(
 		setshell.New,
 		wire.NewSet(
+			afero.NewOsFs,
+			wire.Bind(new(installpackage.Cleaner), new(afero.Fs)),
+		),
+	)
+	return &setshell.Controller{}, nil
+}
+
+func InitializeOutputShellCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime, stdout io.Writer) (*outputshell.Controller, error) {
+	wire.Build(
+		outputshell.New,
+		wire.NewSet(
 			finder.NewConfigFinder,
-			wire.Bind(new(setshell.ConfigFinder), new(*finder.ConfigFinder)),
+			wire.Bind(new(outputshell.ConfigFinder), new(*finder.ConfigFinder)),
 		),
 		wire.NewSet(
 			github.New,
@@ -1008,7 +1020,7 @@ func InitializeSetShellCommandController(ctx context.Context, param *config.Para
 		),
 		wire.NewSet(
 			registry.New,
-			wire.Bind(new(setshell.RegistryInstaller), new(*registry.Installer)),
+			wire.Bind(new(outputshell.RegistryInstaller), new(*registry.Installer)),
 		),
 		wire.NewSet(
 			download.NewGitHubContentFileDownloader,
@@ -1016,7 +1028,7 @@ func InitializeSetShellCommandController(ctx context.Context, param *config.Para
 		),
 		wire.NewSet(
 			reader.New,
-			wire.Bind(new(setshell.ConfigReader), new(*reader.ConfigReader)),
+			wire.Bind(new(outputshell.ConfigReader), new(*reader.ConfigReader)),
 		),
 		wire.NewSet(
 			download.NewDownloader,
@@ -1045,5 +1057,5 @@ func InitializeSetShellCommandController(ctx context.Context, param *config.Para
 			wire.Bind(new(slsa.Executor), new(*slsa.ExecutorImpl)),
 		),
 	)
-	return &setshell.Controller{}, nil
+	return &outputshell.Controller{}, nil
 }

--- a/pkg/controller/wire_gen.go
+++ b/pkg/controller/wire_gen.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aquaproj/aqua/v2/pkg/controller/initpolicy"
 	"github.com/aquaproj/aqua/v2/pkg/controller/install"
 	"github.com/aquaproj/aqua/v2/pkg/controller/list"
+	"github.com/aquaproj/aqua/v2/pkg/controller/outputshell"
 	"github.com/aquaproj/aqua/v2/pkg/controller/remove"
 	"github.com/aquaproj/aqua/v2/pkg/controller/setshell"
 	"github.com/aquaproj/aqua/v2/pkg/controller/update"
@@ -359,6 +360,12 @@ func InitializeRemoveCommandController(ctx context.Context, param *config.Param,
 
 func InitializeSetShellCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime, stdout io.Writer) (*setshell.Controller, error) {
 	fs := afero.NewOsFs()
+	controller := setshell.New(param, fs, rt, stdout)
+	return controller, nil
+}
+
+func InitializeOutputShellCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime, stdout io.Writer) (*outputshell.Controller, error) {
+	fs := afero.NewOsFs()
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs, param)
 	repositoriesService := github.New(ctx)
@@ -370,6 +377,6 @@ func InitializeSetShellCommandController(ctx context.Context, param *config.Para
 	executorImpl := slsa.NewExecutor(executor, param)
 	slsaVerifier := slsa.New(downloader, fs, executorImpl)
 	installer := registry.New(param, gitHubContentFileDownloader, fs, rt, verifier, slsaVerifier)
-	controller := setshell.New(param, configFinder, configReader, installer, fs, rt, stdout)
+	controller := outputshell.New(param, configFinder, configReader, installer, fs, rt, stdout)
 	return controller, nil
 }

--- a/tests/nodejs/v20.16.0/aqua.yaml
+++ b/tests/nodejs/v20.16.0/aqua.yaml
@@ -1,0 +1,13 @@
+---
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# checksum:
+#   enabled: true
+#   require_checksum: true
+#   supported_envs:
+#   - all
+registries:
+  - type: standard
+    ref: v4.215.0-1 # renovate: depName=aquaproj/aqua-registry
+packages:
+  - name: nodejs/node@v20.16.0

--- a/tests/nodejs/v22.6.0/aqua.yaml
+++ b/tests/nodejs/v22.6.0/aqua.yaml
@@ -1,0 +1,13 @@
+---
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# checksum:
+#   enabled: true
+#   require_checksum: true
+#   supported_envs:
+#   - all
+registries:
+  - type: standard
+    ref: v4.215.0-1 # renovate: depName=aquaproj/aqua-registry
+packages:
+  - name: nodejs/node@v22.6.0


### PR DESCRIPTION
- https://github.com/aquaproj/aqua/issues/2996
- https://github.com/aquaproj/aqua-registry/pull/26002

Adding the subcommand `set-shell`, which outputs the script to change the environment variable `$PATH` dynamically.

```sh
. "$(aqua set-shell <shell type>)"
```

The support shell types are `zsh` and `bash`.

To support Node.js and Python, aqua needs to be able to change the environment variable `$PATH` dynamically because npm and pip install tools in the same directory.