### PR TITLE
feat: support removing links

### DIFF
--- a/.github/workflows/wc-integration-test.yaml
+++ b/.github/workflows/wc-integration-test.yaml
@@ -286,6 +286,9 @@ jobs:
       - name: Test rm
         run: aqua rm x-motemen/ghq bats-core/bats-core
 
+      - name: Test rm -l
+        run: aqua rm -l x-motemen/ghq bats-core/bats-core
+
       - name: Test rm --all
         run: aqua rm -a
 

--- a/.github/workflows/wc-integration-test.yaml
+++ b/.github/workflows/wc-integration-test.yaml
@@ -286,8 +286,10 @@ jobs:
       - name: Test rm
         run: aqua rm x-motemen/ghq bats-core/bats-core
 
-      - name: Test rm -l
-        run: aqua rm -l x-motemen/ghq bats-core/bats-core
+      - name: Test rm -m l
+        run: aqua rm -m l ghcp
+      - name: Test rm -m lp
+        run: aqua rm -m lp ghcp reviewdog
 
       - name: Test rm --all
         run: aqua rm -a

--- a/pkg/cli/remove.go
+++ b/pkg/cli/remove.go
@@ -22,6 +22,11 @@ func (r *Runner) newRemoveCommand() *cli.Command {
 				Usage:   "uninstall all packages",
 			},
 			&cli.BoolFlag{
+				Name:    "link",
+				Aliases: []string{"l"},
+				Usage:   "Remove links from the bin directory",
+			},
+			&cli.BoolFlag{
 				Name:  "i",
 				Usage: "Select packages with a Fuzzy Finder",
 			},
