### PR TITLE
(cmd/remove) Handle panic error when package is not found, #3136

### DIFF
--- a/pkg/controller/remove/remove.go
+++ b/pkg/controller/remove/remove.go
@@ -163,6 +163,9 @@ func (c *Controller) removeCommands(ctx context.Context, logE *logrus.Entry, par
 		if err != nil {
 			return fmt.Errorf("find a command: %w", err)
 		}
+		if findResult.Package == nil {
+			return fmt.Errorf("command not found, check if %s is defined in aqua.yaml", cmd)
+		}
 		logE = logE.WithField("package_name", findResult.Package.Package.Name)
 		if err := c.removePackage(logE, param.RootDir, findResult.Package.PackageInfo); err != nil {
 			return fmt.Errorf("remove a package: %w", logerr.WithFields(err, logrus.Fields{

--- a/pkg/controller/remove/remove.go
+++ b/pkg/controller/remove/remove.go
@@ -164,7 +164,8 @@ func (c *Controller) removeCommands(ctx context.Context, logE *logrus.Entry, par
 			return fmt.Errorf("find a command: %w", err)
 		}
 		if findResult.Package == nil {
-			return fmt.Errorf("command not found, check if %s is defined in aqua.yaml", cmd)
+			logE.Debug("the package isn't found")
+			continue
 		}
 		logE = logE.WithField("package_name", findResult.Package.Package.Name)
 		if err := c.removePackage(logE, param.RootDir, findResult.Package.PackageInfo); err != nil {

--- a/pkg/controller/remove/remove.go
+++ b/pkg/controller/remove/remove.go
@@ -164,7 +164,7 @@ func (c *Controller) removeCommands(ctx context.Context, logE *logrus.Entry, par
 			return fmt.Errorf("find a command: %w", err)
 		}
 		if findResult.Package == nil {
-			logE.Debug("the package isn't found")
+			logE.Debug("no package is found")
 			continue
 		}
 		logE = logE.WithField("package_name", findResult.Package.Package.Name)


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue:
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->

This PR resolves #3136

When running the command `aqua remove {cmd}` for a command that exists in the system but is not defined in aqua.yaml, a nil panic occurs. This happens because the code attempts to reference `findResult.Package`, which is `nil` in this case, causing the panic.
https://github.com/aquaproj/aqua/blob/9eff9747af84ae6c77164fd929dee2629b5cfb73/pkg/controller/remove/remove.go#L167

`findResult` is returned from `controller/which/which.go`, where Package is nil in some case.
https://github.com/aquaproj/aqua/blob/fc24ef902cda24f9a190427415e582bf51397129/pkg/controller/which/which.go#L50-L54
