### PR TITLE
chore: update goccy/go-yaml to 1.15.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/adrg/xdg v0.5.3
 	github.com/expr-lang/expr v1.16.9
 	github.com/forPelevin/gomoji v1.2.0
-	github.com/goccy/go-yaml v1.15.6
+	github.com/goccy/go-yaml v1.15.7
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-github/v67 v67.0.0
 	github.com/google/wire v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdk
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
 github.com/gdamore/tcell/v2 v2.6.0 h1:OKbluoP9VYmJwZwq/iLb4BxwKcwGthaa1YNBJIyCySg=
 github.com/gdamore/tcell/v2 v2.6.0/go.mod h1:be9omFATkdr0D9qewWW3d+MEvl5dha+Etb5y65J2H8Y=
-github.com/goccy/go-yaml v1.15.6 h1:gy5kf1yjMia3/c3wWD+u1z3lU5XlhpT8FZGaLJU9cOA=
-github.com/goccy/go-yaml v1.15.6/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
+github.com/goccy/go-yaml v1.15.7 h1:L7XuKpd/A66X4w/dlk08lVfiIADdy79a1AzRoIefC98=
+github.com/goccy/go-yaml v1.15.7/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/golang/snappy v0.0.2/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=

--- a/pkg/controller/generate/output/insert.go
+++ b/pkg/controller/generate/output/insert.go
@@ -75,13 +75,6 @@ func updateASTFile(values *ast.MappingValueNode, pkgs []*aqua.Package) error {
 		if err := ast.Merge(values.Value, node); err != nil {
 			return fmt.Errorf("merge packages: %w", err)
 		}
-		seq, ok := values.Value.(*ast.SequenceNode)
-		if ok {
-			for range pkgs {
-				// https://github.com/goccy/go-yaml/issues/502#issuecomment-2515981600
-				seq.ValueHeadComments = append(seq.ValueHeadComments, nil)
-			}
-		}
 		return nil
 	default:
 		return errors.New("packages must be null or array")


### PR DESCRIPTION
- https://github.com/aquaproj/aqua/pull/3325
- https://github.com/goccy/go-yaml/pull/570
- https://github.com/goccy/go-yaml/releases/tag/v1.15.7