### PR TITLE
feat: get a GitHub Access Token from keyring

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/suzuki-shunsuke/logrus-error v0.1.4
 	github.com/urfave/cli/v2 v2.27.4
 	github.com/wk8/go-ordered-map/v2 v2.1.8
+	github.com/zalando/go-keyring v0.2.5
 	golang.org/x/oauth2 v0.23.0
 	golang.org/x/sys v0.26.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -36,16 +37,19 @@ require (
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.3.0 // indirect
+	github.com/alessio/shellescape v1.4.1 // indirect
 	github.com/andybalholm/brotli v1.0.1 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
+	github.com/danieljoos/wincred v1.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/gdamore/encoding v1.0.0 // indirect
 	github.com/gdamore/tcell/v2 v2.6.0 // indirect
 	github.com/go-playground/validator/v10 v10.11.1 // indirect
+	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/zalando/go-keyring v0.2.5
 	golang.org/x/oauth2 v0.23.0
 	golang.org/x/sys v0.26.0
+	golang.org/x/term v0.23.0
 	gopkg.in/yaml.v2 v2.4.0
 )
 
@@ -80,7 +81,6 @@ require (
 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
 	golang.org/x/crypto v0.26.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect
-	golang.org/x/term v0.23.0 // indirect
 	golang.org/x/text v0.17.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe
 github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
 github.com/adrg/xdg v0.5.0 h1:dDaZvhMXatArP1NPHhnfaQUqWBLBsmx1h1HXQdMoFCY=
 github.com/adrg/xdg v0.5.0/go.mod h1:dDdY4M4DF9Rjy4kHPeNL+ilVF+p2lK8IdM9/rTSGcI4=
+github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
+github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/andybalholm/brotli v1.0.1 h1:KqhlKozYbRtJvsPrrEeXcO+N2l6NYT5A2QAFmSULpEc=
 github.com/andybalholm/brotli v1.0.1/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
@@ -17,6 +19,8 @@ github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx2
 github.com/cpuguy83/go-md2man/v2 v2.0.4 h1:wfIWP927BUkWJb2NmU/kNDYIBTh/ziUX91+lVfRxZq4=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/danieljoos/wincred v1.2.0 h1:ozqKHaLK0W/ii4KVbbvluM91W2H3Sh0BncbUNPS7jLE=
+github.com/danieljoos/wincred v1.2.0/go.mod h1:FzQLLMKBFdvu+osBrnFODiv32YGwCfx0SkRa/eYHgec=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -45,6 +49,8 @@ github.com/go-playground/validator/v10 v10.11.1 h1:prmOlTVv+YjZjmRmNSF3VmspqJIxJ
 github.com/go-playground/validator/v10 v10.11.1/go.mod h1:i+3WkQ1FvaUjjxh1kSvIA4dMGDBiPU55YFDl0WbKdWU=
 github.com/goccy/go-yaml v1.12.0 h1:/1WHjnMsI1dlIBQutrvSMGZRQufVO3asrHfTwfACoPM=
 github.com/goccy/go-yaml v1.12.0/go.mod h1:wKnAMd44+9JAAnGQpWVEgBzGt3YuTaQ4uXoHvE4m7WU=
+github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
+github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/golang/snappy v0.0.2/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -155,6 +161,8 @@ github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNo
 github.com/spf13/cast v1.7.0 h1:ntdiHjuueXFgm5nzDRdOS4yfT43P5Fnud6DH50rz/7w=
 github.com/spf13/cast v1.7.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -189,6 +197,8 @@ github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMx
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/zalando/go-keyring v0.2.5 h1:Bc2HHpjALryKD62ppdEzaFG6VxL6Bc+5v0LYpN8Lba8=
+github.com/zalando/go-keyring v0.2.5/go.mod h1:HL4k+OXQfJUWaMnqyuSOc0drfGPX2b51Du6K+MRgZMk=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=

--- a/pkg/cli/cp/command.go
+++ b/pkg/cli/cp/command.go
@@ -85,7 +85,7 @@ func (i *command) action(c *cli.Context) error {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
 	param.SkipLink = true
-	ctrl, err := controller.InitializeCopyCommandController(c.Context, param, http.DefaultClient, i.r.Runtime)
+	ctrl, err := controller.InitializeCopyCommandController(c.Context, param, http.DefaultClient, i.r.Runtime, param.GitHub)
 	if err != nil {
 		return fmt.Errorf("initialize a CopyController: %w", err)
 	}

--- a/pkg/cli/exec/command.go
+++ b/pkg/cli/exec/command.go
@@ -46,7 +46,7 @@ func (i *command) action(c *cli.Context) error {
 	if err := util.SetParam(c, i.r.LogE, "exec", param, i.r.LDFlags); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
-	ctrl, err := controller.InitializeExecCommandController(c.Context, param, http.DefaultClient, i.r.Runtime)
+	ctrl, err := controller.InitializeExecCommandController(c.Context, param, http.DefaultClient, i.r.Runtime, param.GitHub)
 	if err != nil {
 		return fmt.Errorf("initialize a ExecController: %w", err)
 	}

--- a/pkg/cli/generate/command.go
+++ b/pkg/cli/generate/command.go
@@ -79,7 +79,7 @@ func (i *command) action(c *cli.Context) error {
 	if err := util.SetParam(c, i.r.LogE, "generate", param, i.r.LDFlags); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
-	ctrl := controller.InitializeGenerateCommandController(c.Context, param, http.DefaultClient, i.r.Runtime)
+	ctrl := controller.InitializeGenerateCommandController(c.Context, param, http.DefaultClient, i.r.Runtime, param.GitHub)
 	return ctrl.Generate(c.Context, i.r.LogE, param, c.Args().Slice()...) //nolint:wrapcheck
 }
 

--- a/pkg/cli/genr/command.go
+++ b/pkg/cli/genr/command.go
@@ -132,6 +132,6 @@ func (i *command) action(c *cli.Context) error {
 	if err := util.SetParam(c, i.r.LogE, "generate-registry", param, i.r.LDFlags); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
-	ctrl := controller.InitializeGenerateRegistryCommandController(c.Context, param, http.DefaultClient, os.Stdout)
+	ctrl := controller.InitializeGenerateRegistryCommandController(c.Context, param, http.DefaultClient, os.Stdout, param.GitHub)
 	return ctrl.GenerateRegistry(c.Context, param, i.r.LogE, c.Args().Slice()...) //nolint:wrapcheck
 }

--- a/pkg/cli/initcmd/command.go
+++ b/pkg/cli/initcmd/command.go
@@ -42,6 +42,6 @@ func (ic *initCommand) action(c *cli.Context) error {
 	if err := util.SetParam(c, ic.r.LogE, "init", param, ic.r.LDFlags); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
-	ctrl := controller.InitializeInitCommandController(c.Context, param)
+	ctrl := controller.InitializeInitCommandController(c.Context, param, param.GitHub)
 	return ctrl.Init(c.Context, ic.r.LogE, c.Args().First()) //nolint:wrapcheck
 }

--- a/pkg/cli/install/command.go
+++ b/pkg/cli/install/command.go
@@ -84,7 +84,7 @@ func (i *command) action(c *cli.Context) error {
 	if err := util.SetParam(c, i.r.LogE, "install", param, i.r.LDFlags); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
-	ctrl, err := controller.InitializeInstallCommandController(c.Context, param, http.DefaultClient, i.r.Runtime)
+	ctrl, err := controller.InitializeInstallCommandController(c.Context, param, http.DefaultClient, i.r.Runtime, param.GitHub)
 	if err != nil {
 		return fmt.Errorf("initialize a InstallController: %w", err)
 	}

--- a/pkg/cli/list/command.go
+++ b/pkg/cli/list/command.go
@@ -71,6 +71,6 @@ func (i *command) action(c *cli.Context) error {
 	if err := util.SetParam(c, i.r.LogE, "list", param, i.r.LDFlags); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
-	ctrl := controller.InitializeListCommandController(c.Context, param, http.DefaultClient, i.r.Runtime)
+	ctrl := controller.InitializeListCommandController(c.Context, param, http.DefaultClient, i.r.Runtime, param.GitHub)
 	return ctrl.List(c.Context, i.r.LogE, param) //nolint:wrapcheck
 }

--- a/pkg/cli/remove/command.go
+++ b/pkg/cli/remove/command.go
@@ -88,7 +88,7 @@ func (i *command) action(c *cli.Context) error {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
 	param.SkipLink = true
-	ctrl := controller.InitializeRemoveCommandController(c.Context, param, http.DefaultClient, i.r.Runtime, mode)
+	ctrl := controller.InitializeRemoveCommandController(c.Context, param, http.DefaultClient, i.r.Runtime, mode, param.GitHub)
 	if err := ctrl.Remove(c.Context, i.r.LogE, param); err != nil {
 		return err //nolint:wrapcheck
 	}

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -76,11 +76,6 @@ func Run(ctx context.Context, param *util.Param, args ...string) error { //nolin
 				Usage:   "Disable GitHub Artifact Attestations verification",
 				EnvVars: []string{"AQUA_DISABLE_GITHUB_ARTIFACT_ATTESTATION"},
 			},
-			&cli.BoolFlag{
-				Name:    "keyring",
-				Usage:   "Enable keyring",
-				EnvVars: []string{"AQUA_KEYRING"},
-			},
 			&cli.StringFlag{
 				Name:  "trace",
 				Usage: "trace output file path",

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -75,6 +75,11 @@ func Run(ctx context.Context, param *util.Param, args ...string) error { //nolin
 				Usage:   "Disable GitHub Artifact Attestations verification",
 				EnvVars: []string{"AQUA_DISABLE_GITHUB_ARTIFACT_ATTESTATION"},
 			},
+			&cli.BoolFlag{
+				Name:    "keyring",
+				Usage:   "Enable keyring",
+				EnvVars: []string{"AQUA_KEYRING"},
+			},
 			&cli.StringFlag{
 				Name:  "trace",
 				Usage: "trace output file path",

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -16,6 +16,7 @@ import (
 	cpolicy "github.com/aquaproj/aqua/v2/pkg/cli/policy"
 	"github.com/aquaproj/aqua/v2/pkg/cli/remove"
 	"github.com/aquaproj/aqua/v2/pkg/cli/root"
+	"github.com/aquaproj/aqua/v2/pkg/cli/token"
 	"github.com/aquaproj/aqua/v2/pkg/cli/upc"
 	"github.com/aquaproj/aqua/v2/pkg/cli/update"
 	"github.com/aquaproj/aqua/v2/pkg/cli/updateaqua"
@@ -110,6 +111,7 @@ func Run(ctx context.Context, param *util.Param, args ...string) error { //nolin
 			upc.New,
 			remove.New,
 			update.New,
+			token.New,
 		),
 	}
 

--- a/pkg/cli/token/command.go
+++ b/pkg/cli/token/command.go
@@ -1,0 +1,16 @@
+package token
+
+import (
+	"github.com/aquaproj/aqua/v2/pkg/cli/util"
+	"github.com/urfave/cli/v2"
+)
+
+func New(r *util.Param) *cli.Command {
+	return &cli.Command{
+		Name:  "token",
+		Usage: "Manage a GitHub Access Token in keyring",
+		Subcommands: []*cli.Command{
+			newSet(r),
+		},
+	}
+}

--- a/pkg/cli/token/set.go
+++ b/pkg/cli/token/set.go
@@ -1,0 +1,42 @@
+package token
+
+import (
+	"fmt"
+
+	"github.com/aquaproj/aqua/v2/pkg/cli/profile"
+	"github.com/aquaproj/aqua/v2/pkg/cli/util"
+	"github.com/aquaproj/aqua/v2/pkg/config"
+	"github.com/aquaproj/aqua/v2/pkg/controller/settoken"
+	"github.com/urfave/cli/v2"
+)
+
+type setCommand struct {
+	r *util.Param
+}
+
+func newSet(r *util.Param) *cli.Command {
+	i := &setCommand{
+		r: r,
+	}
+	return &cli.Command{
+		Action:      i.action,
+		Name:        "set",
+		Usage:       "Set a GitHub Access token in keyring",
+		Description: `Set a GitHub Access token in keyring`,
+	}
+}
+
+func (pa *setCommand) action(c *cli.Context) error {
+	profiler, err := profile.Start(c)
+	if err != nil {
+		return fmt.Errorf("start CPU Profile or tracing: %w", err)
+	}
+	defer profiler.Stop()
+
+	param := &config.Param{}
+	if err := util.SetParam(c, pa.r.LogE, "token-set", param, pa.r.LDFlags); err != nil {
+		return fmt.Errorf("parse the command line arguments: %w", err)
+	}
+	ctrl := settoken.New()
+	return ctrl.Set(c.Context, pa.r.LogE) //nolint:wrapcheck
+}

--- a/pkg/cli/token/set.go
+++ b/pkg/cli/token/set.go
@@ -21,8 +21,14 @@ func newSet(r *util.Param) *cli.Command {
 	return &cli.Command{
 		Action:      i.action,
 		Name:        "set",
-		Usage:       "Set a GitHub Access token in keyring",
-		Description: `Set a GitHub Access token in keyring`,
+		Usage:       "Set a GitHub access token in keyring",
+		Description: `Set a GitHub access token in keyring`,
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "stdin",
+				Usage: "Read a GitHub access token from stdin",
+			},
+		},
 	}
 }
 
@@ -37,6 +43,6 @@ func (pa *setCommand) action(c *cli.Context) error {
 	if err := util.SetParam(c, pa.r.LogE, "token-set", param, pa.r.LDFlags); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
-	ctrl := settoken.New(pa.r.Stdout)
-	return ctrl.Set(c.Context, pa.r.LogE) //nolint:wrapcheck
+	ctrl := settoken.New(pa.r.Stdin, pa.r.Stdout)
+	return ctrl.Set(c.Context, pa.r.LogE, param) //nolint:wrapcheck
 }

--- a/pkg/cli/token/set.go
+++ b/pkg/cli/token/set.go
@@ -37,6 +37,6 @@ func (pa *setCommand) action(c *cli.Context) error {
 	if err := util.SetParam(c, pa.r.LogE, "token-set", param, pa.r.LDFlags); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
-	ctrl := settoken.New()
+	ctrl := settoken.New(pa.r.Stdout)
 	return ctrl.Set(c.Context, pa.r.LogE) //nolint:wrapcheck
 }

--- a/pkg/cli/upc/command.go
+++ b/pkg/cli/upc/command.go
@@ -71,6 +71,6 @@ func (i *command) action(c *cli.Context) error {
 	if err := util.SetParam(c, i.r.LogE, "update-checksum", param, i.r.LDFlags); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
-	ctrl := controller.InitializeUpdateChecksumCommandController(c.Context, param, http.DefaultClient, i.r.Runtime)
+	ctrl := controller.InitializeUpdateChecksumCommandController(c.Context, param, http.DefaultClient, i.r.Runtime, param.GitHub)
 	return ctrl.UpdateChecksum(c.Context, i.r.LogE, param) //nolint:wrapcheck
 }

--- a/pkg/cli/update/command.go
+++ b/pkg/cli/update/command.go
@@ -139,6 +139,6 @@ func (i *command) action(c *cli.Context) error {
 	if err := util.SetParam(c, i.r.LogE, "update", param, i.r.LDFlags); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
-	ctrl := controller.InitializeUpdateCommandController(c.Context, param, http.DefaultClient, i.r.Runtime)
+	ctrl := controller.InitializeUpdateCommandController(c.Context, param, http.DefaultClient, i.r.Runtime, param.GitHub)
 	return ctrl.Update(c.Context, i.r.LogE, param) //nolint:wrapcheck
 }

--- a/pkg/cli/updateaqua/command.go
+++ b/pkg/cli/updateaqua/command.go
@@ -52,7 +52,7 @@ func (ua *updateAquaCommand) action(c *cli.Context) error {
 	if err := util.SetParam(c, ua.r.LogE, "update-aqua", param, ua.r.LDFlags); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
-	ctrl, err := controller.InitializeUpdateAquaCommandController(c.Context, param, http.DefaultClient, ua.r.Runtime)
+	ctrl, err := controller.InitializeUpdateAquaCommandController(c.Context, param, http.DefaultClient, ua.r.Runtime, param.GitHub)
 	if err != nil {
 		return fmt.Errorf("initialize a UpdateAquaController: %w", err)
 	}

--- a/pkg/cli/util/util.go
+++ b/pkg/cli/util/util.go
@@ -54,14 +54,8 @@ func SetParam(c *cli.Context, logE *logrus.Entry, commandName string, param *con
 	}
 	param.All = c.Bool("all")
 	param.Stdin = c.Bool("stdin")
-	if a := os.Getenv("AQUA_ENABLE_KEYRING"); a != "" {
-		b, err := strconv.ParseBool(a)
-		if err != nil {
-			return fmt.Errorf("parse the environment variable AQUA_ENABLE_KEYRING as bool: %w", err)
-		}
-		param.GitHub = &github.Option{
-			Keyring: b,
-		}
+	if err := setEnableKeyring(param); err != nil {
+		return err
 	}
 	param.Global = c.Bool("g")
 	param.Detail = c.Bool("detail")
@@ -160,4 +154,17 @@ func parseTags(tags []string) map[string]struct{} {
 		tagsM[tag] = struct{}{}
 	}
 	return tagsM
+}
+
+func setEnableKeyring(param *config.Param) error {
+	if a := os.Getenv("AQUA_ENABLE_KEYRING"); a != "" {
+		b, err := strconv.ParseBool(a)
+		if err != nil {
+			return fmt.Errorf("parse the environment variable AQUA_ENABLE_KEYRING as bool: %w", err)
+		}
+		param.GitHub = &github.Option{
+			Keyring: b,
+		}
+	}
+	return nil
 }

--- a/pkg/cli/util/util.go
+++ b/pkg/cli/util/util.go
@@ -54,8 +54,14 @@ func SetParam(c *cli.Context, logE *logrus.Entry, commandName string, param *con
 	}
 	param.All = c.Bool("all")
 	param.Stdin = c.Bool("stdin")
-	param.GitHub = &github.Option{
-		Keyring: c.Bool("keyring"),
+	if a := os.Getenv("AQUA_ENABLE_KEYRING"); a != "" {
+		b, err := strconv.ParseBool(a)
+		if err != nil {
+			return fmt.Errorf("parse the environment variable AQUA_ENABLE_KEYRING as bool: %w", err)
+		}
+		param.GitHub = &github.Option{
+			Keyring: b,
+		}
 	}
 	param.Global = c.Bool("g")
 	param.Detail = c.Bool("detail")

--- a/pkg/cli/util/util.go
+++ b/pkg/cli/util/util.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aquaproj/aqua/v2/pkg/config"
 	finder "github.com/aquaproj/aqua/v2/pkg/config-finder"
+	"github.com/aquaproj/aqua/v2/pkg/github"
 	"github.com/aquaproj/aqua/v2/pkg/log"
 	"github.com/aquaproj/aqua/v2/pkg/policy"
 	"github.com/aquaproj/aqua/v2/pkg/runtime"
@@ -52,6 +53,9 @@ func SetParam(c *cli.Context, logE *logrus.Entry, commandName string, param *con
 		param.Insert = c.Bool("i")
 	}
 	param.All = c.Bool("all")
+	param.GitHub = &github.Option{
+		Keyring: c.Bool("keyring"),
+	}
 	param.Global = c.Bool("g")
 	param.Detail = c.Bool("detail")
 	param.Prune = c.Bool("prune")

--- a/pkg/cli/util/util.go
+++ b/pkg/cli/util/util.go
@@ -53,6 +53,7 @@ func SetParam(c *cli.Context, logE *logrus.Entry, commandName string, param *con
 		param.Insert = c.Bool("i")
 	}
 	param.All = c.Bool("all")
+	param.Stdin = c.Bool("stdin")
 	param.GitHub = &github.Option{
 		Keyring: c.Bool("keyring"),
 	}

--- a/pkg/cli/which/command.go
+++ b/pkg/cli/which/command.go
@@ -70,7 +70,7 @@ func (i *command) action(c *cli.Context) error {
 	if err := util.SetParam(c, i.r.LogE, "which", param, i.r.LDFlags); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
-	ctrl := controller.InitializeWhichCommandController(c.Context, param, http.DefaultClient, i.r.Runtime)
+	ctrl := controller.InitializeWhichCommandController(c.Context, param, http.DefaultClient, i.r.Runtime, param.GitHub)
 	exeName, _, err := ParseExecArgs(c.Args().Slice())
 	if err != nil {
 		return err

--- a/pkg/config/package.go
+++ b/pkg/config/package.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aquaproj/aqua/v2/pkg/asset"
 	"github.com/aquaproj/aqua/v2/pkg/config/aqua"
 	"github.com/aquaproj/aqua/v2/pkg/config/registry"
+	"github.com/aquaproj/aqua/v2/pkg/github"
 	"github.com/aquaproj/aqua/v2/pkg/runtime"
 	"github.com/aquaproj/aqua/v2/pkg/template"
 	"github.com/aquaproj/aqua/v2/pkg/unarchive"
@@ -291,8 +292,10 @@ type Param struct {
 	GitHubArtifactAttestationDisabled bool
 	SLSADisabled                      bool
 	Installed                         bool
+	Keyring                           bool
 	PolicyConfigFilePaths             []string
 	Commands                          []string
+	GitHub                            *github.Option
 }
 
 func appendExt(s, format string) string {

--- a/pkg/config/package.go
+++ b/pkg/config/package.go
@@ -293,6 +293,7 @@ type Param struct {
 	SLSADisabled                      bool
 	Installed                         bool
 	Keyring                           bool
+	Stdin                             bool
 	PolicyConfigFilePaths             []string
 	Commands                          []string
 	GitHub                            *github.Option

--- a/pkg/controller/generate-registry/generate.go
+++ b/pkg/controller/generate-registry/generate.go
@@ -71,12 +71,12 @@ func (c *Controller) genRegistry(ctx context.Context, param *config.Param, logE 
 	return nil
 }
 
-func (c *Controller) getRelease(ctx context.Context, repoOwner, repoName, version string) (*github.RepositoryRelease, error) {
+func (c *Controller) getRelease(ctx context.Context, logE *logrus.Entry, repoOwner, repoName, version string) (*github.RepositoryRelease, error) {
 	if version == "" {
-		release, _, err := c.github.GetLatestRelease(ctx, repoOwner, repoName)
+		release, _, err := c.github.GetLatestRelease(ctx, logE, repoOwner, repoName)
 		return release, err //nolint:wrapcheck
 	}
-	release, _, err := c.github.GetReleaseByTag(ctx, repoOwner, repoName, version)
+	release, _, err := c.github.GetReleaseByTag(ctx, logE, repoOwner, repoName, version)
 	return release, err //nolint:wrapcheck
 }
 
@@ -98,7 +98,7 @@ func (c *Controller) getPackageInfo(ctx context.Context, logE *logrus.Entry, arg
 	}
 	pkgInfo.RepoOwner = splitPkgNames[0]
 	pkgInfo.RepoName = splitPkgNames[1]
-	repo, _, err := c.github.Get(ctx, pkgInfo.RepoOwner, pkgInfo.RepoName)
+	repo, _, err := c.github.Get(ctx, logE, pkgInfo.RepoOwner, pkgInfo.RepoName)
 	if err != nil {
 		logE.WithFields(logrus.Fields{
 			"repo_owner": pkgInfo.RepoOwner,
@@ -110,7 +110,7 @@ func (c *Controller) getPackageInfo(ctx context.Context, logE *logrus.Entry, arg
 	if limit != 1 && version == "" {
 		return c.getPackageInfoWithVersionOverrides(ctx, logE, pkgName, pkgInfo, limit)
 	}
-	release, err := c.getRelease(ctx, pkgInfo.RepoOwner, pkgInfo.RepoName, version)
+	release, err := c.getRelease(ctx, logE, pkgInfo.RepoOwner, pkgInfo.RepoName, version)
 	if err != nil {
 		logE.WithFields(logrus.Fields{
 			"repo_owner": pkgInfo.RepoOwner,
@@ -205,7 +205,7 @@ func (c *Controller) listReleaseAssets(ctx context.Context, logE *logrus.Entry, 
 	}
 	var arr []*github.ReleaseAsset
 	for range 10 {
-		assets, _, err := c.github.ListReleaseAssets(ctx, pkgInfo.RepoOwner, pkgInfo.RepoName, releaseID, opts)
+		assets, _, err := c.github.ListReleaseAssets(ctx, logE, pkgInfo.RepoOwner, pkgInfo.RepoName, releaseID, opts)
 		if err != nil {
 			logE.WithFields(logrus.Fields{
 				"repo_owner": pkgInfo.RepoOwner,

--- a/pkg/controller/generate-registry/interface.go
+++ b/pkg/controller/generate-registry/interface.go
@@ -4,12 +4,13 @@ import (
 	"context"
 
 	"github.com/aquaproj/aqua/v2/pkg/github"
+	"github.com/sirupsen/logrus"
 )
 
 type RepositoriesService interface {
-	Get(ctx context.Context, owner, repo string) (*github.Repository, *github.Response, error)
-	GetLatestRelease(ctx context.Context, repoOwner, repoName string) (*github.RepositoryRelease, *github.Response, error)
-	GetReleaseByTag(ctx context.Context, owner, repo, tag string) (*github.RepositoryRelease, *github.Response, error)
-	ListReleaseAssets(ctx context.Context, owner, repo string, id int64, opts *github.ListOptions) ([]*github.ReleaseAsset, *github.Response, error)
-	ListReleases(ctx context.Context, owner, repo string, opts *github.ListOptions) ([]*github.RepositoryRelease, *github.Response, error)
+	Get(ctx context.Context, logE *logrus.Entry, owner, repo string) (*github.Repository, *github.Response, error)
+	GetLatestRelease(ctx context.Context, logE *logrus.Entry, repoOwner, repoName string) (*github.RepositoryRelease, *github.Response, error)
+	GetReleaseByTag(ctx context.Context, logE *logrus.Entry, owner, repo, tag string) (*github.RepositoryRelease, *github.Response, error)
+	ListReleaseAssets(ctx context.Context, logE *logrus.Entry, owner, repo string, id int64, opts *github.ListOptions) ([]*github.ReleaseAsset, *github.Response, error)
+	ListReleases(ctx context.Context, logE *logrus.Entry, owner, repo string, opts *github.ListOptions) ([]*github.RepositoryRelease, *github.Response, error)
 }

--- a/pkg/controller/generate-registry/version_overrides.go
+++ b/pkg/controller/generate-registry/version_overrides.go
@@ -115,7 +115,7 @@ func (c *Controller) listReleases(ctx context.Context, logE *logrus.Entry, pkgIn
 	var arr []*github.RepositoryRelease
 
 	for range 10 {
-		releases, resp, err := c.github.ListReleases(ctx, repoOwner, repoName, opt)
+		releases, resp, err := c.github.ListReleases(ctx, logE, repoOwner, repoName, opt)
 		if err != nil {
 			logerr.WithError(logE, err).WithFields(logrus.Fields{
 				"repo_owner": repoOwner,

--- a/pkg/controller/generate/interface.go
+++ b/pkg/controller/generate/interface.go
@@ -5,12 +5,13 @@ import (
 
 	"github.com/aquaproj/aqua/v2/pkg/controller/generate/output"
 	"github.com/aquaproj/aqua/v2/pkg/github"
+	"github.com/sirupsen/logrus"
 )
 
 type RepositoriesService interface {
-	GetLatestRelease(ctx context.Context, repoOwner, repoName string) (*github.RepositoryRelease, *github.Response, error)
-	ListReleases(ctx context.Context, owner, repo string, opts *github.ListOptions) ([]*github.RepositoryRelease, *github.Response, error)
-	ListTags(ctx context.Context, owner string, repo string, opts *github.ListOptions) ([]*github.RepositoryTag, *github.Response, error)
+	GetLatestRelease(ctx context.Context, logE *logrus.Entry, repoOwner, repoName string) (*github.RepositoryRelease, *github.Response, error)
+	ListReleases(ctx context.Context, logE *logrus.Entry, owner, repo string, opts *github.ListOptions) ([]*github.RepositoryRelease, *github.Response, error)
+	ListTags(ctx context.Context, logE *logrus.Entry, owner string, repo string, opts *github.ListOptions) ([]*github.RepositoryTag, *github.Response, error)
 }
 
 type ConfigFinder interface {

--- a/pkg/controller/initcmd/init.go
+++ b/pkg/controller/initcmd/init.go
@@ -50,7 +50,7 @@ func (c *Controller) Init(ctx context.Context, logE *logrus.Entry, cfgFilePath s
 	}
 
 	registryVersion := "v4.232.0" // renovate: depName=aquaproj/aqua-registry
-	release, _, err := c.github.GetLatestRelease(ctx, "aquaproj", "aqua-registry")
+	release, _, err := c.github.GetLatestRelease(ctx, logE, "aquaproj", "aqua-registry")
 	if err != nil {
 		logerr.WithError(logE, err).WithFields(logrus.Fields{
 			"repo_owner": "aquaproj",

--- a/pkg/controller/initcmd/interface.go
+++ b/pkg/controller/initcmd/interface.go
@@ -4,8 +4,9 @@ import (
 	"context"
 
 	"github.com/aquaproj/aqua/v2/pkg/github"
+	"github.com/sirupsen/logrus"
 )
 
 type RepositoriesService interface {
-	GetLatestRelease(ctx context.Context, repoOwner, repoName string) (*github.RepositoryRelease, *github.Response, error)
+	GetLatestRelease(ctx context.Context, logE *logrus.Entry, repoOwner, repoName string) (*github.RepositoryRelease, *github.Response, error)
 }

--- a/pkg/controller/settoken/controller.go
+++ b/pkg/controller/settoken/controller.go
@@ -1,0 +1,7 @@
+package settoken
+
+type Controller struct{}
+
+func New() *Controller {
+	return &Controller{}
+}

--- a/pkg/controller/settoken/controller.go
+++ b/pkg/controller/settoken/controller.go
@@ -3,11 +3,13 @@ package settoken
 import "io"
 
 type Controller struct {
+	stdin  io.Reader
 	stdout io.Writer
 }
 
-func New(stdout io.Writer) *Controller {
+func New(stdin io.Reader, stdout io.Writer) *Controller {
 	return &Controller{
+		stdin:  stdin,
 		stdout: stdout,
 	}
 }

--- a/pkg/controller/settoken/controller.go
+++ b/pkg/controller/settoken/controller.go
@@ -1,7 +1,13 @@
 package settoken
 
-type Controller struct{}
+import "io"
 
-func New() *Controller {
-	return &Controller{}
+type Controller struct {
+	stdout io.Writer
+}
+
+func New(stdout io.Writer) *Controller {
+	return &Controller{
+		stdout: stdout,
+	}
 }

--- a/pkg/controller/settoken/set.go
+++ b/pkg/controller/settoken/set.go
@@ -3,6 +3,7 @@ package settoken
 import (
 	"context"
 	"fmt"
+	"strings"
 	"syscall"
 
 	"github.com/aquaproj/aqua/v2/pkg/github"
@@ -16,7 +17,9 @@ func (c *Controller) Set(ctx context.Context, logE *logrus.Entry) error {
 	if err != nil {
 		return fmt.Errorf("read a GitHub Access Token from stdin: %w", err)
 	}
-	fmt.Println("")
-	github.SetTokenInKeyring(string(text))
+	fmt.Fprintln(c.stdout, "")
+	if err := github.SetTokenInKeyring(strings.TrimSpace(string(text))); err != nil {
+		return fmt.Errorf("set a GitHub Access Token to the secret store: %w", err)
+	}
 	return nil
 }

--- a/pkg/controller/settoken/set.go
+++ b/pkg/controller/settoken/set.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (c *Controller) Set(ctx context.Context, logE *logrus.Entry) error {
-	fmt.Print("Enter a GitHub acccess token for aqua: ")
+	fmt.Fprint(c.stdout, "Enter a GitHub acccess token for aqua: ")
 	text, err := term.ReadPassword(int(syscall.Stdin))
 	if err != nil {
 		return fmt.Errorf("read a GitHub Access Token from stdin: %w", err)

--- a/pkg/controller/settoken/set.go
+++ b/pkg/controller/settoken/set.go
@@ -11,9 +11,9 @@ import (
 	"golang.org/x/term"
 )
 
-func (c *Controller) Set(ctx context.Context, logE *logrus.Entry) error {
+func (c *Controller) Set(_ context.Context, logE *logrus.Entry) error {
 	fmt.Fprint(c.stdout, "Enter a GitHub acccess token for aqua: ")
-	text, err := term.ReadPassword(int(syscall.Stdin))
+	text, err := term.ReadPassword(syscall.Stdin)
 	if err != nil {
 		return fmt.Errorf("read a GitHub Access Token from stdin: %w", err)
 	}

--- a/pkg/controller/settoken/set.go
+++ b/pkg/controller/settoken/set.go
@@ -3,23 +3,41 @@ package settoken
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 	"syscall"
 
+	"github.com/aquaproj/aqua/v2/pkg/config"
 	"github.com/aquaproj/aqua/v2/pkg/github"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/term"
 )
 
-func (c *Controller) Set(_ context.Context, logE *logrus.Entry) error {
-	fmt.Fprint(c.stdout, "Enter a GitHub acccess token for aqua: ")
-	text, err := term.ReadPassword(syscall.Stdin)
+func (c *Controller) Set(_ context.Context, logE *logrus.Entry, param *config.Param) error {
+	text, err := c.get(logE, param)
 	if err != nil {
-		return fmt.Errorf("read a GitHub Access Token from stdin: %w", err)
+		return fmt.Errorf("get a GitHub access Token: %w", err)
 	}
-	fmt.Fprintln(c.stdout, "")
 	if err := github.SetTokenInKeyring(strings.TrimSpace(string(text))); err != nil {
-		return fmt.Errorf("set a GitHub Access Token to the secret store: %w", err)
+		return fmt.Errorf("set a GitHub access Token to the secret store: %w", err)
 	}
 	return nil
+}
+
+func (c *Controller) get(logE *logrus.Entry, param *config.Param) ([]byte, error) {
+	if param.Stdin {
+		s, err := io.ReadAll(c.stdin)
+		if err != nil {
+			return nil, fmt.Errorf("read a GitHub access token from stdin: %w", err)
+		}
+		logE.Debug("read a GitHub access token from stdin")
+		return s, nil
+	}
+	fmt.Fprint(c.stdout, "Enter a GitHub acccess token for aqua: ")
+	text, err := term.ReadPassword(syscall.Stdin)
+	fmt.Fprintln(c.stdout, "")
+	if err != nil {
+		return nil, fmt.Errorf("read a GitHub access Token from stdin: %w", err)
+	}
+	return text, nil
 }

--- a/pkg/controller/settoken/set.go
+++ b/pkg/controller/settoken/set.go
@@ -34,7 +34,7 @@ func (c *Controller) get(logE *logrus.Entry, param *config.Param) ([]byte, error
 		return s, nil
 	}
 	fmt.Fprint(c.stdout, "Enter a GitHub acccess token for aqua: ")
-	text, err := term.ReadPassword(syscall.Stdin)
+	text, err := term.ReadPassword(int(syscall.Stdin))
 	fmt.Fprintln(c.stdout, "")
 	if err != nil {
 		return nil, fmt.Errorf("read a GitHub access Token from stdin: %w", err)

--- a/pkg/controller/settoken/set.go
+++ b/pkg/controller/settoken/set.go
@@ -34,7 +34,9 @@ func (c *Controller) get(logE *logrus.Entry, param *config.Param) ([]byte, error
 		return s, nil
 	}
 	fmt.Fprint(c.stdout, "Enter a GitHub acccess token for aqua: ")
-	text, err := term.ReadPassword(int(syscall.Stdin))
+	// The conversion is necessary for Windows
+	// https://pkg.go.dev/syscall?GOOS=windows#pkg-variables
+	text, err := term.ReadPassword(int(syscall.Stdin)) //nolint:unconvert
 	fmt.Fprintln(c.stdout, "")
 	if err != nil {
 		return nil, fmt.Errorf("read a GitHub access Token from stdin: %w", err)

--- a/pkg/controller/settoken/set.go
+++ b/pkg/controller/settoken/set.go
@@ -1,0 +1,22 @@
+package settoken
+
+import (
+	"context"
+	"fmt"
+	"syscall"
+
+	"github.com/aquaproj/aqua/v2/pkg/github"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/term"
+)
+
+func (c *Controller) Set(ctx context.Context, logE *logrus.Entry) error {
+	fmt.Print("Enter a GitHub acccess token for aqua: ")
+	text, err := term.ReadPassword(int(syscall.Stdin))
+	if err != nil {
+		return fmt.Errorf("read a GitHub Access Token from stdin: %w", err)
+	}
+	fmt.Println("")
+	github.SetTokenInKeyring(string(text))
+	return nil
+}

--- a/pkg/controller/update/controller.go
+++ b/pkg/controller/update/controller.go
@@ -47,9 +47,9 @@ type FuzzyGetter interface {
 }
 
 type RepositoriesService interface {
-	GetLatestRelease(ctx context.Context, repoOwner, repoName string) (*github.RepositoryRelease, *github.Response, error)
-	ListReleases(ctx context.Context, owner, repo string, opts *github.ListOptions) ([]*github.RepositoryRelease, *github.Response, error)
-	ListTags(ctx context.Context, owner string, repo string, opts *github.ListOptions) ([]*github.RepositoryTag, *github.Response, error)
+	GetLatestRelease(ctx context.Context, logE *logrus.Entry, repoOwner, repoName string) (*github.RepositoryRelease, *github.Response, error)
+	ListReleases(ctx context.Context, logE *logrus.Entry, owner, repo string, opts *github.ListOptions) ([]*github.RepositoryRelease, *github.Response, error)
+	ListTags(ctx context.Context, logE *logrus.Entry, owner string, repo string, opts *github.ListOptions) ([]*github.RepositoryTag, *github.Response, error)
 }
 
 func New(param *config.Param, gh RepositoriesService, configFinder ConfigFinder, configReader ConfigReader, registInstaller RegistryInstaller, fs afero.Fs, rt *runtime.Runtime, fuzzyGetter FuzzyGetter, fuzzyFinder FuzzyFinder, whichController WhichController) *Controller {

--- a/pkg/controller/update/registry.go
+++ b/pkg/controller/update/registry.go
@@ -17,7 +17,7 @@ func (c *Controller) newRegistryVersion(ctx context.Context, logE *logrus.Entry,
 	}
 
 	logE.Debug("getting the latest release")
-	release, _, err := c.gh.GetLatestRelease(ctx, rgst.RepoOwner, rgst.RepoName)
+	release, _, err := c.gh.GetLatestRelease(ctx, logE, rgst.RepoOwner, rgst.RepoName)
 	if err != nil {
 		return "", fmt.Errorf("get the latest release by GitHub API: %w", err)
 	}

--- a/pkg/controller/updateaqua/interface.go
+++ b/pkg/controller/updateaqua/interface.go
@@ -12,7 +12,7 @@ type AquaInstaller interface {
 }
 
 type RepositoriesService interface {
-	GetLatestRelease(ctx context.Context, repoOwner, repoName string) (*github.RepositoryRelease, *github.Response, error)
+	GetLatestRelease(ctx context.Context, logE *logrus.Entry, repoOwner, repoName string) (*github.RepositoryRelease, *github.Response, error)
 }
 
 type ConfigFinder interface {

--- a/pkg/controller/updateaqua/update_aqua.go
+++ b/pkg/controller/updateaqua/update_aqua.go
@@ -18,7 +18,7 @@ func (c *Controller) UpdateAqua(ctx context.Context, logE *logrus.Entry, param *
 		return fmt.Errorf("create the directory: %w", err)
 	}
 
-	version, err := c.getVersion(ctx, param)
+	version, err := c.getVersion(ctx, logE, param)
 	if err != nil {
 		return err
 	}
@@ -33,10 +33,10 @@ func (c *Controller) UpdateAqua(ctx context.Context, logE *logrus.Entry, param *
 	return nil
 }
 
-func (c *Controller) getVersion(ctx context.Context, param *config.Param) (string, error) {
+func (c *Controller) getVersion(ctx context.Context, logE *logrus.Entry, param *config.Param) (string, error) {
 	switch len(param.Args) {
 	case 0:
-		release, _, err := c.github.GetLatestRelease(ctx, "aquaproj", "aqua")
+		release, _, err := c.github.GetLatestRelease(ctx, logE, "aquaproj", "aqua")
 		if err != nil {
 			return "", fmt.Errorf("get the latest version of aqua: %w", err)
 		}

--- a/pkg/controller/wire.go
+++ b/pkg/controller/wire.go
@@ -52,7 +52,7 @@ import (
 	"github.com/suzuki-shunsuke/go-osenv/osenv"
 )
 
-func InitializeListCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *list.Controller {
+func InitializeListCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime, opt *github.Option) *list.Controller {
 	wire.Build(
 		list.NewController,
 		wire.NewSet(
@@ -61,8 +61,8 @@ func InitializeListCommandController(ctx context.Context, param *config.Param, h
 		),
 		wire.NewSet(
 			github.New,
-			wire.Bind(new(github.RepositoriesService), new(*github.RepositoriesServiceImpl)),
-			wire.Bind(new(download.GitHubContentAPI), new(*github.RepositoriesServiceImpl)),
+			wire.Bind(new(download.GitHub), new(*github.GitHub)),
+			wire.Bind(new(download.GitHubContentAPI), new(*github.GitHub)),
 		),
 		wire.NewSet(
 			registry.New,
@@ -105,12 +105,12 @@ func InitializeListCommandController(ctx context.Context, param *config.Param, h
 	return &list.Controller{}
 }
 
-func InitializeGenerateRegistryCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, stdout io.Writer) *genrgst.Controller {
+func InitializeGenerateRegistryCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, stdout io.Writer, opt *github.Option) *genrgst.Controller {
 	wire.Build(
 		genrgst.NewController,
 		wire.NewSet(
 			github.New,
-			wire.Bind(new(genrgst.RepositoriesService), new(*github.RepositoriesServiceImpl)),
+			wire.Bind(new(genrgst.RepositoriesService), new(*github.GitHub)),
 		),
 		afero.NewOsFs,
 		wire.NewSet(
@@ -125,12 +125,12 @@ func InitializeGenerateRegistryCommandController(ctx context.Context, param *con
 	return &genrgst.Controller{}
 }
 
-func InitializeInitCommandController(ctx context.Context, param *config.Param) *initcmd.Controller {
+func InitializeInitCommandController(ctx context.Context, param *config.Param, opt *github.Option) *initcmd.Controller {
 	wire.Build(
 		initcmd.New,
 		wire.NewSet(
 			github.New,
-			wire.Bind(new(initcmd.RepositoriesService), new(*github.RepositoriesServiceImpl)),
+			wire.Bind(new(initcmd.RepositoriesService), new(*github.GitHub)),
 		),
 		afero.NewOsFs,
 	)
@@ -145,7 +145,7 @@ func InitializeInitPolicyCommandController(ctx context.Context) *initpolicy.Cont
 	return &initpolicy.Controller{}
 }
 
-func InitializeGenerateCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *generate.Controller {
+func InitializeGenerateCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime, opt *github.Option) *generate.Controller {
 	wire.Build(
 		generate.New,
 		wire.NewSet(
@@ -154,11 +154,11 @@ func InitializeGenerateCommandController(ctx context.Context, param *config.Para
 		),
 		wire.NewSet(
 			github.New,
-			wire.Bind(new(generate.RepositoriesService), new(*github.RepositoriesServiceImpl)),
-			wire.Bind(new(download.GitHubContentAPI), new(*github.RepositoriesServiceImpl)),
-			wire.Bind(new(github.RepositoriesService), new(*github.RepositoriesServiceImpl)),
-			wire.Bind(new(versiongetter.GitHubTagClient), new(*github.RepositoriesServiceImpl)),
-			wire.Bind(new(versiongetter.GitHubReleaseClient), new(*github.RepositoriesServiceImpl)),
+			wire.Bind(new(generate.RepositoriesService), new(*github.GitHub)),
+			wire.Bind(new(download.GitHubContentAPI), new(*github.GitHub)),
+			wire.Bind(new(download.GitHub), new(*github.GitHub)),
+			wire.Bind(new(versiongetter.GitHubTagClient), new(*github.GitHub)),
+			wire.Bind(new(versiongetter.GitHubReleaseClient), new(*github.GitHub)),
 		),
 		wire.NewSet(
 			registry.New,
@@ -222,7 +222,7 @@ func InitializeGenerateCommandController(ctx context.Context, param *config.Para
 	return &generate.Controller{}
 }
 
-func InitializeInstallCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) (*install.Controller, error) {
+func InitializeInstallCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime, opt *github.Option) (*install.Controller, error) {
 	wire.Build(
 		install.New,
 		wire.NewSet(
@@ -231,8 +231,8 @@ func InitializeInstallCommandController(ctx context.Context, param *config.Param
 		),
 		wire.NewSet(
 			github.New,
-			wire.Bind(new(github.RepositoriesService), new(*github.RepositoriesServiceImpl)),
-			wire.Bind(new(download.GitHubContentAPI), new(*github.RepositoriesServiceImpl)),
+			wire.Bind(new(download.GitHub), new(*github.GitHub)),
+			wire.Bind(new(download.GitHubContentAPI), new(*github.GitHub)),
 		),
 		wire.NewSet(
 			registry.New,
@@ -346,7 +346,7 @@ func InitializeInstallCommandController(ctx context.Context, param *config.Param
 	return &install.Controller{}, nil
 }
 
-func InitializeWhichCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *which.Controller {
+func InitializeWhichCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime, opt *github.Option) *which.Controller {
 	wire.Build(
 		which.New,
 		wire.NewSet(
@@ -355,8 +355,8 @@ func InitializeWhichCommandController(ctx context.Context, param *config.Param, 
 		),
 		wire.NewSet(
 			github.New,
-			wire.Bind(new(github.RepositoriesService), new(*github.RepositoriesServiceImpl)),
-			wire.Bind(new(download.GitHubContentAPI), new(*github.RepositoriesServiceImpl)),
+			wire.Bind(new(download.GitHub), new(*github.GitHub)),
+			wire.Bind(new(download.GitHubContentAPI), new(*github.GitHub)),
 		),
 		wire.NewSet(
 			registry.New,
@@ -405,9 +405,9 @@ func InitializeWhichCommandController(ctx context.Context, param *config.Param, 
 	return nil
 }
 
-func InitializeExecCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) (*cosexec.Controller, error) {
+func InitializeExecCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime, opt *github.Option) (*cexec.Controller, error) {
 	wire.Build(
-		cosexec.New,
+		cexec.New,
 		wire.NewSet(
 			finder.NewConfigFinder,
 			wire.Bind(new(which.ConfigFinder), new(*finder.ConfigFinder)),
@@ -418,12 +418,12 @@ func InitializeExecCommandController(ctx context.Context, param *config.Param, h
 		),
 		wire.NewSet(
 			installpackage.New,
-			wire.Bind(new(cosexec.Installer), new(*installpackage.Installer)),
+			wire.Bind(new(cexec.Installer), new(*installpackage.Installer)),
 		),
 		wire.NewSet(
 			github.New,
-			wire.Bind(new(github.RepositoriesService), new(*github.RepositoriesServiceImpl)),
-			wire.Bind(new(download.GitHubContentAPI), new(*github.RepositoriesServiceImpl)),
+			wire.Bind(new(download.GitHub), new(*github.GitHub)),
+			wire.Bind(new(download.GitHubContentAPI), new(*github.GitHub)),
 		),
 		wire.NewSet(
 			registry.New,
@@ -439,12 +439,12 @@ func InitializeExecCommandController(ctx context.Context, param *config.Param, h
 		),
 		wire.NewSet(
 			which.New,
-			wire.Bind(new(cosexec.WhichController), new(*which.Controller)),
+			wire.Bind(new(cexec.WhichController), new(*which.Controller)),
 		),
 		wire.NewSet(
 			osexec.New,
 			wire.Bind(new(installpackage.Executor), new(*osexec.Executor)),
-			wire.Bind(new(cosexec.Executor), new(*osexec.Executor)),
+			wire.Bind(new(cexec.Executor), new(*osexec.Executor)),
 			wire.Bind(new(cosign.Executor), new(*osexec.Executor)),
 			wire.Bind(new(slsa.CommandExecutor), new(*osexec.Executor)),
 			wire.Bind(new(minisign.CommandExecutor), new(*osexec.Executor)),
@@ -488,7 +488,7 @@ func InitializeExecCommandController(ctx context.Context, param *config.Param, h
 		),
 		wire.NewSet(
 			policy.NewReader,
-			wire.Bind(new(cosexec.PolicyReader), new(*policy.Reader)),
+			wire.Bind(new(cexec.PolicyReader), new(*policy.Reader)),
 		),
 		wire.NewSet(
 			cosign.NewVerifier,
@@ -533,10 +533,10 @@ func InitializeExecCommandController(ctx context.Context, param *config.Param, h
 			wire.Bind(new(installpackage.CargoPackageInstaller), new(*installpackage.CargoPackageInstallerImpl)),
 		),
 	)
-	return &cosexec.Controller{}, nil
+	return &cexec.Controller{}, nil
 }
 
-func InitializeUpdateAquaCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) (*updateaqua.Controller, error) {
+func InitializeUpdateAquaCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime, opt *github.Option) (*updateaqua.Controller, error) {
 	wire.Build(
 		updateaqua.New,
 		wire.NewSet(
@@ -545,8 +545,8 @@ func InitializeUpdateAquaCommandController(ctx context.Context, param *config.Pa
 		),
 		wire.NewSet(
 			github.New,
-			wire.Bind(new(github.RepositoriesService), new(*github.RepositoriesServiceImpl)),
-			wire.Bind(new(updateaqua.RepositoriesService), new(*github.RepositoriesServiceImpl)),
+			wire.Bind(new(download.GitHub), new(*github.GitHub)),
+			wire.Bind(new(updateaqua.RepositoriesService), new(*github.GitHub)),
 		),
 		wire.NewSet(
 			installpackage.New,
@@ -628,7 +628,7 @@ func InitializeUpdateAquaCommandController(ctx context.Context, param *config.Pa
 	return &updateaqua.Controller{}, nil
 }
 
-func InitializeCopyCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) (*cp.Controller, error) {
+func InitializeCopyCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime, opt *github.Option) (*cp.Controller, error) {
 	wire.Build(
 		cp.New,
 		wire.NewSet(
@@ -651,8 +651,8 @@ func InitializeCopyCommandController(ctx context.Context, param *config.Param, h
 		),
 		wire.NewSet(
 			github.New,
-			wire.Bind(new(github.RepositoriesService), new(*github.RepositoriesServiceImpl)),
-			wire.Bind(new(download.GitHubContentAPI), new(*github.RepositoriesServiceImpl)),
+			wire.Bind(new(download.GitHub), new(*github.GitHub)),
+			wire.Bind(new(download.GitHubContentAPI), new(*github.GitHub)),
 		),
 		wire.NewSet(
 			registry.New,
@@ -675,7 +675,7 @@ func InitializeCopyCommandController(ctx context.Context, param *config.Param, h
 		wire.NewSet(
 			osexec.New,
 			wire.Bind(new(installpackage.Executor), new(*osexec.Executor)),
-			wire.Bind(new(cosexec.Executor), new(*osexec.Executor)),
+			wire.Bind(new(cexec.Executor), new(*osexec.Executor)),
 			wire.Bind(new(cosign.Executor), new(*osexec.Executor)),
 			wire.Bind(new(unarchive.Executor), new(*osexec.Executor)),
 			wire.Bind(new(slsa.CommandExecutor), new(*osexec.Executor)),
@@ -768,7 +768,7 @@ func InitializeCopyCommandController(ctx context.Context, param *config.Param, h
 	return &cp.Controller{}, nil
 }
 
-func InitializeUpdateChecksumCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *updatechecksum.Controller {
+func InitializeUpdateChecksumCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime, opt *github.Option) *updatechecksum.Controller {
 	wire.Build(
 		updatechecksum.New,
 		wire.NewSet(
@@ -789,8 +789,8 @@ func InitializeUpdateChecksumCommandController(ctx context.Context, param *confi
 		),
 		wire.NewSet(
 			github.New,
-			wire.Bind(new(github.RepositoriesService), new(*github.RepositoriesServiceImpl)),
-			wire.Bind(new(download.GitHubContentAPI), new(*github.RepositoriesServiceImpl)),
+			wire.Bind(new(download.GitHub), new(*github.GitHub)),
+			wire.Bind(new(download.GitHubContentAPI), new(*github.GitHub)),
 		),
 		wire.NewSet(
 			download.NewGitHubContentFileDownloader,
@@ -827,7 +827,7 @@ func InitializeUpdateChecksumCommandController(ctx context.Context, param *confi
 	return &updatechecksum.Controller{}
 }
 
-func InitializeUpdateCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *update.Controller {
+func InitializeUpdateCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime, opt *github.Option) *update.Controller {
 	wire.Build(
 		update.New,
 		wire.NewSet(
@@ -847,11 +847,11 @@ func InitializeUpdateCommandController(ctx context.Context, param *config.Param,
 		),
 		wire.NewSet(
 			github.New,
-			wire.Bind(new(github.RepositoriesService), new(*github.RepositoriesServiceImpl)),
-			wire.Bind(new(update.RepositoriesService), new(*github.RepositoriesServiceImpl)),
-			wire.Bind(new(download.GitHubContentAPI), new(*github.RepositoriesServiceImpl)),
-			wire.Bind(new(versiongetter.GitHubTagClient), new(*github.RepositoriesServiceImpl)),
-			wire.Bind(new(versiongetter.GitHubReleaseClient), new(*github.RepositoriesServiceImpl)),
+			wire.Bind(new(update.RepositoriesService), new(*github.GitHub)),
+			wire.Bind(new(download.GitHubContentAPI), new(*github.GitHub)),
+			wire.Bind(new(download.GitHub), new(*github.GitHub)),
+			wire.Bind(new(versiongetter.GitHubTagClient), new(*github.GitHub)),
+			wire.Bind(new(versiongetter.GitHubReleaseClient), new(*github.GitHub)),
 		),
 		wire.NewSet(
 			download.NewGitHubContentFileDownloader,
@@ -960,7 +960,7 @@ func InitializeInfoCommandController(ctx context.Context, param *config.Param, r
 	return &info.Controller{}
 }
 
-func InitializeRemoveCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime, target *config.RemoveMode) *remove.Controller {
+func InitializeRemoveCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime, target *config.RemoveMode, opt *github.Option) *remove.Controller {
 	wire.Build(
 		remove.New,
 		wire.NewSet(
@@ -985,8 +985,8 @@ func InitializeRemoveCommandController(ctx context.Context, param *config.Param,
 		),
 		wire.NewSet(
 			github.New,
-			wire.Bind(new(github.RepositoriesService), new(*github.RepositoriesServiceImpl)),
-			wire.Bind(new(download.GitHubContentAPI), new(*github.RepositoriesServiceImpl)),
+			wire.Bind(new(download.GitHub), new(*github.GitHub)),
+			wire.Bind(new(download.GitHubContentAPI), new(*github.GitHub)),
 		),
 		wire.NewSet(
 			cosign.NewVerifier,

--- a/pkg/controller/wire_gen.go
+++ b/pkg/controller/wire_gen.go
@@ -8,9 +8,6 @@ package controller
 
 import (
 	"context"
-	"io"
-	"net/http"
-
 	"github.com/aquaproj/aqua/v2/pkg/cargo"
 	"github.com/aquaproj/aqua/v2/pkg/checksum"
 	"github.com/aquaproj/aqua/v2/pkg/config"
@@ -19,7 +16,7 @@ import (
 	"github.com/aquaproj/aqua/v2/pkg/controller/allowpolicy"
 	"github.com/aquaproj/aqua/v2/pkg/controller/cp"
 	"github.com/aquaproj/aqua/v2/pkg/controller/denypolicy"
-	exec2 "github.com/aquaproj/aqua/v2/pkg/controller/exec"
+	"github.com/aquaproj/aqua/v2/pkg/controller/exec"
 	"github.com/aquaproj/aqua/v2/pkg/controller/generate"
 	"github.com/aquaproj/aqua/v2/pkg/controller/generate-registry"
 	"github.com/aquaproj/aqua/v2/pkg/controller/generate/output"
@@ -50,19 +47,21 @@ import (
 	"github.com/aquaproj/aqua/v2/pkg/versiongetter"
 	"github.com/spf13/afero"
 	"github.com/suzuki-shunsuke/go-osenv/osenv"
+	"io"
+	"net/http"
 )
 
 // Injectors from wire.go:
 
-func InitializeListCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *list.Controller {
+func InitializeListCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime, opt *github.Option) *list.Controller {
 	fs := afero.NewOsFs()
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs, param)
-	repositoriesService := github.New(ctx)
+	gitHub := github.New(ctx, opt)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
-	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(repositoriesService, httpDownloader)
+	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(gitHub, httpDownloader)
 	executor := osexec.New()
-	downloader := download.NewDownloader(repositoriesService, httpDownloader)
+	downloader := download.NewDownloader(gitHub, httpDownloader)
 	verifier := cosign.NewVerifier(executor, fs, downloader, param)
 	executorImpl := slsa.NewExecutor(executor, param)
 	slsaVerifier := slsa.New(downloader, fs, executorImpl)
@@ -71,19 +70,19 @@ func InitializeListCommandController(ctx context.Context, param *config.Param, h
 	return controller
 }
 
-func InitializeGenerateRegistryCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, stdout io.Writer) *genrgst.Controller {
+func InitializeGenerateRegistryCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, stdout io.Writer, opt *github.Option) *genrgst.Controller {
 	fs := afero.NewOsFs()
-	repositoriesService := github.New(ctx)
+	gitHub := github.New(ctx, opt)
 	outputter := output.New(stdout, fs)
 	client := cargo.NewClient(httpClient)
-	controller := genrgst.NewController(fs, repositoriesService, outputter, client)
+	controller := genrgst.NewController(fs, gitHub, outputter, client)
 	return controller
 }
 
-func InitializeInitCommandController(ctx context.Context, param *config.Param) *initcmd.Controller {
-	repositoriesService := github.New(ctx)
+func InitializeInitCommandController(ctx context.Context, param *config.Param, opt *github.Option) *initcmd.Controller {
+	gitHub := github.New(ctx, opt)
 	fs := afero.NewOsFs()
-	controller := initcmd.New(repositoriesService, fs)
+	controller := initcmd.New(gitHub, fs)
 	return controller
 }
 
@@ -93,15 +92,15 @@ func InitializeInitPolicyCommandController(ctx context.Context) *initpolicy.Cont
 	return controller
 }
 
-func InitializeGenerateCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *generate.Controller {
+func InitializeGenerateCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime, opt *github.Option) *generate.Controller {
 	fs := afero.NewOsFs()
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs, param)
-	repositoriesService := github.New(ctx)
+	gitHub := github.New(ctx, opt)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
-	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(repositoriesService, httpDownloader)
+	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(gitHub, httpDownloader)
 	executor := osexec.New()
-	downloader := download.NewDownloader(repositoriesService, httpDownloader)
+	downloader := download.NewDownloader(gitHub, httpDownloader)
 	verifier := cosign.NewVerifier(executor, fs, downloader, param)
 	executorImpl := slsa.NewExecutor(executor, param)
 	slsaVerifier := slsa.New(downloader, fs, executorImpl)
@@ -109,29 +108,29 @@ func InitializeGenerateCommandController(ctx context.Context, param *config.Para
 	fuzzyfinderFinder := fuzzyfinder.New()
 	client := cargo.NewClient(httpClient)
 	cargoVersionGetter := versiongetter.NewCargo(client)
-	gitHubTagVersionGetter := versiongetter.NewGitHubTag(repositoriesService)
-	gitHubReleaseVersionGetter := versiongetter.NewGitHubRelease(repositoriesService)
+	gitHubTagVersionGetter := versiongetter.NewGitHubTag(gitHub)
+	gitHubReleaseVersionGetter := versiongetter.NewGitHubRelease(gitHub)
 	generalVersionGetter := versiongetter.NewGeneralVersionGetter(cargoVersionGetter, gitHubTagVersionGetter, gitHubReleaseVersionGetter)
 	fuzzyGetter := versiongetter.NewFuzzy(fuzzyfinderFinder, generalVersionGetter)
-	controller := generate.New(configFinder, configReader, installer, repositoriesService, fs, fuzzyfinderFinder, fuzzyGetter)
+	controller := generate.New(configFinder, configReader, installer, gitHub, fs, fuzzyfinderFinder, fuzzyGetter)
 	return controller
 }
 
-func InitializeInstallCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) (*install.Controller, error) {
+func InitializeInstallCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime, opt *github.Option) (*install.Controller, error) {
 	fs := afero.NewOsFs()
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs, param)
-	repositoriesService := github.New(ctx)
+	gitHub := github.New(ctx, opt)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
-	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(repositoriesService, httpDownloader)
+	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(gitHub, httpDownloader)
 	executor := osexec.New()
-	downloader := download.NewDownloader(repositoriesService, httpDownloader)
+	downloader := download.NewDownloader(gitHub, httpDownloader)
 	verifier := cosign.NewVerifier(executor, fs, downloader, param)
 	executorImpl := slsa.NewExecutor(executor, param)
 	slsaVerifier := slsa.New(downloader, fs, executorImpl)
 	installer := registry.New(param, gitHubContentFileDownloader, fs, rt, verifier, slsaVerifier)
 	linker := link.New()
-	checksumDownloaderImpl := download.NewChecksumDownloader(repositoriesService, rt, httpDownloader)
+	checksumDownloaderImpl := download.NewChecksumDownloader(gitHub, rt, httpDownloader)
 	calculator := checksum.NewCalculator()
 	unarchiver := unarchive.New(executor, fs)
 	minisignExecutorImpl, err := minisign.NewExecutor(executor, param)
@@ -156,15 +155,15 @@ func InitializeInstallCommandController(ctx context.Context, param *config.Param
 	return controller, nil
 }
 
-func InitializeWhichCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *which.Controller {
+func InitializeWhichCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime, opt *github.Option) *which.Controller {
 	fs := afero.NewOsFs()
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs, param)
-	repositoriesService := github.New(ctx)
+	gitHub := github.New(ctx, opt)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
-	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(repositoriesService, httpDownloader)
+	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(gitHub, httpDownloader)
 	executor := osexec.New()
-	downloader := download.NewDownloader(repositoriesService, httpDownloader)
+	downloader := download.NewDownloader(gitHub, httpDownloader)
 	verifier := cosign.NewVerifier(executor, fs, downloader, param)
 	executorImpl := slsa.NewExecutor(executor, param)
 	slsaVerifier := slsa.New(downloader, fs, executorImpl)
@@ -175,13 +174,13 @@ func InitializeWhichCommandController(ctx context.Context, param *config.Param, 
 	return controller
 }
 
-func InitializeExecCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) (*exec2.Controller, error) {
-	repositoriesService := github.New(ctx)
+func InitializeExecCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime, opt *github.Option) (*exec.Controller, error) {
+	gitHub := github.New(ctx, opt)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
-	downloader := download.NewDownloader(repositoriesService, httpDownloader)
+	downloader := download.NewDownloader(gitHub, httpDownloader)
 	fs := afero.NewOsFs()
 	linker := link.New()
-	checksumDownloaderImpl := download.NewChecksumDownloader(repositoriesService, rt, httpDownloader)
+	checksumDownloaderImpl := download.NewChecksumDownloader(gitHub, rt, httpDownloader)
 	calculator := checksum.NewCalculator()
 	executor := osexec.New()
 	unarchiver := unarchive.New(executor, fs)
@@ -204,7 +203,7 @@ func InitializeExecCommandController(ctx context.Context, param *config.Param, h
 	installer := installpackage.New(param, downloader, rt, fs, linker, checksumDownloaderImpl, calculator, unarchiver, verifier, slsaVerifier, minisignVerifier, ghattestationVerifier, goInstallInstallerImpl, goBuildInstallerImpl, cargoPackageInstallerImpl)
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs, param)
-	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(repositoriesService, httpDownloader)
+	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(gitHub, httpDownloader)
 	registryInstaller := registry.New(param, gitHubContentFileDownloader, fs, rt, verifier, slsaVerifier)
 	osEnv := osenv.New()
 	controller := which.New(param, configFinder, configReader, registryInstaller, rt, osEnv, fs, linker)
@@ -212,17 +211,17 @@ func InitializeExecCommandController(ctx context.Context, param *config.Param, h
 	configFinderImpl := policy.NewConfigFinder(fs)
 	configReaderImpl := policy.NewConfigReader(fs)
 	policyReader := policy.NewReader(fs, validatorImpl, configFinderImpl, configReaderImpl)
-	execController := exec2.New(installer, controller, executor, osEnv, fs, policyReader)
+	execController := exec.New(installer, controller, executor, osEnv, fs, policyReader)
 	return execController, nil
 }
 
-func InitializeUpdateAquaCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) (*updateaqua.Controller, error) {
+func InitializeUpdateAquaCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime, opt *github.Option) (*updateaqua.Controller, error) {
 	fs := afero.NewOsFs()
-	repositoriesService := github.New(ctx)
+	gitHub := github.New(ctx, opt)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
-	downloader := download.NewDownloader(repositoriesService, httpDownloader)
+	downloader := download.NewDownloader(gitHub, httpDownloader)
 	linker := link.New()
-	checksumDownloaderImpl := download.NewChecksumDownloader(repositoriesService, rt, httpDownloader)
+	checksumDownloaderImpl := download.NewChecksumDownloader(gitHub, rt, httpDownloader)
 	calculator := checksum.NewCalculator()
 	executor := osexec.New()
 	unarchiver := unarchive.New(executor, fs)
@@ -243,17 +242,17 @@ func InitializeUpdateAquaCommandController(ctx context.Context, param *config.Pa
 	goBuildInstallerImpl := installpackage.NewGoBuildInstallerImpl(executor)
 	cargoPackageInstallerImpl := installpackage.NewCargoPackageInstallerImpl(executor, fs)
 	installer := installpackage.New(param, downloader, rt, fs, linker, checksumDownloaderImpl, calculator, unarchiver, verifier, slsaVerifier, minisignVerifier, ghattestationVerifier, goInstallInstallerImpl, goBuildInstallerImpl, cargoPackageInstallerImpl)
-	controller := updateaqua.New(param, fs, rt, repositoriesService, installer)
+	controller := updateaqua.New(param, fs, rt, gitHub, installer)
 	return controller, nil
 }
 
-func InitializeCopyCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) (*cp.Controller, error) {
-	repositoriesService := github.New(ctx)
+func InitializeCopyCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime, opt *github.Option) (*cp.Controller, error) {
+	gitHub := github.New(ctx, opt)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
-	downloader := download.NewDownloader(repositoriesService, httpDownloader)
+	downloader := download.NewDownloader(gitHub, httpDownloader)
 	fs := afero.NewOsFs()
 	linker := link.New()
-	checksumDownloaderImpl := download.NewChecksumDownloader(repositoriesService, rt, httpDownloader)
+	checksumDownloaderImpl := download.NewChecksumDownloader(gitHub, rt, httpDownloader)
 	calculator := checksum.NewCalculator()
 	executor := osexec.New()
 	unarchiver := unarchive.New(executor, fs)
@@ -276,7 +275,7 @@ func InitializeCopyCommandController(ctx context.Context, param *config.Param, h
 	installer := installpackage.New(param, downloader, rt, fs, linker, checksumDownloaderImpl, calculator, unarchiver, verifier, slsaVerifier, minisignVerifier, ghattestationVerifier, goInstallInstallerImpl, goBuildInstallerImpl, cargoPackageInstallerImpl)
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs, param)
-	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(repositoriesService, httpDownloader)
+	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(gitHub, httpDownloader)
 	registryInstaller := registry.New(param, gitHubContentFileDownloader, fs, rt, verifier, slsaVerifier)
 	osEnv := osenv.New()
 	controller := which.New(param, configFinder, configReader, registryInstaller, rt, osEnv, fs, linker)
@@ -289,33 +288,33 @@ func InitializeCopyCommandController(ctx context.Context, param *config.Param, h
 	return cpController, nil
 }
 
-func InitializeUpdateChecksumCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *updatechecksum.Controller {
+func InitializeUpdateChecksumCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime, opt *github.Option) *updatechecksum.Controller {
 	fs := afero.NewOsFs()
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs, param)
-	repositoriesService := github.New(ctx)
+	gitHub := github.New(ctx, opt)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
-	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(repositoriesService, httpDownloader)
+	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(gitHub, httpDownloader)
 	executor := osexec.New()
-	downloader := download.NewDownloader(repositoriesService, httpDownloader)
+	downloader := download.NewDownloader(gitHub, httpDownloader)
 	verifier := cosign.NewVerifier(executor, fs, downloader, param)
 	executorImpl := slsa.NewExecutor(executor, param)
 	slsaVerifier := slsa.New(downloader, fs, executorImpl)
 	installer := registry.New(param, gitHubContentFileDownloader, fs, rt, verifier, slsaVerifier)
-	checksumDownloaderImpl := download.NewChecksumDownloader(repositoriesService, rt, httpDownloader)
+	checksumDownloaderImpl := download.NewChecksumDownloader(gitHub, rt, httpDownloader)
 	controller := updatechecksum.New(param, configFinder, configReader, installer, fs, rt, checksumDownloaderImpl, downloader, gitHubContentFileDownloader)
 	return controller
 }
 
-func InitializeUpdateCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *update.Controller {
-	repositoriesService := github.New(ctx)
+func InitializeUpdateCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime, opt *github.Option) *update.Controller {
+	gitHub := github.New(ctx, opt)
 	fs := afero.NewOsFs()
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs, param)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
-	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(repositoriesService, httpDownloader)
+	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(gitHub, httpDownloader)
 	executor := osexec.New()
-	downloader := download.NewDownloader(repositoriesService, httpDownloader)
+	downloader := download.NewDownloader(gitHub, httpDownloader)
 	verifier := cosign.NewVerifier(executor, fs, downloader, param)
 	executorImpl := slsa.NewExecutor(executor, param)
 	slsaVerifier := slsa.New(downloader, fs, executorImpl)
@@ -323,14 +322,14 @@ func InitializeUpdateCommandController(ctx context.Context, param *config.Param,
 	fuzzyfinderFinder := fuzzyfinder.New()
 	client := cargo.NewClient(httpClient)
 	cargoVersionGetter := versiongetter.NewCargo(client)
-	gitHubTagVersionGetter := versiongetter.NewGitHubTag(repositoriesService)
-	gitHubReleaseVersionGetter := versiongetter.NewGitHubRelease(repositoriesService)
+	gitHubTagVersionGetter := versiongetter.NewGitHubTag(gitHub)
+	gitHubReleaseVersionGetter := versiongetter.NewGitHubRelease(gitHub)
 	generalVersionGetter := versiongetter.NewGeneralVersionGetter(cargoVersionGetter, gitHubTagVersionGetter, gitHubReleaseVersionGetter)
 	fuzzyGetter := versiongetter.NewFuzzy(fuzzyfinderFinder, generalVersionGetter)
 	osEnv := osenv.New()
 	linker := link.New()
 	controller := which.New(param, configFinder, configReader, installer, rt, osEnv, fs, linker)
-	updateController := update.New(param, repositoriesService, configFinder, configReader, installer, fs, rt, fuzzyGetter, fuzzyfinderFinder, controller)
+	updateController := update.New(param, gitHub, configFinder, configReader, installer, fs, rt, fuzzyGetter, fuzzyfinderFinder, controller)
 	return updateController
 }
 
@@ -357,15 +356,15 @@ func InitializeInfoCommandController(ctx context.Context, param *config.Param, r
 	return controller
 }
 
-func InitializeRemoveCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime, target *config.RemoveMode) *remove.Controller {
+func InitializeRemoveCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime, target *config.RemoveMode, opt *github.Option) *remove.Controller {
 	fs := afero.NewOsFs()
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs, param)
-	repositoriesService := github.New(ctx)
+	gitHub := github.New(ctx, opt)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
-	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(repositoriesService, httpDownloader)
+	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(gitHub, httpDownloader)
 	executor := osexec.New()
-	downloader := download.NewDownloader(repositoriesService, httpDownloader)
+	downloader := download.NewDownloader(gitHub, httpDownloader)
 	verifier := cosign.NewVerifier(executor, fs, downloader, param)
 	executorImpl := slsa.NewExecutor(executor, param)
 	slsaVerifier := slsa.New(downloader, fs, executorImpl)

--- a/pkg/download/checksum.go
+++ b/pkg/download/checksum.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aquaproj/aqua/v2/pkg/config"
 	"github.com/aquaproj/aqua/v2/pkg/domain"
-	"github.com/aquaproj/aqua/v2/pkg/github"
 	"github.com/aquaproj/aqua/v2/pkg/runtime"
 	"github.com/sirupsen/logrus"
 	"github.com/suzuki-shunsuke/logrus-error/logerr"
@@ -17,13 +16,13 @@ import (
 var errUnknownChecksumFileType = errors.New("unknown checksum type")
 
 type ChecksumDownloaderImpl struct {
-	github    github.RepositoriesService
+	github    GitHub
 	runtime   *runtime.Runtime
 	http      HTTPDownloader
 	ghRelease domain.GitHubReleaseDownloader
 }
 
-func NewChecksumDownloader(gh github.RepositoriesService, rt *runtime.Runtime, httpDownloader HTTPDownloader) *ChecksumDownloaderImpl {
+func NewChecksumDownloader(gh GitHub, rt *runtime.Runtime, httpDownloader HTTPDownloader) *ChecksumDownloaderImpl {
 	return &ChecksumDownloaderImpl{
 		github:    gh,
 		runtime:   rt,

--- a/pkg/download/github_archive.go
+++ b/pkg/download/github_archive.go
@@ -6,9 +6,10 @@ import (
 	"io"
 
 	"github.com/aquaproj/aqua/v2/pkg/github"
+	"github.com/sirupsen/logrus"
 )
 
-func (dl *Downloader) getReadCloserFromGitHubArchive(ctx context.Context, file *File) (io.ReadCloser, int64, error) {
+func (dl *Downloader) getReadCloserFromGitHubArchive(ctx context.Context, logE *logrus.Entry, file *File) (io.ReadCloser, int64, error) {
 	if rc, length, err := dl.http.Download(ctx, fmt.Sprintf("https://github.com/%s/%s/archive/refs/tags/%s.tar.gz", file.RepoOwner, file.RepoName, file.Version)); err == nil {
 		return rc, length, nil
 	}
@@ -16,7 +17,7 @@ func (dl *Downloader) getReadCloserFromGitHubArchive(ctx context.Context, file *
 	if rc, length, err := dl.http.Download(ctx, fmt.Sprintf("https://github.com/%s/%s/archive/%s.tar.gz", file.RepoOwner, file.RepoName, file.Version)); err == nil {
 		return rc, length, nil
 	}
-	u, _, err := dl.github.GetArchiveLink(ctx, file.RepoOwner, file.RepoName, github.Tarball, &github.RepositoryContentGetOptions{
+	u, _, err := dl.github.GetArchiveLink(ctx, logE, file.RepoOwner, file.RepoName, github.Tarball, &github.RepositoryContentGetOptions{
 		Ref: file.Version,
 	}, 2) //nolint:mnd
 	if err != nil {

--- a/pkg/download/github_content.go
+++ b/pkg/download/github_content.go
@@ -17,7 +17,7 @@ type GitHubContentFileDownloader struct {
 }
 
 type GitHubContentAPI interface {
-	DownloadContents(ctx context.Context, owner, repo, filepath string, opts *github.RepositoryContentGetOptions) (io.ReadCloser, *github.Response, error)
+	DownloadContents(ctx context.Context, logE *logrus.Entry, owner, repo, filepath string, opts *github.RepositoryContentGetOptions) (io.ReadCloser, *github.Response, error)
 }
 
 func NewGitHubContentFileDownloader(gh GitHubContentAPI, httpDL HTTPDownloader) *GitHubContentFileDownloader {
@@ -27,7 +27,7 @@ func NewGitHubContentFileDownloader(gh GitHubContentAPI, httpDL HTTPDownloader) 
 	}
 }
 
-func (dl *GitHubContentFileDownloader) DownloadGitHubContentFile(ctx context.Context, _ *logrus.Entry, param *domain.GitHubContentFileParam) (*domain.GitHubContentFile, error) {
+func (dl *GitHubContentFileDownloader) DownloadGitHubContentFile(ctx context.Context, logE *logrus.Entry, param *domain.GitHubContentFileParam) (*domain.GitHubContentFile, error) {
 	if !param.Private {
 		// https://github.com/aquaproj/aqua/issues/391
 		body, _, err := dl.http.Download(ctx, fmt.Sprintf(
@@ -44,7 +44,7 @@ func (dl *GitHubContentFileDownloader) DownloadGitHubContentFile(ctx context.Con
 		}
 	}
 
-	file, resp, err := dl.github.DownloadContents(ctx, param.RepoOwner, param.RepoName, param.Path, &github.RepositoryContentGetOptions{
+	file, resp, err := dl.github.DownloadContents(ctx, logE, param.RepoOwner, param.RepoName, param.Path, &github.RepositoryContentGetOptions{
 		Ref: param.Ref,
 	})
 	if err != nil {

--- a/pkg/download/github_content_test.go
+++ b/pkg/download/github_content_test.go
@@ -18,7 +18,7 @@ func TestGitHubContentFileDownloader_DownloadGitHubContentFile(t *testing.T) { /
 	data := []struct {
 		name       string
 		param      *domain.GitHubContentFileParam
-		github     github.RepositoriesService
+		github     download.GitHub
 		httpClient *http.Client
 		isErr      bool
 		exp        string

--- a/pkg/download/github_release.go
+++ b/pkg/download/github_release.go
@@ -17,8 +17,8 @@ type GitHubReleaseDownloader struct {
 }
 
 type GitHubReleaseAPI interface {
-	GetReleaseByTag(ctx context.Context, owner, repoName, version string) (*github.RepositoryRelease, *github.Response, error)
-	DownloadReleaseAsset(ctx context.Context, owner, repoName string, assetID int64, httpClient *http.Client) (io.ReadCloser, string, error)
+	GetReleaseByTag(ctx context.Context, logE *logrus.Entry, owner, repoName, version string) (*github.RepositoryRelease, *github.Response, error)
+	DownloadReleaseAsset(ctx context.Context, logE *logrus.Entry, owner, repoName string, assetID int64, httpClient *http.Client) (io.ReadCloser, string, error)
 }
 
 func NewGitHubReleaseDownloader(gh GitHubReleaseAPI, httpDL HTTPDownloader) *GitHubReleaseDownloader {
@@ -52,7 +52,7 @@ func (dl *GitHubReleaseDownloader) DownloadGitHubRelease(ctx context.Context, lo
 		}).Debug("failed to download an asset from GitHub Release without GitHub API. Try again with GitHub API")
 	}
 
-	release, _, err := dl.github.GetReleaseByTag(ctx, param.RepoOwner, param.RepoName, param.Version)
+	release, _, err := dl.github.GetReleaseByTag(ctx, logE, param.RepoOwner, param.RepoName, param.Version)
 	if err != nil {
 		return nil, 0, fmt.Errorf("get the GitHub Release by Tag: %w", err)
 	}
@@ -60,7 +60,7 @@ func (dl *GitHubReleaseDownloader) DownloadGitHubRelease(ctx context.Context, lo
 	if err != nil {
 		return nil, 0, err
 	}
-	body, redirectURL, err := dl.github.DownloadReleaseAsset(ctx, param.RepoOwner, param.RepoName, assetID, http.DefaultClient)
+	body, redirectURL, err := dl.github.DownloadReleaseAsset(ctx, logE, param.RepoOwner, param.RepoName, assetID, http.DefaultClient)
 	if err != nil {
 		return nil, 0, fmt.Errorf("download the release asset (asset id: %d): %w", assetID, err)
 	}

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -33,9 +33,10 @@ type Option struct {
 }
 
 func New(ctx context.Context, opt *Option) *GitHub {
-	if opt == nil || !opt.Keyring {
+	token := getGitHubToken()
+	if opt == nil || !opt.Keyring || token != "" {
 		return &GitHub{
-			repo:  github.NewClient(getHTTPClientForGitHub(ctx, getGitHubToken())).Repositories,
+			repo:  github.NewClient(getHTTPClientForGitHub(ctx, token)).Repositories,
 			mutex: &sync.RWMutex{},
 		}
 	}

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/google/go-github/v66/github"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 )
 
@@ -26,8 +27,17 @@ type (
 
 const Tarball = github.Tarball
 
-func New(ctx context.Context) *RepositoriesServiceImpl {
-	return github.NewClient(getHTTPClientForGitHub(ctx, getGitHubToken())).Repositories
+type Option struct {
+	Keyring bool
+}
+
+func New(ctx context.Context, opt *Option) *GitHub {
+	if opt == nil || !opt.Keyring {
+		return &GitHub{
+			repo: github.NewClient(getHTTPClientForGitHub(ctx, getGitHubToken())).Repositories,
+		}
+	}
+	return &GitHub{}
 }
 
 type RepositoriesService interface {
@@ -35,6 +45,11 @@ type RepositoriesService interface {
 	GetReleaseByTag(ctx context.Context, owner, repoName, version string) (*github.RepositoryRelease, *github.Response, error)
 	DownloadReleaseAsset(ctx context.Context, owner, repoName string, assetID int64, httpClient *http.Client) (io.ReadCloser, string, error)
 	DownloadContents(ctx context.Context, owner, repo, filepath string, opts *github.RepositoryContentGetOptions) (io.ReadCloser, *github.Response, error)
+	GetLatestRelease(ctx context.Context, repoOwner, repoName string) (*github.RepositoryRelease, *github.Response, error)
+	ListReleases(ctx context.Context, owner, repo string, opts *github.ListOptions) ([]*github.RepositoryRelease, *github.Response, error)
+	ListTags(ctx context.Context, owner string, repo string, opts *github.ListOptions) ([]*github.RepositoryTag, *github.Response, error)
+	Get(ctx context.Context, owner, repo string) (*github.Repository, *github.Response, error)
+	ListReleaseAssets(ctx context.Context, owner, repo string, id int64, opts *github.ListOptions) ([]*github.ReleaseAsset, *github.Response, error)
 }
 
 func getGitHubToken() string {
@@ -51,4 +66,65 @@ func getHTTPClientForGitHub(ctx context.Context, token string) *http.Client {
 	return oauth2.NewClient(ctx, oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: token},
 	))
+}
+
+type GitHub struct {
+	repo RepositoriesService
+}
+
+func (g *GitHub) init(ctx context.Context, logE *logrus.Entry) {
+	if g.repo != nil {
+		return
+	}
+	token, err := getTokenFromKeyring()
+	if err != nil {
+		logE.WithError(err).Warn("get a GitHub Access token from keyring")
+		g.repo = github.NewClient(http.DefaultClient).Repositories
+	}
+	g.repo = github.NewClient(getHTTPClientForGitHub(ctx, token)).Repositories
+}
+
+func (g *GitHub) GetArchiveLink(ctx context.Context, logE *logrus.Entry, owner, repo string, archiveformat github.ArchiveFormat, opts *github.RepositoryContentGetOptions, maxRedirects int) (*url.URL, *github.Response, error) {
+	g.init(ctx, logE)
+	return g.repo.GetArchiveLink(ctx, owner, repo, archiveformat, opts, maxRedirects)
+}
+
+func (g *GitHub) GetReleaseByTag(ctx context.Context, logE *logrus.Entry, owner, repoName, version string) (*github.RepositoryRelease, *github.Response, error) {
+	g.init(ctx, logE)
+	return g.repo.GetReleaseByTag(ctx, owner, repoName, version)
+}
+
+func (g *GitHub) DownloadReleaseAsset(ctx context.Context, logE *logrus.Entry, owner, repoName string, assetID int64, httpClient *http.Client) (io.ReadCloser, string, error) {
+	g.init(ctx, logE)
+	return g.repo.DownloadReleaseAsset(ctx, owner, repoName, assetID, httpClient)
+}
+
+func (g *GitHub) DownloadContents(ctx context.Context, logE *logrus.Entry, owner, repo, filepath string, opts *github.RepositoryContentGetOptions) (io.ReadCloser, *github.Response, error) {
+	g.init(ctx, logE)
+	return g.repo.DownloadContents(ctx, owner, repo, filepath, opts)
+}
+
+func (g *GitHub) GetLatestRelease(ctx context.Context, logE *logrus.Entry, repoOwner, repoName string) (*github.RepositoryRelease, *github.Response, error) {
+	g.init(ctx, logE)
+	return g.repo.GetLatestRelease(ctx, repoOwner, repoName)
+}
+
+func (g *GitHub) ListReleases(ctx context.Context, logE *logrus.Entry, owner, repo string, opts *github.ListOptions) ([]*github.RepositoryRelease, *github.Response, error) {
+	g.init(ctx, logE)
+	return g.repo.ListReleases(ctx, owner, repo, opts)
+}
+
+func (g *GitHub) ListTags(ctx context.Context, logE *logrus.Entry, owner string, repo string, opts *github.ListOptions) ([]*github.RepositoryTag, *github.Response, error) {
+	g.init(ctx, logE)
+	return g.repo.ListTags(ctx, owner, repo, opts)
+}
+
+func (g *GitHub) Get(ctx context.Context, logE *logrus.Entry, owner, repo string) (*github.Repository, *github.Response, error) {
+	g.init(ctx, logE)
+	return g.repo.Get(ctx, owner, repo)
+}
+
+func (g *GitHub) ListReleaseAssets(ctx context.Context, logE *logrus.Entry, owner, repo string, id int64, opts *github.ListOptions) ([]*github.ReleaseAsset, *github.Response, error) {
+	g.init(ctx, logE)
+	return g.repo.ListReleaseAssets(ctx, owner, repo, id, opts)
 }

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -95,45 +95,45 @@ func (g *GitHub) init(ctx context.Context, logE *logrus.Entry) {
 
 func (g *GitHub) GetArchiveLink(ctx context.Context, logE *logrus.Entry, owner, repo string, archiveformat github.ArchiveFormat, opts *github.RepositoryContentGetOptions, maxRedirects int) (*url.URL, *github.Response, error) {
 	g.init(ctx, logE)
-	return g.repo.GetArchiveLink(ctx, owner, repo, archiveformat, opts, maxRedirects)
+	return g.repo.GetArchiveLink(ctx, owner, repo, archiveformat, opts, maxRedirects) //nolint:wrapcheck
 }
 
 func (g *GitHub) GetReleaseByTag(ctx context.Context, logE *logrus.Entry, owner, repoName, version string) (*github.RepositoryRelease, *github.Response, error) {
 	g.init(ctx, logE)
-	return g.repo.GetReleaseByTag(ctx, owner, repoName, version)
+	return g.repo.GetReleaseByTag(ctx, owner, repoName, version) //nolint:wrapcheck
 }
 
 func (g *GitHub) DownloadReleaseAsset(ctx context.Context, logE *logrus.Entry, owner, repoName string, assetID int64, httpClient *http.Client) (io.ReadCloser, string, error) {
 	g.init(ctx, logE)
-	return g.repo.DownloadReleaseAsset(ctx, owner, repoName, assetID, httpClient)
+	return g.repo.DownloadReleaseAsset(ctx, owner, repoName, assetID, httpClient) //nolint:wrapcheck
 }
 
 func (g *GitHub) DownloadContents(ctx context.Context, logE *logrus.Entry, owner, repo, filepath string, opts *github.RepositoryContentGetOptions) (io.ReadCloser, *github.Response, error) {
 	g.init(ctx, logE)
-	return g.repo.DownloadContents(ctx, owner, repo, filepath, opts)
+	return g.repo.DownloadContents(ctx, owner, repo, filepath, opts) //nolint:wrapcheck
 }
 
 func (g *GitHub) GetLatestRelease(ctx context.Context, logE *logrus.Entry, repoOwner, repoName string) (*github.RepositoryRelease, *github.Response, error) {
 	g.init(ctx, logE)
-	return g.repo.GetLatestRelease(ctx, repoOwner, repoName)
+	return g.repo.GetLatestRelease(ctx, repoOwner, repoName) //nolint:wrapcheck
 }
 
 func (g *GitHub) ListReleases(ctx context.Context, logE *logrus.Entry, owner, repo string, opts *github.ListOptions) ([]*github.RepositoryRelease, *github.Response, error) {
 	g.init(ctx, logE)
-	return g.repo.ListReleases(ctx, owner, repo, opts)
+	return g.repo.ListReleases(ctx, owner, repo, opts) //nolint:wrapcheck
 }
 
 func (g *GitHub) ListTags(ctx context.Context, logE *logrus.Entry, owner string, repo string, opts *github.ListOptions) ([]*github.RepositoryTag, *github.Response, error) {
 	g.init(ctx, logE)
-	return g.repo.ListTags(ctx, owner, repo, opts)
+	return g.repo.ListTags(ctx, owner, repo, opts) //nolint:wrapcheck
 }
 
 func (g *GitHub) Get(ctx context.Context, logE *logrus.Entry, owner, repo string) (*github.Repository, *github.Response, error) {
 	g.init(ctx, logE)
-	return g.repo.Get(ctx, owner, repo)
+	return g.repo.Get(ctx, owner, repo) //nolint:wrapcheck
 }
 
 func (g *GitHub) ListReleaseAssets(ctx context.Context, logE *logrus.Entry, owner, repo string, id int64, opts *github.ListOptions) ([]*github.ReleaseAsset, *github.Response, error) {
 	g.init(ctx, logE)
-	return g.repo.ListReleaseAssets(ctx, owner, repo, id, opts)
+	return g.repo.ListReleaseAssets(ctx, owner, repo, id, opts) //nolint:wrapcheck
 }

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestNew(t *testing.T) {
 	t.Parallel()
-	if client := github.New(context.Background()); client == nil {
+	if client := github.New(context.Background(), nil); client == nil {
 		t.Fatal("client must not be nil")
 	}
 }

--- a/pkg/github/keyring.go
+++ b/pkg/github/keyring.go
@@ -19,7 +19,7 @@ func getTokenFromKeyring() (string, error) {
 	return s, nil
 }
 
-func setTokenInKeyring(token string) error {
+func SetTokenInKeyring(token string) error {
 	if err := keyring.Set(keyService, keyName, token); err != nil {
 		return fmt.Errorf("set a GitHub Access token in keyring: %w", err)
 	}

--- a/pkg/github/keyring.go
+++ b/pkg/github/keyring.go
@@ -1,0 +1,27 @@
+package github
+
+import (
+	"fmt"
+
+	"github.com/zalando/go-keyring"
+)
+
+const (
+	keyService = "aquaproj.github.io"
+	keyName    = "GITHUB_TOKEN"
+)
+
+func getTokenFromKeyring() (string, error) {
+	s, err := keyring.Get(keyService, keyName)
+	if err != nil {
+		return "", fmt.Errorf("get a GitHub Access token from keyring: %w", err)
+	}
+	return s, nil
+}
+
+func setTokenInKeyring(token string) error {
+	if err := keyring.Set(keyService, keyName, token); err != nil {
+		return fmt.Errorf("set a GitHub Access token in keyring: %w", err)
+	}
+	return nil
+}

--- a/pkg/github/mock.go
+++ b/pkg/github/mock.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/google/go-github/v66/github"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -31,14 +32,14 @@ type MockRepositoriesService struct {
 	URL      *url.URL
 }
 
-func (m *MockRepositoriesService) GetLatestRelease(ctx context.Context, repoOwner, repoName string) (*github.RepositoryRelease, *github.Response, error) {
+func (m *MockRepositoriesService) GetLatestRelease(ctx context.Context, logE *logrus.Entry, repoOwner, repoName string) (*github.RepositoryRelease, *github.Response, error) {
 	if len(m.Releases) == 0 {
 		return nil, nil, errReleaseNotFound
 	}
 	return m.Releases[0], nil, nil
 }
 
-func (m *MockRepositoriesService) DownloadContents(ctx context.Context, owner, repo, filepath string, opts *github.RepositoryContentGetOptions) (io.ReadCloser, *github.Response, error) {
+func (m *MockRepositoriesService) DownloadContents(ctx context.Context, logE *logrus.Entry, owner, repo, filepath string, opts *github.RepositoryContentGetOptions) (io.ReadCloser, *github.Response, error) {
 	if m.Content == "" {
 		return nil, nil, errContentNotFound
 	}
@@ -49,49 +50,49 @@ func (m *MockRepositoriesService) DownloadContents(ctx context.Context, owner, r
 	}, nil
 }
 
-func (m *MockRepositoriesService) GetReleaseByTag(ctx context.Context, owner, repoName, version string) (*github.RepositoryRelease, *github.Response, error) {
+func (m *MockRepositoriesService) GetReleaseByTag(ctx context.Context, logE *logrus.Entry, owner, repoName, version string) (*github.RepositoryRelease, *github.Response, error) {
 	if len(m.Releases) == 0 {
 		return nil, nil, errReleaseNotFound
 	}
 	return m.Releases[0], nil, nil
 }
 
-func (m *MockRepositoriesService) DownloadReleaseAsset(ctx context.Context, owner, repoName string, assetID int64, httpClient *http.Client) (io.ReadCloser, string, error) {
+func (m *MockRepositoriesService) DownloadReleaseAsset(ctx context.Context, logE *logrus.Entry, owner, repoName string, assetID int64, httpClient *http.Client) (io.ReadCloser, string, error) {
 	if m.Asset == "" {
 		return nil, "", errAssetNotFound
 	}
 	return io.NopCloser(strings.NewReader(m.Asset)), "", nil
 }
 
-func (m *MockRepositoriesService) ListReleases(ctx context.Context, owner, repo string, opts *github.ListOptions) ([]*github.RepositoryRelease, *github.Response, error) {
+func (m *MockRepositoriesService) ListReleases(ctx context.Context, logE *logrus.Entry, owner, repo string, opts *github.ListOptions) ([]*github.RepositoryRelease, *github.Response, error) {
 	if m.Releases == nil {
 		return nil, nil, errReleaseNotFound
 	}
 	return m.Releases, &github.Response{}, nil
 }
 
-func (m *MockRepositoriesService) ListTags(ctx context.Context, owner string, repo string, opts *github.ListOptions) ([]*github.RepositoryTag, *github.Response, error) {
+func (m *MockRepositoriesService) ListTags(ctx context.Context, logE *logrus.Entry, owner string, repo string, opts *github.ListOptions) ([]*github.RepositoryTag, *github.Response, error) {
 	if m.Tags == nil {
 		return nil, nil, errTagNotFound
 	}
 	return m.Tags, &github.Response{}, nil
 }
 
-func (m *MockRepositoriesService) GetArchiveLink(ctx context.Context, owner, repo string, archiveformat github.ArchiveFormat, opts *github.RepositoryContentGetOptions, maxRedirects int) (*url.URL, *github.Response, error) {
+func (m *MockRepositoriesService) GetArchiveLink(ctx context.Context, logE *logrus.Entry, owner, repo string, archiveformat github.ArchiveFormat, opts *github.RepositoryContentGetOptions, maxRedirects int) (*url.URL, *github.Response, error) {
 	if m.URL == nil {
 		return nil, nil, errGetTar
 	}
 	return m.URL, nil, nil
 }
 
-func (m *MockRepositoriesService) Get(ctx context.Context, owner, repo string) (*github.Repository, *github.Response, error) {
+func (m *MockRepositoriesService) Get(ctx context.Context, logE *logrus.Entry, owner, repo string) (*github.Repository, *github.Response, error) {
 	if m.Repo == nil {
 		return nil, nil, errGetRepo
 	}
 	return m.Repo, nil, nil
 }
 
-func (m *MockRepositoriesService) ListReleaseAssets(ctx context.Context, owner, repo string, id int64, opts *github.ListOptions) ([]*github.ReleaseAsset, *github.Response, error) {
+func (m *MockRepositoriesService) ListReleaseAssets(ctx context.Context, logE *logrus.Entry, owner, repo string, id int64, opts *github.ListOptions) ([]*github.ReleaseAsset, *github.Response, error) {
 	if m.Assets == nil {
 		return nil, nil, errListAssets
 	}

--- a/pkg/versiongetter/github_release.go
+++ b/pkg/versiongetter/github_release.go
@@ -25,8 +25,8 @@ func NewGitHubRelease(gh GitHubReleaseClient) *GitHubReleaseVersionGetter {
 }
 
 type GitHubReleaseClient interface {
-	GetLatestRelease(ctx context.Context, repoOwner, repoName string) (*github.RepositoryRelease, *github.Response, error)
-	ListReleases(ctx context.Context, owner, repo string, opts *github.ListOptions) ([]*github.RepositoryRelease, *github.Response, error)
+	GetLatestRelease(ctx context.Context, logE *logrus.Entry, repoOwner, repoName string) (*github.RepositoryRelease, *github.Response, error)
+	ListReleases(ctx context.Context, logE *logrus.Entry, owner, repo string, opts *github.ListOptions) ([]*github.RepositoryRelease, *github.Response, error)
 }
 
 type Release struct {
@@ -100,7 +100,7 @@ func (g *GitHubReleaseVersionGetter) Get(ctx context.Context, logE *logrus.Entry
 		PerPage: 30, //nolint:mnd
 	}
 	for {
-		releases, resp, err := g.gh.ListReleases(ctx, repoOwner, repoName, opt)
+		releases, resp, err := g.gh.ListReleases(ctx, logE, repoOwner, repoName, opt)
 		respToLog = resp
 		if err != nil {
 			return "", fmt.Errorf("list tags: %w", err)
@@ -130,7 +130,7 @@ func (g *GitHubReleaseVersionGetter) List(ctx context.Context, logE *logrus.Entr
 	var items []*fuzzyfinder.Item
 	tags := map[string]struct{}{}
 	for {
-		releases, resp, err := g.gh.ListReleases(ctx, repoOwner, repoName, opt)
+		releases, resp, err := g.gh.ListReleases(ctx, logE, repoOwner, repoName, opt)
 		if err != nil {
 			*logE = *withRateLimitInfo(logE, resp)
 			return nil, fmt.Errorf("list tags: %w", err)

--- a/pkg/versiongetter/github_tag.go
+++ b/pkg/versiongetter/github_tag.go
@@ -21,7 +21,7 @@ func NewGitHubTag(gh GitHubTagClient) *GitHubTagVersionGetter {
 }
 
 type GitHubTagClient interface {
-	ListTags(ctx context.Context, owner string, repo string, opts *github.ListOptions) ([]*github.RepositoryTag, *github.Response, error)
+	ListTags(ctx context.Context, logE *logrus.Entry, owner string, repo string, opts *github.ListOptions) ([]*github.RepositoryTag, *github.Response, error)
 }
 
 func convTag(tag *github.RepositoryTag) *Release {
@@ -49,7 +49,7 @@ func (g *GitHubTagVersionGetter) Get(ctx context.Context, logE *logrus.Entry, pk
 	candidates := []*Release{}
 
 	for {
-		tags, resp, err := g.gh.ListTags(ctx, repoOwner, repoName, opt)
+		tags, resp, err := g.gh.ListTags(ctx, logE, repoOwner, repoName, opt)
 		respToLog = resp
 		if err != nil {
 			return "", fmt.Errorf("list tags: %w", err)
@@ -79,7 +79,7 @@ func (g *GitHubTagVersionGetter) List(ctx context.Context, logE *logrus.Entry, p
 	var versions []string
 	tagNames := map[string]struct{}{}
 	for {
-		tags, resp, err := g.gh.ListTags(ctx, repoOwner, repoName, opt)
+		tags, resp, err := g.gh.ListTags(ctx, logE, repoOwner, repoName, opt)
 		if err != nil {
 			*logE = *withRateLimitInfo(logE, resp)
 			return nil, fmt.Errorf("list tags: %w", err)

--- a/pkg/versiongetter/mock_github_release.go
+++ b/pkg/versiongetter/mock_github_release.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/aquaproj/aqua/v2/pkg/github"
+	"github.com/sirupsen/logrus"
 )
 
 type MockGitHubReleaseClient struct {
@@ -18,7 +19,7 @@ func NewMockGitHubReleaseClient(releases map[string][]*github.RepositoryRelease)
 	}
 }
 
-func (g *MockGitHubReleaseClient) GetLatestRelease(ctx context.Context, repoOwner, repoName string) (*github.RepositoryRelease, *github.Response, error) {
+func (g *MockGitHubReleaseClient) GetLatestRelease(ctx context.Context, _ *logrus.Entry, repoOwner, repoName string) (*github.RepositoryRelease, *github.Response, error) {
 	releases, ok := g.releases[fmt.Sprintf("%s/%s", repoOwner, repoName)]
 	if !ok {
 		return nil, nil, errors.New("repository isn't found")
@@ -26,7 +27,7 @@ func (g *MockGitHubReleaseClient) GetLatestRelease(ctx context.Context, repoOwne
 	return releases[0], &github.Response{}, nil
 }
 
-func (g *MockGitHubReleaseClient) ListReleases(ctx context.Context, owner, repo string, opts *github.ListOptions) ([]*github.RepositoryRelease, *github.Response, error) {
+func (g *MockGitHubReleaseClient) ListReleases(ctx context.Context, _ *logrus.Entry, owner, repo string, opts *github.ListOptions) ([]*github.RepositoryRelease, *github.Response, error) {
 	releases, ok := g.releases[fmt.Sprintf("%s/%s", owner, repo)]
 	if !ok {
 		return nil, nil, errors.New("repository isn't found")

--- a/pkg/versiongetter/mock_github_tag.go
+++ b/pkg/versiongetter/mock_github_tag.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/aquaproj/aqua/v2/pkg/github"
+	"github.com/sirupsen/logrus"
 )
 
 type MockGitHubTagClient struct {
@@ -18,7 +19,7 @@ func NewMockGitHubTagClient(tags map[string][]*github.RepositoryTag) *MockGitHub
 	}
 }
 
-func (g *MockGitHubTagClient) ListTags(ctx context.Context, owner string, repo string, opts *github.ListOptions) ([]*github.RepositoryTag, *github.Response, error) {
+func (g *MockGitHubTagClient) ListTags(ctx context.Context, _ *logrus.Entry, owner string, repo string, opts *github.ListOptions) ([]*github.RepositoryTag, *github.Response, error) {
 	tags, ok := g.tags[fmt.Sprintf("%s/%s", owner, repo)]
 	if !ok {
 		return nil, nil, errors.New("repository is not found")


### PR DESCRIPTION
This pull request adds the feature to get a GitHub Access token from a secret store such as [Windows Credential Manager](https://support.microsoft.com/en-us/windows/accessing-credential-manager-1b5c916a-6a16-889f-8581-fc16e8165ac0), [macOS Keychain](https://en.wikipedia.org/wiki/Keychain_(software)), and [GNOME Keyring](https://wiki.gnome.org/Projects/GnomeKeyring).
You can manage a GitHub Access Token securely.
This feature is powered by the third party library [zalando/go-keyring](https://github.com/zalando/go-keyring).
This feature is disabled by default.
To enable this feature, you have to configure the environment variable `AQUA_ENABLE_KEYRING`.

```sh
export AQUA_ENABLE_KEYRING=true
```

And you have to set a GitHub Access token by `aqua token set` command.

```sh
aqua token set
```

You can also pass a GitHub Access token from stdin.

```sh
echo "$GITHUB_TOKEN" | aqua token set -stdin
```

Then you can use aqua as usual.
When aqua accesses a secret store, you may need to approve the access via prompt.

![image](https://github.com/user-attachments/assets/53892afb-0e99-45fd-a46b-ce9f0b01e1a8)

If the environment variable `GITHUB_TOKEN` or `AQUA_GITHUB_TOKEN` is set, this feature is ignored.
And even if aqua can't get a GitHub Access Token, aqua still works without a GitHub Access Token.

## Performance Test

Access to secret store makes the performance worse, so we implement the lazy load, meaning aqua accesses a secret store only when the access is really necessary.
I confirmed that when aqua didn't access a secret store, the performance didn't get worse.

```console
$ hyperfine -N --warmup 3 '/Users/shunsukesuzuki/go/bin/aqua which mkghtag' '/Users/shunsukesuzuki/.local/share/aquaproj-aqua/bin/aqua which mkghtag'
KEYRING IS ENABLED
Benchmark 1: /Users/shunsukesuzuki/go/bin/aqua which mkghtag
  Time (mean ± σ):      32.5 ms ±   2.5 ms    [User: 32.6 ms, System: 3.5 ms]
  Range (min … max):    30.7 ms …  42.4 ms    75 runs
 
  Warning: The first benchmarking run for this command was significantly slower than the rest (39.8 ms). This could be caused by (filesystem) caches that were not filled until after the first run. You are already using the '--warmup' option which helps to fill these caches before the actual benchmark. You can either try to increase the warmup count further or re-run this benchmark on a quiet system in case it was a random outlier. Alternatively, consider using the '--prepare' option to clear the caches before each timing run.
 
Benchmark 2: /Users/shunsukesuzuki/.local/share/aquaproj-aqua/bin/aqua which mkghtag
  Time (mean ± σ):      32.4 ms ±   2.5 ms    [User: 32.5 ms, System: 3.5 ms]
  Range (min … max):    30.3 ms …  42.8 ms    72 runs
 
  Warning: The first benchmarking run for this command was significantly slower than the rest (41.1 ms). This could be caused by (filesystem) caches that were not filled until after the first run. You are already using the '--warmup' option which helps to fill these caches before the actual benchmark. You can either try to increase the warmup count further or re-run this benchmark on a quiet system in case it was a random outlier. Alternatively, consider using the '--prepare' option to clear the caches before each timing run.
 
Summary
  /Users/shunsukesuzuki/.local/share/aquaproj-aqua/bin/aqua which mkghtag ran
    1.00 ± 0.11 times faster than /Users/shunsukesuzuki/go/bin/aqua which mkghtag
```