### PR TITLE
fix: improve the completion settings suggested in `aqua completion --help`

### DIFF
--- a/pkg/cli/completion/command.go
+++ b/pkg/cli/completion/command.go
@@ -24,7 +24,7 @@ e.g.
 .bashrc
 
 if command -v aqua &> /dev/null; then
-	source <(aqua completion bash)
+	eval "$(aqua completion bash)"
 fi
 
 .zshrc

--- a/pkg/cli/completion/command.go
+++ b/pkg/cli/completion/command.go
@@ -21,13 +21,13 @@ Source the output to enable completion.
 
 e.g.
 
-.bash_profile
+.bashrc
 
 if command -v aqua &> /dev/null; then
 	source <(aqua completion bash)
 fi
 
-.zprofile
+.zshrc
 
 if command -v aqua &> /dev/null; then
 	source <(aqua completion zsh)

--- a/pkg/cli/completion/command.go
+++ b/pkg/cli/completion/command.go
@@ -21,19 +21,19 @@ Source the output to enable completion.
 
 e.g.
 
-.bashrc
+# .bashrc
 
 if command -v aqua &> /dev/null; then
 	eval "$(aqua completion bash)"
 fi
 
-.zshrc
+# .zshrc
 
 if command -v aqua &> /dev/null; then
 	source <(aqua completion zsh)
 fi
 
-fish
+# fish
 
 aqua completion fish > ~/.config/fish/completions/aqua.fish
 `,


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: https://github.com/aquaproj/aqua/issues/3294
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->

Three fixes are included in this PR.

## (1) `.bashrc` and `.zshrc` 4e21f1d09baa3f2e47efc47dfbb6617091777a9c

The current help text suggests adding the completion settings in `.bash_profile` and `.zprofile`, but `.bash_profile` and `.zprofile` are loaded only in login shell sessions. They are not loaded in (non-login) interactive sessions started inside the login shells, and thus the completion would be disabled in non-login interactive sessions.

**Actual**

```console
$ cat .bash_profile
if command -v aqua &> /dev/null; then
  source <(aqua completion bash)
fi
$ bash
$ complete -p aqua
<nothing is output>
```

**Expected**

```console
$ cat .bashrc
if command -v aqua &> /dev/null; then
  source <(aqua completion bash)
fi
$ bash
$ complete -p aqua
complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete aqua
```

In general, `.bash_profile` and `.zprofile` should only contain the settings that are automatically inherited by the child processes or the global user settings in the operating system.  The interactive settings should be put in `.bashrc` and `.zshrc`.

In this commit, we suggest `.bashrc` and `.zshrc` instead of `.bash_profile` and `.zprofile`, respectively.

## (2) Fix for Bash 3.* 8cbabba284a9cd5141561344a6f92e4303a88329

The currently suggested setting does not work for Bash 3.* because the `source` builtin in Bash 3.* does not support reading from a pipe and `source <(command)` fails silently.  Instead, `eval "$(command)"` works in all versions of Bash.

**Actual**

```console
$ bash-3.2
$ source <(aqua completion bash)
$ complete -p aqua
<nothing is output>
```

**Expected**

```console
$ bash-3.2
$ eval "$(aqua completion bash)"
$ complete -p aqua
complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete aqua
```

## (3) Style improvement 64ad3b42138c7f50fd4f137785a2ea412ac97cb2

This is an appearance improvement for the examples of different shells, and the change is just as you see in the diff.