@@ -30,7 +35,7 @@ func (r *Runner) newRemoveCommand() *cli.Command {
 
 e.g.
 $ aqua rm --all
-$ aqua rm cli/cli direnv/direnv
+$ aqua rm cli/cli direnv/direnv tfcmt # Package names and command names
 
 Note that this command remove files from AQUA_ROOT_DIR/pkgs, but doesn't remove packages from aqua.yaml and doesn't remove files from AQUA_ROOT_DIR/bin and AQUA_ROOT_DIR/bat.
 
@@ -38,6 +43,11 @@ If you want to uninstall packages of non standard registry, you need to specify 
 
 e.g.
 $ aqua rm foo,suzuki-shunsuke/foo
+
+By default, this command doesn't remove links from the bin directory.
+If you want to remove them, you need to specify the --link flag.
+
+$ aqua rm -l cli/cli
 
 Limitation:
 "http" and "go_install" packages can't be removed.

--- a/pkg/cli/remove.go
+++ b/pkg/cli/remove.go
@@ -21,10 +21,10 @@ func (r *Runner) newRemoveCommand() *cli.Command {
 				Aliases: []string{"a"},
 				Usage:   "uninstall all packages",
 			},
-			&cli.BoolFlag{
-				Name:    "link",
-				Aliases: []string{"l"},
-				Usage:   "Remove links from the bin directory",
+			&cli.StringFlag{
+				Name:    "mode",
+				Aliases: []string{"m"},
+				Usage:   "Removed target modes. l: link, p: package",
 			},
 			&cli.BoolFlag{
 				Name:  "i",
@@ -44,10 +44,13 @@ If you want to uninstall packages of non standard registry, you need to specify 
 e.g.
 $ aqua rm foo,suzuki-shunsuke/foo
 
-By default, this command doesn't remove links from the bin directory.
-If you want to remove them, you need to specify the --link flag.
+By default, this command removes only packages from the pkgs directory and doesn't remove links from the bin directory.
+You can change this behaviour by specifying the -mode flag.
+The value of -mode is a string containing characters "l" and "p".
+The order of the characters doesn't matter.
 
-$ aqua rm -l cli/cli
+$ aqua rm -m l cli/cli # Remove only links
+$ aqua rm -m pl cli/cli # Remove links and packages
 
 Limitation:
 "http" and "go_install" packages can't be removed.
@@ -69,14 +72,39 @@ func (r *Runner) removeAction(c *cli.Context) error {
 	}
 	defer cpuProfiler.Stop()
 
+	mode, err := parseRemoveMode(c.String("mode"))
+	if err != nil {
+		return fmt.Errorf("parse the mode option: %w", err)
+	}
+
 	param := &config.Param{}
 	if err := r.setParam(c, "remove", param); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
 	param.SkipLink = true
-	ctrl := controller.InitializeRemoveCommandController(c.Context, param, http.DefaultClient, r.Runtime)
+	ctrl := controller.InitializeRemoveCommandController(c.Context, param, http.DefaultClient, r.Runtime, mode)
 	if err := ctrl.Remove(c.Context, r.LogE, param); err != nil {
 		return err //nolint:wrapcheck
 	}
 	return nil
+}
+
+func parseRemoveMode(target string) (*config.RemoveMode, error) {
+	if target == "" {
+		return &config.RemoveMode{
+			Package: true,
+		}, nil
+	}
+	t := &config.RemoveMode{}
+	for _, c := range target {
+		switch c {
+		case 'l':
+			t.Link = true
+		case 'p':
+			t.Package = true
+		default:
+			return nil, fmt.Errorf("invalid mode: %c", c)
+		}
+	}
+	return t, nil
 }

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -63,7 +63,6 @@ func (r *Runner) setParam(c *cli.Context, commandName string, param *config.Para
 	param.SelectVersion = c.Bool("select-version")
 	param.Installed = c.Bool("installed")
 	param.ShowVersion = c.Bool("version")
-	param.Link = c.Bool("link")
 	param.File = c.String("f")
 	if cmd := c.String("cmd"); cmd != "" {
 		param.Commands = strings.Split(cmd, ",")

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -63,6 +63,7 @@ func (r *Runner) setParam(c *cli.Context, commandName string, param *config.Para
 	param.SelectVersion = c.Bool("select-version")
 	param.Installed = c.Bool("installed")
 	param.ShowVersion = c.Bool("version")
+	param.Link = c.Bool("link")
 	param.File = c.String("f")
 	if cmd := c.String("cmd"); cmd != "" {
 		param.Commands = strings.Split(cmd, ",")

--- a/pkg/config/package.go
+++ b/pkg/config/package.go
@@ -285,6 +285,7 @@ type Param struct {
 	CosignDisabled         bool
 	SLSADisabled           bool
 	Installed              bool
+	Link                   bool
 	PolicyConfigFilePaths  []string
 	Commands               []string
 }

--- a/pkg/config/package.go
+++ b/pkg/config/package.go
@@ -243,6 +243,11 @@ const (
 	PkgInfoTypeCargo         = "cargo"
 )
 
+type RemoveMode struct {
+	Link    bool
+	Package bool
+}
+
 type Param struct {
 	GlobalConfigFilePaths  []string
 	ConfigFilePath         string
@@ -285,7 +290,6 @@ type Param struct {
 	CosignDisabled         bool
 	SLSADisabled           bool
 	Installed              bool
-	Link                   bool
 	PolicyConfigFilePaths  []string
 	Commands               []string
 }

--- a/pkg/controller/remove/controller.go
+++ b/pkg/controller/remove/controller.go
@@ -23,6 +23,7 @@ type Controller struct {
 	registryInstaller RegistryInstaller
 	fuzzyFinder       FuzzyFinder
 	which             WhichController
+	mode              *config.RemoveMode
 }
 
 type WhichController interface {
@@ -37,7 +38,7 @@ type FuzzyFinder interface {
 	FindMulti(pkgs []*fuzzyfinder.Item, hasPreview bool) ([]int, error)
 }
 
-func New(param *config.Param, fs afero.Fs, rt *runtime.Runtime, configFinder ConfigFinder, configReader ConfigReader, registryInstaller RegistryInstaller, fuzzyFinder FuzzyFinder, whichController WhichController) *Controller {
+func New(param *config.Param, target *config.RemoveMode, fs afero.Fs, rt *runtime.Runtime, configFinder ConfigFinder, configReader ConfigReader, registryInstaller RegistryInstaller, fuzzyFinder FuzzyFinder, whichController WhichController) *Controller {
 	return &Controller{
 		rootDir:           param.RootDir,
 		fs:                fs,
@@ -47,6 +48,7 @@ func New(param *config.Param, fs afero.Fs, rt *runtime.Runtime, configFinder Con
 		registryInstaller: registryInstaller,
 		fuzzyFinder:       fuzzyFinder,
 		which:             whichController,
+		mode:              target,
 	}
 }
 

--- a/pkg/controller/remove/remove.go
+++ b/pkg/controller/remove/remove.go
@@ -107,7 +107,7 @@ func (c *Controller) removePackagesInteractively(logE *logrus.Entry, param *conf
 		pkg := pkgs[idx]
 		pkgName := pkg.PackageInfo.GetName()
 		logE := logE.WithField("package_name", pkgName)
-		if err := c.removePackage(logE, param.RootDir, pkg.PackageInfo, param.Link); err != nil {
+		if err := c.removePackage(logE, param.RootDir, pkg.PackageInfo); err != nil {
 			return fmt.Errorf("remove a package: %w", logerr.WithFields(err, logrus.Fields{
 				"package_name": pkgName,
 			}))
@@ -129,7 +129,7 @@ func (c *Controller) removePackages(logE *logrus.Entry, param *config.Param, reg
 				"package_name": pkgName,
 			}))
 		}
-		if err := c.removePackage(logE, param.RootDir, pkg, param.Link); err != nil {
+		if err := c.removePackage(logE, param.RootDir, pkg); err != nil {
 			return fmt.Errorf("remove a package: %w", logerr.WithFields(err, logrus.Fields{
 				"package_name": pkgName,
 			}))
@@ -139,6 +139,23 @@ func (c *Controller) removePackages(logE *logrus.Entry, param *config.Param, reg
 }
 
 func (c *Controller) removeCommands(ctx context.Context, logE *logrus.Entry, param *config.Param, cmds []string) error {
+	var gErr error
+	if c.mode.Link {
+		for _, cmd := range cmds {
+			logE := logE.WithField("exe_name", cmd)
+			logE.Info("removing a link")
+			if err := c.fs.Remove(filepath.Join(c.rootDir, "bin", cmd)); err != nil {
+				if errors.Is(err, fs.ErrNotExist) {
+					continue
+				}
+				logerr.WithError(logE, err).Error("remove a link")
+				gErr = errors.New("remove links")
+			}
+		}
+	}
+	if !c.mode.Package {
+		return gErr
+	}
 	for _, cmd := range cmds {
 		logE := logE.WithField("exe_name", cmd)
 		findResult, err := c.which.Which(ctx, logE, param, cmd)
@@ -146,45 +163,43 @@ func (c *Controller) removeCommands(ctx context.Context, logE *logrus.Entry, par
 			return fmt.Errorf("find a command: %w", err)
 		}
 		logE = logE.WithField("package_name", findResult.Package.Package.Name)
-		if err := c.removePackage(logE, param.RootDir, findResult.Package.PackageInfo, param.Link); err != nil {
+		if err := c.removePackage(logE, param.RootDir, findResult.Package.PackageInfo); err != nil {
 			return fmt.Errorf("remove a package: %w", logerr.WithFields(err, logrus.Fields{
 				"package_name": findResult.Package.Package.Name,
 			}))
 		}
 	}
-	return nil
+	return gErr
 }
 
-func (c *Controller) removePackage(logE *logrus.Entry, rootDir string, pkg *registry.PackageInfo, isRemoveLink bool) error {
-	failed := false
+func (c *Controller) removePackage(logE *logrus.Entry, rootDir string, pkg *registry.PackageInfo) error {
+	var gErr error
 	logE.Info("removing a package")
-	if isRemoveLink {
+	if c.mode.Link {
 		for _, file := range pkg.GetFiles() {
 			if err := c.fs.Remove(filepath.Join(rootDir, "bin", file.Name)); err != nil {
 				if errors.Is(err, fs.ErrNotExist) {
 					continue
 				}
 				logerr.WithError(logE, err).WithField("link", file.Name).Error("remove a link")
-				failed = true
+				gErr = errors.New("remove links")
 			}
 		}
 	}
+	if !c.mode.Package {
+		return gErr
+	}
+
 	path := pkg.PkgPath()
 	if path == "" {
 		logE.WithField("package_type", pkg.Type).Warn("this package type can't be removed")
-		if failed {
-			return errors.New("failed to remove links")
-		}
-		return nil
+		return gErr
 	}
 	pkgPath := filepath.Join(rootDir, "pkgs", path)
 	if err := c.fs.RemoveAll(pkgPath); err != nil {
 		return fmt.Errorf("remove directories: %w", err)
 	}
-	if failed {
-		return errors.New("failed to remove links")
-	}
-	return nil
+	return gErr
 }
 
 func parsePkgName(pkgName string) (string, string) {
@@ -211,8 +226,17 @@ func findPkg(pkgName string, registryContents map[string]*registry.Config) (*reg
 }
 
 func (c *Controller) removeAll(rootDir string) error {
-	if err := c.fs.RemoveAll(filepath.Join(rootDir, "pkgs")); err != nil {
-		return fmt.Errorf("remove all packages $AQUA_ROOT_DIR/pkgs: %w", err)
+	var gErr error
+	if c.mode.Link {
+		if err := c.fs.RemoveAll(filepath.Join(rootDir, "bin")); err != nil {
+			gErr = fmt.Errorf("remove the bin directory: %w", err)
+		}
 	}
-	return nil
+	if !c.mode.Package {
+		return gErr
+	}
+	if err := c.fs.RemoveAll(filepath.Join(rootDir, "pkgs")); err != nil {
+		return fmt.Errorf("remove all packages: %w", err)
+	}
+	return gErr
 }

--- a/pkg/controller/wire.go
+++ b/pkg/controller/wire.go
@@ -923,7 +923,7 @@ func InitializeInfoCommandController(ctx context.Context, param *config.Param, r
 	return &info.Controller{}
 }
 
-func InitializeRemoveCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *remove.Controller {
+func InitializeRemoveCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime, target *config.RemoveTarget) *remove.Controller {
 	wire.Build(
 		remove.New,
 		wire.NewSet(

--- a/pkg/controller/wire_gen.go
+++ b/pkg/controller/wire_gen.go
@@ -335,7 +335,7 @@ func InitializeInfoCommandController(ctx context.Context, param *config.Param, r
 	return controller
 }
 
-func InitializeRemoveCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *remove.Controller {
+func InitializeRemoveCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime, target *config.RemoveMode) *remove.Controller {
 	fs := afero.NewOsFs()
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs, param)
@@ -352,6 +352,6 @@ func InitializeRemoveCommandController(ctx context.Context, param *config.Param,
 	osEnv := osenv.New()
 	linker := link.New()
 	controller := which.New(param, configFinder, configReader, installer, rt, osEnv, fs, linker)
-	removeController := remove.New(param, fs, rt, configFinder, configReader, installer, fuzzyfinderFinder, controller)
+	removeController := remove.New(param, target, fs, rt, configFinder, configReader, installer, fuzzyfinderFinder, controller)
 	return removeController
 }


### PR DESCRIPTION
Add a command line option `-mode (-m)` to the sub command `remove`.

By default, `aqua remove` command removes only packages from the `pkgs` directory and doesn't remove links from the `bin` directory.
You can change this behaviour by specifying the `-mode` flag.
The value of `-mode` is a string containing characters `l` and `p`.
The order of the characters doesn't matter.

```sh
aqua rm -m l cli/cli # Remove only links
aqua rm -m pl cli/cli # Remove links and packages
```