### PR TITLE
feat: get versions from Go Proxy

### DIFF
--- a/json-schema/registry.json
+++ b/json-schema/registry.json
@@ -359,6 +359,9 @@
         "path": {
           "type": "string"
         },
+        "go_version_path": {
+          "type": "string"
+        },
         "complete_windows_ext": {
           "type": "boolean"
         },
@@ -481,6 +484,9 @@
           "type": "string"
         },
         "version_prefix": {
+          "type": "string"
+        },
+        "go_version_path": {
           "type": "string"
         },
         "rosetta2": {
@@ -713,6 +719,9 @@
             "raw",
             "zip"
           ]
+        },
+        "go_version_path": {
+          "type": "string"
         },
         "version_filter": {
           "type": "string"

--- a/pkg/config/registry/package_info.go
+++ b/pkg/config/registry/package_info.go
@@ -39,6 +39,7 @@ type PackageInfo struct {
 	Format                     string                      `json:"format,omitempty" jsonschema:"example=tar.gz,example=raw,example=zip,example=dmg" yaml:",omitempty"`
 	VersionFilter              string                      `yaml:"version_filter,omitempty" json:"version_filter,omitempty"`
 	VersionPrefix              string                      `yaml:"version_prefix,omitempty" json:"version_prefix,omitempty"`
+	GoVersionPath              string                      `yaml:"go_version_path,omitempty" json:"go_version_path,omitempty"`
 	Rosetta2                   bool                        `yaml:",omitempty" json:"rosetta2,omitempty"`
 	WindowsARMEmulation        bool                        `yaml:"windows_arm_emulation,omitempty" json:"windows_arm_emulation,omitempty"`
 	NoAsset                    bool                        `yaml:"no_asset,omitempty" json:"no_asset,omitempty"`
@@ -106,6 +107,7 @@ type VersionOverride struct {
 	Path                       string                      `yaml:",omitempty" json:"path,omitempty"`
 	URL                        string                      `yaml:",omitempty" json:"url,omitempty"`
 	Format                     string                      `yaml:",omitempty" json:"format,omitempty" jsonschema:"example=tar.gz,example=raw,example=zip"`
+	GoVersionPath              *string                     `yaml:"go_version_path,omitempty" json:"go_version_path,omitempty"`
 	VersionFilter              *string                     `yaml:"version_filter,omitempty" json:"version_filter,omitempty"`
 	VersionPrefix              *string                     `yaml:"version_prefix,omitempty" json:"version_prefix,omitempty"`
 	VersionSource              string                      `json:"version_source,omitempty" yaml:"version_source,omitempty"`
@@ -140,6 +142,7 @@ type Override struct {
 	Crate                      string                      `json:"crate,omitempty" yaml:",omitempty"`
 	URL                        string                      `yaml:",omitempty" json:"url,omitempty"`
 	Path                       string                      `yaml:",omitempty" json:"path,omitempty"`
+	GoVersionPath              *string                     `yaml:"go_version_path,omitempty" json:"go_version_path,omitempty"`
 	CompleteWindowsExt         *bool                       `json:"complete_windows_ext,omitempty" yaml:"complete_windows_ext,omitempty"`
 	WindowsExt                 string                      `json:"windows_ext,omitempty" yaml:"windows_ext,omitempty"`
 	AppendExt                  *bool                       `json:"append_ext,omitempty" yaml:"append_ext,omitempty"`
@@ -178,6 +181,7 @@ func (p *PackageInfo) Copy() *PackageInfo {
 		SupportedEnvs:              p.SupportedEnvs,
 		VersionFilter:              p.VersionFilter,
 		VersionPrefix:              p.VersionPrefix,
+		GoVersionPath:              p.GoVersionPath,
 		Rosetta2:                   p.Rosetta2,
 		WindowsARMEmulation:        p.WindowsARMEmulation,
 		Aliases:                    p.Aliases,
@@ -205,22 +209,26 @@ func (p *PackageInfo) resetByPkgType(typ string) { //nolint:funlen
 		p.URL = ""
 		p.Path = ""
 		p.Crate = ""
+		p.GoVersionPath = ""
 		p.Cargo = nil
 	case PkgInfoTypeGitHubContent:
 		p.URL = ""
 		p.Asset = ""
 		p.Crate = ""
+		p.GoVersionPath = ""
 		p.Cargo = nil
 	case PkgInfoTypeGitHubArchive:
 		p.URL = ""
 		p.Path = ""
 		p.Asset = ""
 		p.Crate = ""
+		p.GoVersionPath = ""
 		p.Cargo = nil
 		p.Format = ""
 	case PkgInfoTypeHTTP:
 		p.Path = ""
 		p.Asset = ""
+		p.GoVersionPath = ""
 	case PkgInfoTypeGoInstall:
 		p.URL = ""
 		p.Asset = ""
@@ -265,6 +273,7 @@ func (p *PackageInfo) resetByPkgType(typ string) { //nolint:funlen
 		p.Rosetta2 = false
 		p.WindowsARMEmulation = false
 		p.AppendExt = nil
+		p.GoVersionPath = ""
 	}
 }
 
@@ -318,6 +327,9 @@ func (p *PackageInfo) overrideVersion(child *VersionOverride) *PackageInfo { //n
 	}
 	if child.VersionPrefix != nil {
 		pkg.VersionPrefix = *child.VersionPrefix
+	}
+	if child.GoVersionPath != nil {
+		pkg.GoVersionPath = *child.GoVersionPath
 	}
 	if child.Rosetta2 != nil {
 		pkg.Rosetta2 = *child.Rosetta2
@@ -460,6 +472,10 @@ func (p *PackageInfo) OverrideByRuntime(rt *runtime.Runtime) { //nolint:cyclop,f
 
 	if ov.Vars != nil {
 		p.Vars = ov.Vars
+	}
+
+	if ov.GoVersionPath != nil {
+		p.GoVersionPath = *ov.GoVersionPath
 	}
 }
 

--- a/pkg/controller/wire.go
+++ b/pkg/controller/wire.go
@@ -46,6 +46,7 @@ import (
 	"github.com/aquaproj/aqua/v2/pkg/slsa"
 	"github.com/aquaproj/aqua/v2/pkg/unarchive"
 	"github.com/aquaproj/aqua/v2/pkg/versiongetter"
+	"github.com/aquaproj/aqua/v2/pkg/versiongetter/goproxy"
 
 	"github.com/google/wire"
 	"github.com/spf13/afero"
@@ -218,6 +219,11 @@ func InitializeGenerateCommandController(ctx context.Context, param *config.Para
 		versiongetter.NewCargo,
 		versiongetter.NewGitHubRelease,
 		versiongetter.NewGitHubTag,
+		versiongetter.NewGoGetter,
+		wire.NewSet(
+			goproxy.New,
+			wire.Bind(new(versiongetter.GoProxyClient), new(*goproxy.Client)),
+		),
 	)
 	return &generate.Controller{}
 }
@@ -898,9 +904,14 @@ func InitializeUpdateCommandController(ctx context.Context, param *config.Param,
 		versiongetter.NewCargo,
 		versiongetter.NewGitHubRelease,
 		versiongetter.NewGitHubTag,
+		versiongetter.NewGoGetter,
 		wire.NewSet(
 			cargo.NewClient,
 			wire.Bind(new(versiongetter.CargoClient), new(*cargo.Client)),
+		),
+		wire.NewSet(
+			goproxy.New,
+			wire.Bind(new(versiongetter.GoProxyClient), new(*goproxy.Client)),
 		),
 		wire.NewSet(
 			which.New,

--- a/pkg/controller/wire_gen.go
+++ b/pkg/controller/wire_gen.go
@@ -45,6 +45,7 @@ import (
 	"github.com/aquaproj/aqua/v2/pkg/slsa"
 	"github.com/aquaproj/aqua/v2/pkg/unarchive"
 	"github.com/aquaproj/aqua/v2/pkg/versiongetter"
+	"github.com/aquaproj/aqua/v2/pkg/versiongetter/goproxy"
 	"github.com/spf13/afero"
 	"github.com/suzuki-shunsuke/go-osenv/osenv"
 	"io"
@@ -110,7 +111,9 @@ func InitializeGenerateCommandController(ctx context.Context, param *config.Para
 	cargoVersionGetter := versiongetter.NewCargo(client)
 	gitHubTagVersionGetter := versiongetter.NewGitHubTag(repositoriesService)
 	gitHubReleaseVersionGetter := versiongetter.NewGitHubRelease(repositoriesService)
-	generalVersionGetter := versiongetter.NewGeneralVersionGetter(cargoVersionGetter, gitHubTagVersionGetter, gitHubReleaseVersionGetter)
+	goproxyClient := goproxy.New(httpClient)
+	goGetter := versiongetter.NewGoGetter(goproxyClient)
+	generalVersionGetter := versiongetter.NewGeneralVersionGetter(cargoVersionGetter, gitHubTagVersionGetter, gitHubReleaseVersionGetter, goGetter)
 	fuzzyGetter := versiongetter.NewFuzzy(fuzzyfinderFinder, generalVersionGetter)
 	controller := generate.New(configFinder, configReader, installer, repositoriesService, fs, fuzzyfinderFinder, fuzzyGetter)
 	return controller
@@ -324,7 +327,9 @@ func InitializeUpdateCommandController(ctx context.Context, param *config.Param,
 	cargoVersionGetter := versiongetter.NewCargo(client)
 	gitHubTagVersionGetter := versiongetter.NewGitHubTag(repositoriesService)
 	gitHubReleaseVersionGetter := versiongetter.NewGitHubRelease(repositoriesService)
-	generalVersionGetter := versiongetter.NewGeneralVersionGetter(cargoVersionGetter, gitHubTagVersionGetter, gitHubReleaseVersionGetter)
+	goproxyClient := goproxy.New(httpClient)
+	goGetter := versiongetter.NewGoGetter(goproxyClient)
+	generalVersionGetter := versiongetter.NewGeneralVersionGetter(cargoVersionGetter, gitHubTagVersionGetter, gitHubReleaseVersionGetter, goGetter)
 	fuzzyGetter := versiongetter.NewFuzzy(fuzzyfinderFinder, generalVersionGetter)
 	osEnv := osenv.New()
 	linker := link.New()

--- a/pkg/versiongetter/fuzzy_getter.go
+++ b/pkg/versiongetter/fuzzy_getter.go
@@ -31,6 +31,7 @@ type FuzzyFinder interface {
 func (g *FuzzyGetter) Get(ctx context.Context, logE *logrus.Entry, pkg *registry.PackageInfo, currentVersion string, useFinder bool, limit int) string { //nolint:cyclop
 	filters, err := createFilters(pkg)
 	if err != nil {
+		logerr.WithError(logE, err).Warn("create filters")
 		return ""
 	}
 

--- a/pkg/versiongetter/general.go
+++ b/pkg/versiongetter/general.go
@@ -15,13 +15,15 @@ type GeneralVersionGetter struct {
 	cargo     *CargoVersionGetter
 	ghTag     *GitHubTagVersionGetter
 	ghRelease *GitHubReleaseVersionGetter
+	goGetter  *GoGetter
 }
 
-func NewGeneralVersionGetter(cargo *CargoVersionGetter, ghTag *GitHubTagVersionGetter, ghRelease *GitHubReleaseVersionGetter) *GeneralVersionGetter {
+func NewGeneralVersionGetter(cargo *CargoVersionGetter, ghTag *GitHubTagVersionGetter, ghRelease *GitHubReleaseVersionGetter, goGetter *GoGetter) *GeneralVersionGetter {
 	return &GeneralVersionGetter{
 		cargo:     cargo,
 		ghTag:     ghTag,
 		ghRelease: ghRelease,
+		goGetter:  goGetter,
 	}
 }
 
@@ -44,6 +46,9 @@ func (g *GeneralVersionGetter) List(ctx context.Context, logE *logrus.Entry, pkg
 func (g *GeneralVersionGetter) get(pkg *registry.PackageInfo) VersionGetter {
 	if pkg.Type == "cargo" {
 		return g.cargo
+	}
+	if pkg.GoVersionPath != "" {
+		return g.goGetter
 	}
 	if g.ghTag == nil {
 		return nil

--- a/pkg/versiongetter/go.go
+++ b/pkg/versiongetter/go.go
@@ -1,0 +1,58 @@
+package versiongetter
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aquaproj/aqua/v2/pkg/config/registry"
+	"github.com/aquaproj/aqua/v2/pkg/fuzzyfinder"
+	"github.com/hashicorp/go-version"
+	"github.com/sirupsen/logrus"
+)
+
+type GoGetter struct {
+	gc GoProxyClient
+}
+
+func NewGoGetter(gc GoProxyClient) *GoGetter {
+	return &GoGetter{
+		gc: gc,
+	}
+}
+
+type GoProxyClient interface {
+	List(ctx context.Context, path string) ([]string, error)
+}
+
+func (g *GoGetter) Get(ctx context.Context, logE *logrus.Entry, pkg *registry.PackageInfo, filters []*Filter) (string, error) {
+	versions, err := g.gc.List(ctx, pkg.GoVersionPath)
+	if err != nil {
+		return "", fmt.Errorf("list versions: %w", err)
+	}
+	var latest *version.Version
+	for _, vs := range versions {
+		v, err := version.NewSemver(vs)
+		if err != nil {
+			logE.WithError(err).WithField("version", vs).Warn("parse a version")
+			continue
+		}
+		if latest == nil || v.GreaterThan(latest) {
+			latest = v
+		}
+	}
+	return latest.String(), nil
+}
+
+func (g *GoGetter) List(ctx context.Context, logE *logrus.Entry, pkg *registry.PackageInfo, _ []*Filter, _ int) ([]*fuzzyfinder.Item, error) {
+	versions, err := g.gc.List(ctx, pkg.GoVersionPath)
+	if err != nil {
+		return nil, fmt.Errorf("list versions: %w", err)
+	}
+	items := make([]*fuzzyfinder.Item, len(versions))
+	for i, version := range versions {
+		items[i] = &fuzzyfinder.Item{
+			Item: version,
+		}
+	}
+	return items, nil
+}

--- a/pkg/versiongetter/go.go
+++ b/pkg/versiongetter/go.go
@@ -25,7 +25,7 @@ type GoProxyClient interface {
 	List(ctx context.Context, path string) ([]string, error)
 }
 
-func (g *GoGetter) Get(ctx context.Context, logE *logrus.Entry, pkg *registry.PackageInfo, _ []*Filter) (string, error) {
+func (g *GoGetter) Get(ctx context.Context, logE *logrus.Entry, pkg *registry.PackageInfo, _ []*Filter) (string, error) { //nolint:cyclop
 	versions, err := g.gc.List(ctx, pkg.GoVersionPath)
 	if err != nil {
 		return "", fmt.Errorf("list versions: %w", err)

--- a/pkg/versiongetter/go.go
+++ b/pkg/versiongetter/go.go
@@ -25,7 +25,7 @@ type GoProxyClient interface {
 	List(ctx context.Context, path string) ([]string, error)
 }
 
-func (g *GoGetter) Get(ctx context.Context, logE *logrus.Entry, pkg *registry.PackageInfo, filters []*Filter) (string, error) {
+func (g *GoGetter) Get(ctx context.Context, logE *logrus.Entry, pkg *registry.PackageInfo, _ []*Filter) (string, error) {
 	versions, err := g.gc.List(ctx, pkg.GoVersionPath)
 	if err != nil {
 		return "", fmt.Errorf("list versions: %w", err)

--- a/pkg/versiongetter/go.go
+++ b/pkg/versiongetter/go.go
@@ -3,6 +3,7 @@ package versiongetter
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/aquaproj/aqua/v2/pkg/config/registry"
 	"github.com/aquaproj/aqua/v2/pkg/fuzzyfinder"
@@ -44,14 +45,24 @@ func (g *GoGetter) Get(ctx context.Context, logE *logrus.Entry, pkg *registry.Pa
 }
 
 func (g *GoGetter) List(ctx context.Context, logE *logrus.Entry, pkg *registry.PackageInfo, _ []*Filter, _ int) ([]*fuzzyfinder.Item, error) {
-	versions, err := g.gc.List(ctx, pkg.GoVersionPath)
+	vs, err := g.gc.List(ctx, pkg.GoVersionPath)
 	if err != nil {
 		return nil, fmt.Errorf("list versions: %w", err)
 	}
+	versions := make(version.Collection, 0, len(vs))
+	for _, v := range vs {
+		v, err := version.NewSemver(v)
+		if err != nil {
+			logE.WithError(err).WithField("version", vs).Warn("parse a version")
+			continue
+		}
+		versions = append(versions, v)
+	}
+	sort.Sort(sort.Reverse(versions))
 	items := make([]*fuzzyfinder.Item, len(versions))
 	for i, version := range versions {
 		items[i] = &fuzzyfinder.Item{
-			Item: version,
+			Item: version.Original(),
 		}
 	}
 	return items, nil

--- a/pkg/versiongetter/goproxy/client.go
+++ b/pkg/versiongetter/goproxy/client.go
@@ -35,5 +35,9 @@ func (c *Client) List(ctx context.Context, path string) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read a response body: %w", err)
 	}
-	return strings.Split(strings.TrimSpace(string(b)), "\n"), nil
+	s := strings.TrimSpace(string(b))
+	if s == "" {
+		return nil, nil
+	}
+	return strings.Split(s, "\n"), nil
 }

--- a/pkg/versiongetter/goproxy/client.go
+++ b/pkg/versiongetter/goproxy/client.go
@@ -1,0 +1,39 @@
+package goproxy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+type Client struct {
+	client *http.Client
+}
+
+func New(client *http.Client) *Client {
+	return &Client{
+		client: client,
+	}
+}
+
+func (c *Client) List(ctx context.Context, path string) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://proxy.golang.org/%s/@v/list", path), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create a http request: %w", err)
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("send a http request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read a response body: %w", err)
+	}
+	return strings.Split(strings.TrimSpace(string(b)), "\n"), nil
+}


### PR DESCRIPTION
This pull request adds a new field `go_version_path` to registry.

e.g.

```yaml
packages:
  - name: _go/sigsum.org/sigsum-go#cmd/sigsum-key
    type: go_install
    path: sigsum.org/sigsum-go/cmd/sigsum-key
    go_version_path: sigsum.org/sigsum-go
```

If this field is set, `aqua g` and `aqua up` commands gets available versions from [Go Module Proxy](https://proxy.golang.org/).