### PR TITLE
feat: vacuum unused packages

### DIFF
--- a/.github/workflows/wc-integration-test.yaml
+++ b/.github/workflows/wc-integration-test.yaml
@@ -203,6 +203,19 @@ jobs:
           git checkout -- .
         working-directory: tests/update3
 
+      - name: Test aqua install with AQUA_VACUUM_DAYS
+        env:
+          AQUA_VACUUM_DAYS: 1
+        run: aqua install
+      - name: Test aqua exec with AQUA_VACUUM_DAYS
+        env:
+          AQUA_VACUUM_DAYS: 1
+        run: cmdx -v
+      - name: Test vacuum Run command
+        env:
+          AQUA_VACUUM_DAYS: 1
+        run: aqua vacuum
+
       - run: aqua update-checksum -a
 
       - run: terraform --help

--- a/.github/workflows/wc-integration-test.yaml
+++ b/.github/workflows/wc-integration-test.yaml
@@ -203,18 +203,12 @@ jobs:
           git checkout -- .
         working-directory: tests/update3
 
-      - name: Test aqua install with AQUA_VACUUM_DAYS
-        env:
-          AQUA_VACUUM_DAYS: 1
-        run: aqua install
-      - name: Test aqua exec with AQUA_VACUUM_DAYS
-        env:
-          AQUA_VACUUM_DAYS: 1
-        run: cmdx -v
-      - name: Test vacuum Run command
+      - name: Test vacuum
         env:
           AQUA_VACUUM_DAYS: 1
         run: aqua vacuum
+      - name: Test vacuum --init
+        run: aqua vacuum --init
 
       - run: aqua update-checksum -a
 

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aquaproj/aqua/v2/pkg/cli/update"
 	"github.com/aquaproj/aqua/v2/pkg/cli/updateaqua"
 	"github.com/aquaproj/aqua/v2/pkg/cli/util"
+	"github.com/aquaproj/aqua/v2/pkg/cli/vacuum"
 	"github.com/aquaproj/aqua/v2/pkg/cli/version"
 	"github.com/aquaproj/aqua/v2/pkg/cli/which"
 	"github.com/urfave/cli/v2"
@@ -110,6 +111,7 @@ func Run(ctx context.Context, param *util.Param, args ...string) error { //nolin
 			upc.New,
 			remove.New,
 			update.New,
+			vacuum.New,
 		),
 	}
 

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -84,12 +84,6 @@ func Run(ctx context.Context, param *util.Param, args ...string) error { //nolin
 				Name:  "cpu-profile",
 				Usage: "cpu profile output file path",
 			},
-			&cli.IntFlag{
-				Name:    "vacuum-days",
-				Usage:   "Vacuum days",
-				EnvVars: []string{"AQUA_VACUUM_DAYS"},
-				Value:   60, //nolint:mnd
-			},
 		},
 		EnableBashCompletion: true,
 		Commands: commands(

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -83,6 +83,11 @@ func Run(ctx context.Context, param *util.Param, args ...string) error { //nolin
 				Name:  "cpu-profile",
 				Usage: "cpu profile output file path",
 			},
+			&cli.IntFlag{
+				Name:    "vacuum-days",
+				Usage:   "Vacuum days",
+				EnvVars: []string{"AQUA_VACUUM_DAYS"},
+			},
 		},
 		EnableBashCompletion: true,
 		Commands: commands(

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -88,6 +88,7 @@ func Run(ctx context.Context, param *util.Param, args ...string) error { //nolin
 				Name:    "vacuum-days",
 				Usage:   "Vacuum days",
 				EnvVars: []string{"AQUA_VACUUM_DAYS"},
+				Value:   60, //nolint:mnd
 			},
 		},
 		EnableBashCompletion: true,

--- a/pkg/cli/util/util.go
+++ b/pkg/cli/util/util.go
@@ -137,9 +137,9 @@ func SetParam(c *cli.Context, logE *logrus.Entry, commandName string, param *con
 		}
 		param.EnforceRequireChecksum = requireChecksum
 	}
-	param.VacuumDays = c.Int("vacuum-days")
+	param.VacuumDays = c.Int("days")
 	if param.VacuumDays <= 0 {
-		return errors.New("vacuum-days must be greater than 0")
+		return errors.New("vacuum days must be greater than 0")
 	}
 	return nil
 }

--- a/pkg/cli/util/util.go
+++ b/pkg/cli/util/util.go
@@ -136,6 +136,7 @@ func SetParam(c *cli.Context, logE *logrus.Entry, commandName string, param *con
 		}
 		param.EnforceRequireChecksum = requireChecksum
 	}
+	param.VacuumDays = c.Int("vacuum-days")
 	return nil
 }
 

--- a/pkg/cli/util/util.go
+++ b/pkg/cli/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -138,7 +139,7 @@ func SetParam(c *cli.Context, logE *logrus.Entry, commandName string, param *con
 	}
 	param.VacuumDays = c.Int("vacuum-days")
 	if param.VacuumDays <= 0 {
-		return fmt.Errorf("vacuum-days must be greater than 0")
+		return errors.New("vacuum-days must be greater than 0")
 	}
 	return nil
 }

--- a/pkg/cli/util/util.go
+++ b/pkg/cli/util/util.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -136,10 +135,6 @@ func SetParam(c *cli.Context, logE *logrus.Entry, commandName string, param *con
 			return fmt.Errorf("parse the environment variable AQUA_ENFORCE_REQUIRE_CHECKSUM as bool: %w", err)
 		}
 		param.EnforceRequireChecksum = requireChecksum
-	}
-	param.VacuumDays = c.Int("days")
-	if param.VacuumDays <= 0 {
-		return errors.New("vacuum days must be greater than 0")
 	}
 	return nil
 }

--- a/pkg/cli/util/util.go
+++ b/pkg/cli/util/util.go
@@ -137,6 +137,9 @@ func SetParam(c *cli.Context, logE *logrus.Entry, commandName string, param *con
 		param.EnforceRequireChecksum = requireChecksum
 	}
 	param.VacuumDays = c.Int("vacuum-days")
+	if param.VacuumDays <= 0 {
+		return fmt.Errorf("vacuum-days must be greater than 0")
+	}
 	return nil
 }
 

--- a/pkg/cli/vacuum/command.go
+++ b/pkg/cli/vacuum/command.go
@@ -1,0 +1,64 @@
+package vacuum
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/aquaproj/aqua/v2/pkg/cli/profile"
+	"github.com/aquaproj/aqua/v2/pkg/cli/util"
+	"github.com/aquaproj/aqua/v2/pkg/config"
+	"github.com/aquaproj/aqua/v2/pkg/controller"
+	"github.com/urfave/cli/v2"
+)
+
+const description = `Perform vacuuming tasks.
+
+Enable vacuuming by setting the AQUA_VACUUM_DAYS environment variable to a value greater than 0.
+This command removes versions of packages that have not been used for the specified number of days.
+
+You can list all packages managed by the vacuum system or only expired packages.
+
+	$ aqua vacuum
+`
+
+type command struct {
+	r *util.Param
+}
+
+func New(r *util.Param) *cli.Command {
+	i := &command{
+		r: r,
+	}
+	return &cli.Command{
+		Name:        "vacuum",
+		Usage:       "Operate vacuuming tasks (If AQUA_VACUUM_DAYS is set)",
+		Aliases:     []string{"v"},
+		Description: description,
+		Action:      i.action,
+	}
+}
+
+func (i *command) action(c *cli.Context) error {
+	profiler, err := profile.Start(c)
+	if err != nil {
+		return fmt.Errorf("start CPU Profile or tracing: %w", err)
+	}
+	defer profiler.Stop()
+
+	logE := i.r.LogE
+
+	param := &config.Param{}
+	if err := util.SetParam(c, logE, "vacuum", param, i.r.LDFlags); err != nil {
+		return fmt.Errorf("parse the command line arguments: %w", err)
+	}
+
+	if param.VacuumDays == 0 {
+		return errors.New("vacuum is not enabled, please set the AQUA_VACUUM_DAYS environment variable")
+	}
+
+	ctrl := controller.InitializeVacuumCommandController(c.Context, param, i.r.Runtime)
+	if err := ctrl.Vacuum(c.Context, logE, param); err != nil {
+		return err //nolint:wrapcheck
+	}
+	return nil
+}

--- a/pkg/cli/vacuum/command.go
+++ b/pkg/cli/vacuum/command.go
@@ -3,6 +3,7 @@ package vacuum
 import (
 	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/aquaproj/aqua/v2/pkg/cli/profile"
 	"github.com/aquaproj/aqua/v2/pkg/cli/util"
@@ -35,6 +36,12 @@ func New(r *util.Param) *cli.Command {
 		Aliases:     []string{"v"},
 		Description: description,
 		Action:      i.action,
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "init",
+				Usage: "Create timestamp files.",
+			},
+		},
 	}
 }
 
@@ -52,8 +59,16 @@ func (i *command) action(c *cli.Context) error {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
 
+	if c.Bool("init") {
+		ctrl := controller.InitializeVacuumInitCommandController(c.Context, param, i.r.Runtime, &http.Client{})
+		if err := ctrl.Init(c.Context, logE, param); err != nil {
+			return err //nolint:wrapcheck
+		}
+		return nil
+	}
+
 	if param.VacuumDays == 0 {
-		return errors.New("vacuum is not enabled, please set the AQUA_VACUUM_DAYS environment variable")
+		return errors.New("vacuum-days is required")
 	}
 
 	ctrl := controller.InitializeVacuumCommandController(c.Context, param, i.r.Runtime)

--- a/pkg/cli/vacuum/command.go
+++ b/pkg/cli/vacuum/command.go
@@ -1,6 +1,7 @@
 package vacuum
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -71,6 +72,11 @@ func (i *command) action(c *cli.Context) error {
 			return err //nolint:wrapcheck
 		}
 		return nil
+	}
+
+	param.VacuumDays = c.Int("days")
+	if param.VacuumDays <= 0 {
+		return errors.New("vacuum days must be greater than 0")
 	}
 
 	ctrl := controller.InitializeVacuumCommandController(c.Context, param, i.r.Runtime)

--- a/pkg/cli/vacuum/command.go
+++ b/pkg/cli/vacuum/command.go
@@ -1,7 +1,6 @@
 package vacuum
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -41,6 +40,13 @@ func New(r *util.Param) *cli.Command {
 				Name:  "init",
 				Usage: "Create timestamp files.",
 			},
+			&cli.IntFlag{
+				Name:    "days",
+				Aliases: []string{"d"},
+				Usage:   "Vacuum days",
+				EnvVars: []string{"AQUA_VACUUM_DAYS"},
+				Value:   60, //nolint:mnd
+			},
 		},
 	}
 }
@@ -65,10 +71,6 @@ func (i *command) action(c *cli.Context) error {
 			return err //nolint:wrapcheck
 		}
 		return nil
-	}
-
-	if param.VacuumDays == 0 {
-		return errors.New("vacuum-days is required")
 	}
 
 	ctrl := controller.InitializeVacuumCommandController(c.Context, param, i.r.Runtime)

--- a/pkg/cli/vacuum/command.go
+++ b/pkg/cli/vacuum/command.go
@@ -12,14 +12,32 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-const description = `Perform vacuuming tasks.
+const description = `Remove unused installed packages.
 
-Enable vacuuming by setting the AQUA_VACUUM_DAYS environment variable to a value greater than 0.
-This command removes versions of packages that have not been used for the specified number of days.
-
-You can list all packages managed by the vacuum system or only expired packages.
+This command removes unused installed packages, which is useful to save storage and keep your machine clean.
 
 	$ aqua vacuum
+
+It removes installed packages which haven't been used for over the expiration days.
+The default expiration days is 60, but you can change it by the environment variable $AQUA_VACUUM_DAYS or the command line option "-days <expiration days>".
+
+e.g.
+
+	$ export AQUA_VACUUM_DAYS=90
+
+	$ aqua vacuum -d 30
+
+As of aqua v2.43.0, aqua records packages' last used date times.
+Date times are updated when packages are installed or executed.
+Packages installed by aqua v2.42.2 or older don't have records of last used date times, so aqua can't remove them.
+To solve the problem, "aqua vacuum --init" is available.
+
+	aqua vacuum --init
+
+"aqua vacuum --init" searches installed packages from aqua.yaml including $AQUA_GLOBAL_CONFIG and records the current date time as the last used date time of those packages if their last used date times aren't recorded.
+
+"aqua vacuum --init" can't record date times of install packages which are not found in aqua.yaml.
+If you want to record their date times, you need to remove them by "aqua rm" command and re-install them.
 `
 
 type command struct {
@@ -32,8 +50,7 @@ func New(r *util.Param) *cli.Command {
 	}
 	return &cli.Command{
 		Name:        "vacuum",
-		Usage:       "Operate vacuuming tasks (If AQUA_VACUUM_DAYS is set)",
-		Aliases:     []string{"v"},
+		Usage:       "Remove unused installed packages",
 		Description: description,
 		Action:      i.action,
 		Flags: []cli.Flag{
@@ -44,7 +61,7 @@ func New(r *util.Param) *cli.Command {
 			&cli.IntFlag{
 				Name:    "days",
 				Aliases: []string{"d"},
-				Usage:   "Vacuum days",
+				Usage:   "Expiration days",
 				EnvVars: []string{"AQUA_VACUUM_DAYS"},
 				Value:   60, //nolint:mnd
 			},

--- a/pkg/cli/vacuum/command.go
+++ b/pkg/cli/vacuum/command.go
@@ -57,7 +57,7 @@ func (i *command) action(c *cli.Context) error {
 	}
 
 	ctrl := controller.InitializeVacuumCommandController(c.Context, param, i.r.Runtime)
-	if err := ctrl.Vacuum(c.Context, logE, param); err != nil {
+	if err := ctrl.Vacuum(logE, param); err != nil {
 		return err //nolint:wrapcheck
 	}
 	return nil

--- a/pkg/config/package.go
+++ b/pkg/config/package.go
@@ -120,7 +120,7 @@ func (p *Package) PkgPath(rt *runtime.Runtime) (string, error) { //nolint:cyclop
 	return "", nil
 }
 
-func (p *Package) AbsPkgPath(rootDir string, rt *runtime.Runtime) (string, error) { //nolint:cyclop
+func (p *Package) AbsPkgPath(rootDir string, rt *runtime.Runtime) (string, error) {
 	pkgPath, err := p.PkgPath(rt)
 	if err != nil {
 		return "", err

--- a/pkg/config/package_test.go
+++ b/pkg/config/package_test.go
@@ -210,7 +210,7 @@ func TestPackageInfo_PkgPath(t *testing.T) { //nolint:funlen
 	for _, d := range data {
 		t.Run(d.title, func(t *testing.T) {
 			t.Parallel()
-			pkgPath, err := d.pkg.PkgPath(rootDir, rt)
+			pkgPath, err := d.pkg.AbsPkgPath(rootDir, rt)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/controller/exec/controller.go
+++ b/pkg/controller/exec/controller.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"runtime"
+	"time"
 
 	"github.com/aquaproj/aqua/v2/pkg/config"
 	"github.com/aquaproj/aqua/v2/pkg/controller/which"
@@ -26,13 +27,18 @@ type Controller struct {
 	fs               afero.Fs
 	policyReader     PolicyReader
 	enabledXSysExec  bool
+	vacuum           Vacuum
+}
+
+type Vacuum interface {
+	Update(pkgPath string, timestamp time.Time) error
 }
 
 type Installer interface {
 	InstallPackage(ctx context.Context, logE *logrus.Entry, param *installpackage.ParamInstallPackage) error
 }
 
-func New(pkgInstaller Installer, whichCtrl WhichController, executor Executor, osEnv osenv.OSEnv, fs afero.Fs, policyReader PolicyReader) *Controller {
+func New(pkgInstaller Installer, whichCtrl WhichController, executor Executor, osEnv osenv.OSEnv, fs afero.Fs, policyReader PolicyReader, vacuum Vacuum) *Controller {
 	return &Controller{
 		stdin:            os.Stdin,
 		stdout:           os.Stdout,
@@ -43,6 +49,7 @@ func New(pkgInstaller Installer, whichCtrl WhichController, executor Executor, o
 		enabledXSysExec:  getEnabledXSysExec(osEnv, runtime.GOOS),
 		fs:               fs,
 		policyReader:     policyReader,
+		vacuum:           vacuum,
 	}
 }
 

--- a/pkg/controller/exec/exec.go
+++ b/pkg/controller/exec/exec.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aquaproj/aqua/v2/pkg/osexec"
 	"github.com/aquaproj/aqua/v2/pkg/osfile"
 	"github.com/aquaproj/aqua/v2/pkg/policy"
+	"github.com/aquaproj/aqua/v2/pkg/runtime"
 	"github.com/sirupsen/logrus"
 	"github.com/suzuki-shunsuke/go-error-with-exit-code/ecerror"
 	"github.com/suzuki-shunsuke/logrus-error/logerr"
@@ -62,6 +63,15 @@ func (c *Controller) Exec(ctx context.Context, logE *logrus.Entry, param *config
 	if err := c.install(ctx, logE, findResult, policyCfgs, param); err != nil {
 		return err
 	}
+
+	pkgPath, err := findResult.Package.PkgPath(runtime.New())
+	if err != nil {
+		return err
+	}
+	if err := c.vacuum.Update(pkgPath, time.Now()); err != nil {
+		logerr.WithError(logE, err).Warn("update the last used datetime")
+	}
+
 	return c.execCommandWithRetry(ctx, logE, findResult.ExePath, args...)
 }
 

--- a/pkg/controller/install/install_test.go
+++ b/pkg/controller/install/install_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aquaproj/aqua/v2/pkg/slsa"
 	"github.com/aquaproj/aqua/v2/pkg/testutil"
 	"github.com/aquaproj/aqua/v2/pkg/unarchive"
+	"github.com/aquaproj/aqua/v2/pkg/vacuum"
 	"github.com/sirupsen/logrus"
 )
 
@@ -103,7 +104,8 @@ packages:
 			}
 			downloader := download.NewDownloader(nil, download.NewHTTPDownloader(http.DefaultClient))
 			executor := &osexec.Mock{}
-			pkgInstaller := installpackage.New(d.param, downloader, d.rt, fs, linker, nil, &checksum.Calculator{}, unarchive.New(executor, fs), &cosign.MockVerifier{}, &slsa.MockVerifier{}, &minisign.MockVerifier{}, &ghattestation.MockVerifier{}, &installpackage.MockGoInstallInstaller{}, &installpackage.MockGoBuildInstaller{}, &installpackage.MockCargoPackageInstaller{})
+			vacuumMock := vacuum.NewMock(d.param.RootDir, nil, nil)
+			pkgInstaller := installpackage.New(d.param, downloader, d.rt, fs, linker, nil, &checksum.Calculator{}, unarchive.New(executor, fs), &cosign.MockVerifier{}, &slsa.MockVerifier{}, &minisign.MockVerifier{}, &ghattestation.MockVerifier{}, &installpackage.MockGoInstallInstaller{}, &installpackage.MockGoBuildInstaller{}, &installpackage.MockCargoPackageInstaller{}, vacuumMock)
 			policyFinder := policy.NewConfigFinder(fs)
 			policyReader := policy.NewReader(fs, &policy.MockValidator{}, policyFinder, policy.NewConfigReader(fs))
 			ctrl := install.New(d.param, finder.NewConfigFinder(fs), reader.New(fs, d.param), registry.New(d.param, registryDownloader, fs, d.rt, &cosign.MockVerifier{}, &slsa.MockVerifier{}), pkgInstaller, fs, d.rt, policyReader)

--- a/pkg/controller/remove/controller.go
+++ b/pkg/controller/remove/controller.go
@@ -24,6 +24,7 @@ type Controller struct {
 	fuzzyFinder       FuzzyFinder
 	which             WhichController
 	mode              *config.RemoveMode
+	vacuum            Vacuum
 }
 
 type WhichController interface {
@@ -38,7 +39,7 @@ type FuzzyFinder interface {
 	FindMulti(pkgs []*fuzzyfinder.Item, hasPreview bool) ([]int, error)
 }
 
-func New(param *config.Param, target *config.RemoveMode, fs afero.Fs, rt *runtime.Runtime, configFinder ConfigFinder, configReader ConfigReader, registryInstaller RegistryInstaller, fuzzyFinder FuzzyFinder, whichController WhichController) *Controller {
+func New(param *config.Param, target *config.RemoveMode, fs afero.Fs, rt *runtime.Runtime, configFinder ConfigFinder, configReader ConfigReader, registryInstaller RegistryInstaller, fuzzyFinder FuzzyFinder, whichController WhichController, vacuum Vacuum) *Controller {
 	return &Controller{
 		rootDir:           param.RootDir,
 		fs:                fs,
@@ -49,6 +50,7 @@ func New(param *config.Param, target *config.RemoveMode, fs afero.Fs, rt *runtim
 		fuzzyFinder:       fuzzyFinder,
 		which:             whichController,
 		mode:              target,
+		vacuum:            vacuum,
 	}
 }
 
@@ -58,4 +60,8 @@ type ConfigFinder interface {
 
 type RegistryInstaller interface {
 	InstallRegistries(ctx context.Context, logE *logrus.Entry, cfg *aqua.Config, cfgFilePath string, checksums *checksum.Checksums) (map[string]*registry.Config, error)
+}
+
+type Vacuum interface {
+	Remove(pkgPath string) error
 }

--- a/pkg/controller/remove/remove.go
+++ b/pkg/controller/remove/remove.go
@@ -191,6 +191,20 @@ func (c *Controller) removeCommand(ctx context.Context, logE *logrus.Entry, para
 	return nil
 }
 
+func (c *Controller) removeTimestamp(pkg *config.Package) error {
+	pkgPath, err := pkg.PkgPath(c.runtime)
+	if err != nil {
+		return fmt.Errorf("get a package path: %w", err)
+	}
+	if err := c.vacuum.Remove(pkgPath); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("remove the last used datetime: %w", err)
+	}
+	return nil
+}
+
 func (c *Controller) removePackage(logE *logrus.Entry, rootDir string, pkg *registry.PackageInfo) error {
 	var gErr error
 	logE.Info("removing a package")
@@ -218,12 +232,30 @@ func (c *Controller) removePackage(logE *logrus.Entry, rootDir string, pkg *regi
 		if err := c.removePath(logE, rootDir, path); err != nil {
 			return err
 		}
+		if err := c.removeMetadataPath(logE, rootDir, path); err != nil {
+			return err
+		}
 	}
 	return gErr
 }
 
 func (c *Controller) removePath(logE *logrus.Entry, rootDir string, path string) error {
 	pkgPath := filepath.Join(rootDir, "pkgs", path)
+	arr, err := afero.Glob(c.fs, pkgPath)
+	if err != nil {
+		return fmt.Errorf("find directories: %w", err)
+	}
+	for _, p := range arr {
+		logE.WithField("removed_path", p).Debug("removing a directory")
+		if err := c.fs.RemoveAll(p); err != nil {
+			return fmt.Errorf("remove directories: %w", err)
+		}
+	}
+	return nil
+}
+
+func (c *Controller) removeMetadataPath(logE *logrus.Entry, rootDir string, path string) error {
+	pkgPath := filepath.Join(rootDir, "metadata", "pkgs", path)
 	arr, err := afero.Glob(c.fs, pkgPath)
 	if err != nil {
 		return fmt.Errorf("find directories: %w", err)
@@ -272,6 +304,9 @@ func (c *Controller) removeAll(rootDir string) error {
 	}
 	if err := c.fs.RemoveAll(filepath.Join(rootDir, "pkgs")); err != nil {
 		return fmt.Errorf("remove all packages: %w", err)
+	}
+	if err := c.fs.RemoveAll(filepath.Join(rootDir, "metadata")); err != nil {
+		return fmt.Errorf("remove all package metadata: %w", err)
 	}
 	return gErr
 }

--- a/pkg/controller/remove/remove.go
+++ b/pkg/controller/remove/remove.go
@@ -191,20 +191,6 @@ func (c *Controller) removeCommand(ctx context.Context, logE *logrus.Entry, para
 	return nil
 }
 
-func (c *Controller) removeTimestamp(pkg *config.Package) error {
-	pkgPath, err := pkg.PkgPath(c.runtime)
-	if err != nil {
-		return fmt.Errorf("get a package path: %w", err)
-	}
-	if err := c.vacuum.Remove(pkgPath); err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return nil
-		}
-		return fmt.Errorf("remove the last used datetime: %w", err)
-	}
-	return nil
-}
-
 func (c *Controller) removePackage(logE *logrus.Entry, rootDir string, pkg *registry.PackageInfo) error {
 	var gErr error
 	logE.Info("removing a package")

--- a/pkg/controller/vacuum/controller.go
+++ b/pkg/controller/vacuum/controller.go
@@ -1,0 +1,30 @@
+package vacuum
+
+import (
+	"time"
+
+	"github.com/aquaproj/aqua/v2/pkg/config"
+	"github.com/aquaproj/aqua/v2/pkg/runtime"
+	"github.com/spf13/afero"
+)
+
+type Controller struct {
+	rootDir string
+	runtime *runtime.Runtime
+	fs      afero.Fs
+	vacuum  Vacuum
+}
+
+func New(param *config.Param, rt *runtime.Runtime, fs afero.Fs, vc Vacuum) *Controller {
+	return &Controller{
+		rootDir: param.RootDir,
+		runtime: rt,
+		fs:      fs,
+		vacuum:  vc,
+	}
+}
+
+type Vacuum interface {
+	FindAll() (map[string]time.Time, error)
+	Remove(pkgPath string) error
+}

--- a/pkg/controller/vacuum/controller.go
+++ b/pkg/controller/vacuum/controller.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aquaproj/aqua/v2/pkg/config"
 	"github.com/aquaproj/aqua/v2/pkg/runtime"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 )
 
@@ -25,6 +26,6 @@ func New(param *config.Param, rt *runtime.Runtime, fs afero.Fs, vc Vacuum) *Cont
 }
 
 type Vacuum interface {
-	FindAll() (map[string]time.Time, error)
+	FindAll(logE *logrus.Entry) (map[string]time.Time, error)
 	Remove(pkgPath string) error
 }

--- a/pkg/controller/vacuum/initialize/controller.go
+++ b/pkg/controller/vacuum/initialize/controller.go
@@ -1,0 +1,52 @@
+package initialize
+
+import (
+	"context"
+	"time"
+
+	"github.com/aquaproj/aqua/v2/pkg/checksum"
+	"github.com/aquaproj/aqua/v2/pkg/config"
+	"github.com/aquaproj/aqua/v2/pkg/config/aqua"
+	"github.com/aquaproj/aqua/v2/pkg/config/registry"
+	"github.com/aquaproj/aqua/v2/pkg/runtime"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+)
+
+type Controller struct {
+	rootDir           string
+	runtime           *runtime.Runtime
+	fs                afero.Fs
+	vacuum            Vacuum
+	configFinder      ConfigFinder
+	configReader      ConfigReader
+	registryInstaller RegistryInstaller
+}
+
+func New(param *config.Param, rt *runtime.Runtime, fs afero.Fs, vc Vacuum, configFinder ConfigFinder, configReader ConfigReader, registryInstaller RegistryInstaller) *Controller {
+	return &Controller{
+		rootDir:           param.RootDir,
+		runtime:           rt,
+		fs:                fs,
+		vacuum:            vc,
+		configFinder:      configFinder,
+		configReader:      configReader,
+		registryInstaller: registryInstaller,
+	}
+}
+
+type Vacuum interface {
+	Create(pkgPath string, timestamp time.Time) error
+}
+
+type ConfigReader interface {
+	Read(logE *logrus.Entry, configFilePath string, cfg *aqua.Config) error
+}
+
+type ConfigFinder interface {
+	Finds(wd, configFilePath string) []string
+}
+
+type RegistryInstaller interface {
+	InstallRegistries(ctx context.Context, logE *logrus.Entry, cfg *aqua.Config, cfgFilePath string, checksums *checksum.Checksums) (map[string]*registry.Config, error)
+}

--- a/pkg/controller/vacuum/initialize/init.go
+++ b/pkg/controller/vacuum/initialize/init.go
@@ -3,6 +3,7 @@ package initialize
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"time"
 
 	"github.com/aquaproj/aqua/v2/pkg/checksum"
@@ -10,6 +11,7 @@ import (
 	finder "github.com/aquaproj/aqua/v2/pkg/config-finder"
 	"github.com/aquaproj/aqua/v2/pkg/config/aqua"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
 	"github.com/suzuki-shunsuke/logrus-error/logerr"
 )
 
@@ -67,6 +69,13 @@ func (c *Controller) create(ctx context.Context, logE *logrus.Entry, cfgFilePath
 		pkgPath, err := pkg.PkgPath(c.runtime)
 		if err != nil {
 			logerr.WithError(logE, err).Warn("get a package path")
+			continue
+		}
+		absPkgPath := filepath.Join(c.rootDir, pkgPath)
+		if f, err := afero.Exists(c.fs, absPkgPath); err != nil {
+			logerr.WithError(logE, err).Warn("check if the package is installed")
+			continue
+		} else if !f {
 			continue
 		}
 		if err := c.vacuum.Create(pkgPath, now); err != nil {

--- a/pkg/controller/vacuum/initialize/init.go
+++ b/pkg/controller/vacuum/initialize/init.go
@@ -1,0 +1,77 @@
+package initialize
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aquaproj/aqua/v2/pkg/checksum"
+	"github.com/aquaproj/aqua/v2/pkg/config"
+	finder "github.com/aquaproj/aqua/v2/pkg/config-finder"
+	"github.com/aquaproj/aqua/v2/pkg/config/aqua"
+	"github.com/sirupsen/logrus"
+	"github.com/suzuki-shunsuke/logrus-error/logerr"
+)
+
+func (c *Controller) Init(ctx context.Context, logE *logrus.Entry, param *config.Param) error {
+	for _, cfgFilePath := range c.configFinder.Finds(param.PWD, param.ConfigFilePath) {
+		if err := c.create(ctx, logE, cfgFilePath, param); err != nil {
+			return err
+		}
+	}
+	for _, cfgFilePath := range param.GlobalConfigFilePaths {
+		if _, err := c.fs.Stat(cfgFilePath); err != nil {
+			continue
+		}
+		if err := c.create(ctx, logE, cfgFilePath, param); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Controller) create(ctx context.Context, logE *logrus.Entry, cfgFilePath string, param *config.Param) error { //nolint:cyclop
+	cfg := &aqua.Config{}
+	if cfgFilePath == "" {
+		return finder.ErrConfigFileNotFound
+	}
+	if err := c.configReader.Read(logE, cfgFilePath, cfg); err != nil {
+		return err //nolint:wrapcheck
+	}
+
+	var checksums *checksum.Checksums
+	if cfg.ChecksumEnabled(param.EnforceChecksum, param.Checksum) {
+		checksums = checksum.New()
+		checksumFilePath, err := checksum.GetChecksumFilePathFromConfigFilePath(c.fs, cfgFilePath)
+		if err != nil {
+			return err //nolint:wrapcheck
+		}
+		if err := checksums.ReadFile(c.fs, checksumFilePath); err != nil {
+			return fmt.Errorf("read a checksum JSON: %w", err)
+		}
+		defer func() {
+			if err := checksums.UpdateFile(c.fs, checksumFilePath); err != nil {
+				logE.WithError(err).Error("update a checksum file")
+			}
+		}()
+	}
+
+	registryContents, err := c.registryInstaller.InstallRegistries(ctx, logE, cfg, cfgFilePath, checksums)
+	if err != nil {
+		return err //nolint:wrapcheck
+	}
+
+	pkgs, _ := config.ListPackages(logE, cfg, c.runtime, registryContents)
+	now := time.Now()
+	for _, pkg := range pkgs {
+		pkgPath, err := pkg.PkgPath(c.runtime)
+		if err != nil {
+			logerr.WithError(logE, err).Warn("get a package path")
+			continue
+		}
+		if err := c.vacuum.Create(pkgPath, now); err != nil {
+			logerr.WithError(logE, err).Warn("create a timestamp file")
+		}
+	}
+	return nil
+}

--- a/pkg/controller/vacuum/vacuum.go
+++ b/pkg/controller/vacuum/vacuum.go
@@ -1,7 +1,6 @@
 package vacuum
 
 import (
-	"context"
 	"path/filepath"
 	"time"
 
@@ -10,8 +9,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func (c *Controller) Vacuum(ctx context.Context, logE *logrus.Entry, param *config.Param) error {
-	timestamps, err := c.vacuum.FindAll()
+func (c *Controller) Vacuum(logE *logrus.Entry, param *config.Param) error {
+	timestamps, err := c.vacuum.FindAll(logE)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/vacuum/vacuum.go
+++ b/pkg/controller/vacuum/vacuum.go
@@ -1,0 +1,36 @@
+package vacuum
+
+import (
+	"context"
+	"path/filepath"
+	"time"
+
+	"github.com/aquaproj/aqua/v2/pkg/config"
+	"github.com/aquaproj/aqua/v2/pkg/vacuum"
+	"github.com/sirupsen/logrus"
+)
+
+func (c *Controller) Vacuum(ctx context.Context, logE *logrus.Entry, param *config.Param) error {
+	timestamps, err := c.vacuum.FindAll()
+	if err != nil {
+		return err
+	}
+	timestampChecker := vacuum.NewTimestampChecker(time.Now(), param.VacuumDays)
+	for pkgPath, timestamp := range timestamps {
+		logE := logE.WithField("package_path", pkgPath)
+		if !timestampChecker.Expired(timestamp) {
+			continue
+		}
+		// remove the package
+		p := filepath.Join(c.rootDir, pkgPath)
+		if err := c.fs.RemoveAll(p); err != nil {
+			return err
+		}
+		// remove the timestamp file
+		if err := c.vacuum.Remove(pkgPath); err != nil {
+			return err
+		}
+		logE.Info("removed the package")
+	}
+	return nil
+}

--- a/pkg/controller/wire.go
+++ b/pkg/controller/wire.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aquaproj/aqua/v2/pkg/controller/update"
 	"github.com/aquaproj/aqua/v2/pkg/controller/updateaqua"
 	"github.com/aquaproj/aqua/v2/pkg/controller/updatechecksum"
+	cvacuum "github.com/aquaproj/aqua/v2/pkg/controller/vacuum"
 	"github.com/aquaproj/aqua/v2/pkg/controller/which"
 	"github.com/aquaproj/aqua/v2/pkg/cosign"
 	"github.com/aquaproj/aqua/v2/pkg/domain"
@@ -45,6 +46,7 @@ import (
 	"github.com/aquaproj/aqua/v2/pkg/runtime"
 	"github.com/aquaproj/aqua/v2/pkg/slsa"
 	"github.com/aquaproj/aqua/v2/pkg/unarchive"
+	"github.com/aquaproj/aqua/v2/pkg/vacuum"
 	"github.com/aquaproj/aqua/v2/pkg/versiongetter"
 	"github.com/aquaproj/aqua/v2/pkg/versiongetter/goproxy"
 
@@ -348,6 +350,10 @@ func InitializeInstallCommandController(ctx context.Context, param *config.Param
 			installpackage.NewCargoPackageInstallerImpl,
 			wire.Bind(new(installpackage.CargoPackageInstaller), new(*installpackage.CargoPackageInstallerImpl)),
 		),
+		wire.NewSet(
+			vacuum.New,
+			wire.Bind(new(installpackage.Vacuum), new(*vacuum.Client)),
+		),
 	)
 	return &install.Controller{}, nil
 }
@@ -538,6 +544,11 @@ func InitializeExecCommandController(ctx context.Context, param *config.Param, h
 			installpackage.NewCargoPackageInstallerImpl,
 			wire.Bind(new(installpackage.CargoPackageInstaller), new(*installpackage.CargoPackageInstallerImpl)),
 		),
+		wire.NewSet(
+			vacuum.New,
+			wire.Bind(new(installpackage.Vacuum), new(*vacuum.Client)),
+			wire.Bind(new(cexec.Vacuum), new(*vacuum.Client)),
+		),
 	)
 	return &cexec.Controller{}, nil
 }
@@ -629,6 +640,10 @@ func InitializeUpdateAquaCommandController(ctx context.Context, param *config.Pa
 		wire.NewSet(
 			installpackage.NewCargoPackageInstallerImpl,
 			wire.Bind(new(installpackage.CargoPackageInstaller), new(*installpackage.CargoPackageInstallerImpl)),
+		),
+		wire.NewSet(
+			vacuum.New,
+			wire.Bind(new(installpackage.Vacuum), new(*vacuum.Client)),
 		),
 	)
 	return &updateaqua.Controller{}, nil
@@ -769,6 +784,10 @@ func InitializeCopyCommandController(ctx context.Context, param *config.Param, h
 		wire.NewSet(
 			installpackage.NewCargoPackageInstallerImpl,
 			wire.Bind(new(installpackage.CargoPackageInstaller), new(*installpackage.CargoPackageInstallerImpl)),
+		),
+		wire.NewSet(
+			vacuum.New,
+			wire.Bind(new(installpackage.Vacuum), new(*vacuum.Client)),
 		),
 	)
 	return &cp.Controller{}, nil
@@ -1039,4 +1058,16 @@ func InitializeRemoveCommandController(ctx context.Context, param *config.Param,
 		),
 	)
 	return &remove.Controller{}
+}
+
+func InitializeVacuumCommandController(ctx context.Context, param *config.Param, rt *runtime.Runtime) *cvacuum.Controller {
+	wire.Build(
+		cvacuum.New,
+		afero.NewOsFs,
+		wire.NewSet(
+			vacuum.New,
+			wire.Bind(new(cvacuum.Vacuum), new(*vacuum.Client)),
+		),
+	)
+	return &cvacuum.Controller{}
 }

--- a/pkg/controller/wire.go
+++ b/pkg/controller/wire.go
@@ -1057,6 +1057,10 @@ func InitializeRemoveCommandController(ctx context.Context, param *config.Param,
 			wire.Bind(new(installpackage.Linker), new(*link.Linker)),
 			wire.Bind(new(which.Linker), new(*link.Linker)),
 		),
+		wire.NewSet(
+			vacuum.New,
+			wire.Bind(new(remove.Vacuum), new(*vacuum.Client)),
+		),
 	)
 	return &remove.Controller{}
 }

--- a/pkg/controller/wire_gen.go
+++ b/pkg/controller/wire_gen.go
@@ -385,7 +385,8 @@ func InitializeRemoveCommandController(ctx context.Context, param *config.Param,
 	osEnv := osenv.New()
 	linker := link.New()
 	controller := which.New(param, configFinder, configReader, installer, rt, osEnv, fs, linker)
-	removeController := remove.New(param, target, fs, rt, configFinder, configReader, installer, fuzzyfinderFinder, controller)
+	client := vacuum.New(fs, param)
+	removeController := remove.New(param, target, fs, rt, configFinder, configReader, installer, fuzzyfinderFinder, controller, client)
 	return removeController
 }
 

--- a/pkg/controller/wire_gen.go
+++ b/pkg/controller/wire_gen.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aquaproj/aqua/v2/pkg/controller/update"
 	"github.com/aquaproj/aqua/v2/pkg/controller/updateaqua"
 	"github.com/aquaproj/aqua/v2/pkg/controller/updatechecksum"
+	vacuum2 "github.com/aquaproj/aqua/v2/pkg/controller/vacuum"
 	"github.com/aquaproj/aqua/v2/pkg/controller/which"
 	"github.com/aquaproj/aqua/v2/pkg/cosign"
 	"github.com/aquaproj/aqua/v2/pkg/download"
@@ -44,6 +45,7 @@ import (
 	"github.com/aquaproj/aqua/v2/pkg/runtime"
 	"github.com/aquaproj/aqua/v2/pkg/slsa"
 	"github.com/aquaproj/aqua/v2/pkg/unarchive"
+	"github.com/aquaproj/aqua/v2/pkg/vacuum"
 	"github.com/aquaproj/aqua/v2/pkg/versiongetter"
 	"github.com/aquaproj/aqua/v2/pkg/versiongetter/goproxy"
 	"github.com/spf13/afero"
@@ -149,7 +151,8 @@ func InitializeInstallCommandController(ctx context.Context, param *config.Param
 	goInstallInstallerImpl := installpackage.NewGoInstallInstallerImpl(executor)
 	goBuildInstallerImpl := installpackage.NewGoBuildInstallerImpl(executor)
 	cargoPackageInstallerImpl := installpackage.NewCargoPackageInstallerImpl(executor, fs)
-	installpackageInstaller := installpackage.New(param, downloader, rt, fs, linker, checksumDownloaderImpl, calculator, unarchiver, verifier, slsaVerifier, minisignVerifier, ghattestationVerifier, goInstallInstallerImpl, goBuildInstallerImpl, cargoPackageInstallerImpl)
+	client := vacuum.New(fs, param)
+	installpackageInstaller := installpackage.New(param, downloader, rt, fs, linker, checksumDownloaderImpl, calculator, unarchiver, verifier, slsaVerifier, minisignVerifier, ghattestationVerifier, goInstallInstallerImpl, goBuildInstallerImpl, cargoPackageInstallerImpl, client)
 	validatorImpl := policy.NewValidator(param, fs)
 	configFinderImpl := policy.NewConfigFinder(fs)
 	configReaderImpl := policy.NewConfigReader(fs)
@@ -203,7 +206,8 @@ func InitializeExecCommandController(ctx context.Context, param *config.Param, h
 	goInstallInstallerImpl := installpackage.NewGoInstallInstallerImpl(executor)
 	goBuildInstallerImpl := installpackage.NewGoBuildInstallerImpl(executor)
 	cargoPackageInstallerImpl := installpackage.NewCargoPackageInstallerImpl(executor, fs)
-	installer := installpackage.New(param, downloader, rt, fs, linker, checksumDownloaderImpl, calculator, unarchiver, verifier, slsaVerifier, minisignVerifier, ghattestationVerifier, goInstallInstallerImpl, goBuildInstallerImpl, cargoPackageInstallerImpl)
+	client := vacuum.New(fs, param)
+	installer := installpackage.New(param, downloader, rt, fs, linker, checksumDownloaderImpl, calculator, unarchiver, verifier, slsaVerifier, minisignVerifier, ghattestationVerifier, goInstallInstallerImpl, goBuildInstallerImpl, cargoPackageInstallerImpl, client)
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs, param)
 	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(repositoriesService, httpDownloader)
@@ -214,7 +218,7 @@ func InitializeExecCommandController(ctx context.Context, param *config.Param, h
 	configFinderImpl := policy.NewConfigFinder(fs)
 	configReaderImpl := policy.NewConfigReader(fs)
 	policyReader := policy.NewReader(fs, validatorImpl, configFinderImpl, configReaderImpl)
-	execController := exec.New(installer, controller, executor, osEnv, fs, policyReader)
+	execController := exec.New(installer, controller, executor, osEnv, fs, policyReader, client)
 	return execController, nil
 }
 
@@ -244,7 +248,8 @@ func InitializeUpdateAquaCommandController(ctx context.Context, param *config.Pa
 	goInstallInstallerImpl := installpackage.NewGoInstallInstallerImpl(executor)
 	goBuildInstallerImpl := installpackage.NewGoBuildInstallerImpl(executor)
 	cargoPackageInstallerImpl := installpackage.NewCargoPackageInstallerImpl(executor, fs)
-	installer := installpackage.New(param, downloader, rt, fs, linker, checksumDownloaderImpl, calculator, unarchiver, verifier, slsaVerifier, minisignVerifier, ghattestationVerifier, goInstallInstallerImpl, goBuildInstallerImpl, cargoPackageInstallerImpl)
+	client := vacuum.New(fs, param)
+	installer := installpackage.New(param, downloader, rt, fs, linker, checksumDownloaderImpl, calculator, unarchiver, verifier, slsaVerifier, minisignVerifier, ghattestationVerifier, goInstallInstallerImpl, goBuildInstallerImpl, cargoPackageInstallerImpl, client)
 	controller := updateaqua.New(param, fs, rt, repositoriesService, installer)
 	return controller, nil
 }
@@ -275,7 +280,8 @@ func InitializeCopyCommandController(ctx context.Context, param *config.Param, h
 	goInstallInstallerImpl := installpackage.NewGoInstallInstallerImpl(executor)
 	goBuildInstallerImpl := installpackage.NewGoBuildInstallerImpl(executor)
 	cargoPackageInstallerImpl := installpackage.NewCargoPackageInstallerImpl(executor, fs)
-	installer := installpackage.New(param, downloader, rt, fs, linker, checksumDownloaderImpl, calculator, unarchiver, verifier, slsaVerifier, minisignVerifier, ghattestationVerifier, goInstallInstallerImpl, goBuildInstallerImpl, cargoPackageInstallerImpl)
+	client := vacuum.New(fs, param)
+	installer := installpackage.New(param, downloader, rt, fs, linker, checksumDownloaderImpl, calculator, unarchiver, verifier, slsaVerifier, minisignVerifier, ghattestationVerifier, goInstallInstallerImpl, goBuildInstallerImpl, cargoPackageInstallerImpl, client)
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs, param)
 	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(repositoriesService, httpDownloader)
@@ -380,4 +386,11 @@ func InitializeRemoveCommandController(ctx context.Context, param *config.Param,
 	controller := which.New(param, configFinder, configReader, installer, rt, osEnv, fs, linker)
 	removeController := remove.New(param, target, fs, rt, configFinder, configReader, installer, fuzzyfinderFinder, controller)
 	return removeController
+}
+
+func InitializeVacuumCommandController(ctx context.Context, param *config.Param, rt *runtime.Runtime) *vacuum2.Controller {
+	fs := afero.NewOsFs()
+	client := vacuum.New(fs, param)
+	controller := vacuum2.New(param, rt, fs, client)
+	return controller
 }

--- a/pkg/installpackage/aqua_test.go
+++ b/pkg/installpackage/aqua_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aquaproj/aqua/v2/pkg/slsa"
 	"github.com/aquaproj/aqua/v2/pkg/testutil"
 	"github.com/aquaproj/aqua/v2/pkg/unarchive"
+	"github.com/aquaproj/aqua/v2/pkg/vacuum"
 	"github.com/sirupsen/logrus"
 )
 
@@ -66,9 +67,10 @@ e922723678f493216c2398f3f23fb027c9a98808b49f6fce401ef82ee2c22b03  aqua_linux_arm
 			if err != nil {
 				t.Fatal(err)
 			}
+			vacuumMock := vacuum.NewMock(d.param.RootDir, nil, nil)
 			ctrl := installpackage.New(d.param, &download.Mock{
 				RC: io.NopCloser(strings.NewReader("xxx")),
-			}, d.rt, fs, installpackage.NewMockLinker(fs), d.checksumDownloader, d.checksumCalculator, &unarchive.MockUnarchiver{}, &cosign.MockVerifier{}, &slsa.MockVerifier{}, &minisign.MockVerifier{}, &ghattestation.MockVerifier{}, &installpackage.MockGoInstallInstaller{}, &installpackage.MockGoBuildInstaller{}, &installpackage.MockCargoPackageInstaller{})
+			}, d.rt, fs, installpackage.NewMockLinker(fs), d.checksumDownloader, d.checksumCalculator, &unarchive.MockUnarchiver{}, &cosign.MockVerifier{}, &slsa.MockVerifier{}, &minisign.MockVerifier{}, &ghattestation.MockVerifier{}, &installpackage.MockGoInstallInstaller{}, &installpackage.MockGoBuildInstaller{}, &installpackage.MockCargoPackageInstaller{}, vacuumMock)
 			if err := ctrl.InstallAqua(ctx, logE, d.version); err != nil {
 				if d.isErr {
 					return

--- a/pkg/installpackage/aqua_test.go
+++ b/pkg/installpackage/aqua_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func Test_installer_InstallAqua(t *testing.T) {
+func Test_installer_InstallAqua(t *testing.T) { //nolint:funlen
 	t.Parallel()
 	data := []struct {
 		name               string

--- a/pkg/installpackage/check_file.go
+++ b/pkg/installpackage/check_file.go
@@ -109,7 +109,7 @@ func (is *Installer) checkFileSrc(ctx context.Context, logE *logrus.Entry, pkg *
 		return is.checkFileSrcGo(ctx, logE, pkg, file)
 	}
 
-	pkgPath, err := pkg.PkgPath(is.rootDir, is.runtime)
+	pkgPath, err := pkg.AbsPkgPath(is.rootDir, is.runtime)
 	if err != nil {
 		return "", fmt.Errorf("get the package install path: %w", err)
 	}

--- a/pkg/installpackage/download.go
+++ b/pkg/installpackage/download.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/aquaproj/aqua/v2/pkg/download"
 	"github.com/aquaproj/aqua/v2/pkg/unarchive"
@@ -36,6 +37,13 @@ func (is *Installer) downloadWithRetry(ctx context.Context, logE *logrus.Entry, 
 					continue
 				}
 				return err
+			}
+			pkgPath, err := param.Package.PkgPath(is.runtime)
+			if err != nil {
+				return err
+			}
+			if err := is.vacuum.Update(pkgPath, time.Now()); err != nil {
+				logerr.WithError(logE, err).Warn("update the last used datetime")
 			}
 			return nil
 		}

--- a/pkg/installpackage/download.go
+++ b/pkg/installpackage/download.go
@@ -40,7 +40,7 @@ func (is *Installer) downloadWithRetry(ctx context.Context, logE *logrus.Entry, 
 			}
 			pkgPath, err := param.Package.PkgPath(is.runtime)
 			if err != nil {
-				return err
+				return fmt.Errorf("get a package path: %w", err)
 			}
 			if err := is.vacuum.Update(pkgPath, time.Now()); err != nil {
 				logerr.WithError(logE, err).Warn("update the last used datetime")

--- a/pkg/installpackage/installer_test.go
+++ b/pkg/installpackage/installer_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aquaproj/aqua/v2/pkg/slsa"
 	"github.com/aquaproj/aqua/v2/pkg/testutil"
 	"github.com/aquaproj/aqua/v2/pkg/unarchive"
+	"github.com/aquaproj/aqua/v2/pkg/vacuum"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 )
@@ -188,7 +189,8 @@ func Test_installer_InstallPackages(t *testing.T) { //nolint:funlen
 				}
 			}
 			downloader := download.NewDownloader(nil, download.NewHTTPDownloader(http.DefaultClient))
-			ctrl := installpackage.New(d.param, downloader, d.rt, fs, linker, nil, &checksum.Calculator{}, unarchive.New(d.executor, fs), &cosign.MockVerifier{}, &slsa.MockVerifier{}, &minisign.MockVerifier{}, &ghattestation.MockVerifier{}, &installpackage.MockGoInstallInstaller{}, &installpackage.MockGoBuildInstaller{}, &installpackage.MockCargoPackageInstaller{})
+			vacuumMock := vacuum.NewMock(d.param.RootDir, nil, nil)
+			ctrl := installpackage.New(d.param, downloader, d.rt, fs, linker, nil, &checksum.Calculator{}, unarchive.New(d.executor, fs), &cosign.MockVerifier{}, &slsa.MockVerifier{}, &minisign.MockVerifier{}, &ghattestation.MockVerifier{}, &installpackage.MockGoInstallInstaller{}, &installpackage.MockGoBuildInstaller{}, &installpackage.MockCargoPackageInstaller{}, vacuumMock)
 			if err := ctrl.InstallPackages(ctx, logE, &installpackage.ParamInstallPackages{
 				Config:         d.cfg,
 				Registries:     d.registries,
@@ -263,7 +265,8 @@ func Test_installer_InstallPackage(t *testing.T) { //nolint:funlen
 				t.Fatal(err)
 			}
 			downloader := download.NewDownloader(nil, download.NewHTTPDownloader(http.DefaultClient))
-			ctrl := installpackage.New(d.param, downloader, d.rt, fs, nil, nil, &checksum.Calculator{}, unarchive.New(d.executor, fs), &cosign.MockVerifier{}, &slsa.MockVerifier{}, &minisign.MockVerifier{}, &ghattestation.MockVerifier{}, &installpackage.MockGoInstallInstaller{}, &installpackage.MockGoBuildInstaller{}, &installpackage.MockCargoPackageInstaller{})
+			vacuumMock := vacuum.NewMock(d.param.RootDir, nil, nil)
+			ctrl := installpackage.New(d.param, downloader, d.rt, fs, nil, nil, &checksum.Calculator{}, unarchive.New(d.executor, fs), &cosign.MockVerifier{}, &slsa.MockVerifier{}, &minisign.MockVerifier{}, &ghattestation.MockVerifier{}, &installpackage.MockGoInstallInstaller{}, &installpackage.MockGoBuildInstaller{}, &installpackage.MockCargoPackageInstaller{}, vacuumMock)
 			if err := ctrl.InstallPackage(ctx, logE, &installpackage.ParamInstallPackage{
 				Pkg: d.pkg,
 			}); err != nil {

--- a/pkg/installpackage/link.go
+++ b/pkg/installpackage/link.go
@@ -19,7 +19,7 @@ func (is *Installer) createLinks(logE *logrus.Entry, pkgs []*config.Package) boo
 	var aquaProxyPathOnWindows string
 	if is.runtime.IsWindows() {
 		pkg := proxyPkg()
-		pkgPath, err := pkg.PkgPath(is.rootDir, is.runtime)
+		pkgPath, err := pkg.AbsPkgPath(is.rootDir, is.runtime)
 		if err != nil {
 			logerr.WithError(logE, err).Error("get a path to aqua-proxy")
 			failed = true
@@ -116,7 +116,7 @@ func (is *Installer) recreateHardLinks() error {
 	}
 
 	pkg := proxyPkg()
-	pkgPath, err := pkg.PkgPath(is.rootDir, is.runtime)
+	pkgPath, err := pkg.AbsPkgPath(is.rootDir, is.runtime)
 	if err != nil {
 		return err //nolint:wrapcheck
 	}

--- a/pkg/installpackage/proxy.go
+++ b/pkg/installpackage/proxy.go
@@ -59,7 +59,7 @@ func (is *Installer) InstallProxy(ctx context.Context, logE *logrus.Entry) error
 		return err //nolint:wrapcheck
 	}
 
-	pkgPath, err := pkg.PkgPath(is.rootDir, is.runtime)
+	pkgPath, err := pkg.AbsPkgPath(is.rootDir, is.runtime)
 	if err != nil {
 		return err //nolint:wrapcheck
 	}

--- a/pkg/installpackage/proxy_test.go
+++ b/pkg/installpackage/proxy_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aquaproj/aqua/v2/pkg/slsa"
 	"github.com/aquaproj/aqua/v2/pkg/testutil"
 	"github.com/aquaproj/aqua/v2/pkg/unarchive"
+	"github.com/aquaproj/aqua/v2/pkg/vacuum"
 	"github.com/sirupsen/logrus"
 )
 
@@ -64,7 +65,8 @@ func Test_installer_InstallProxy(t *testing.T) {
 				}
 			}
 			downloader := download.NewDownloader(nil, download.NewHTTPDownloader(http.DefaultClient))
-			ctrl := installpackage.New(d.param, downloader, d.rt, fs, linker, nil, &checksum.Calculator{}, unarchive.New(d.executor, fs), &cosign.MockVerifier{}, &slsa.MockVerifier{}, &minisign.MockVerifier{}, &ghattestation.MockVerifier{}, &installpackage.MockGoInstallInstaller{}, &installpackage.MockGoBuildInstaller{}, &installpackage.MockCargoPackageInstaller{})
+			vacuumMock := vacuum.NewMock(d.param.RootDir, nil, nil)
+			ctrl := installpackage.New(d.param, downloader, d.rt, fs, linker, nil, &checksum.Calculator{}, unarchive.New(d.executor, fs), &cosign.MockVerifier{}, &slsa.MockVerifier{}, &minisign.MockVerifier{}, &ghattestation.MockVerifier{}, &installpackage.MockGoInstallInstaller{}, &installpackage.MockGoBuildInstaller{}, &installpackage.MockCargoPackageInstaller{}, vacuumMock)
 			if err := ctrl.InstallProxy(ctx, logE); err != nil {
 				if d.isErr {
 					return

--- a/pkg/vacuum/check.go
+++ b/pkg/vacuum/check.go
@@ -1,0 +1,17 @@
+package vacuum
+
+import "time"
+
+type TimestampChecker struct {
+	threshold time.Time
+}
+
+func NewTimestampChecker(now time.Time, days int) *TimestampChecker {
+	return &TimestampChecker{
+		threshold: now.Add(-time.Duration(days) * time.Hour * 24), //nolint:mnd
+	}
+}
+
+func (c *TimestampChecker) Expired(timestamp time.Time) bool {
+	return timestamp.Before(c.threshold)
+}

--- a/pkg/vacuum/check_test.go
+++ b/pkg/vacuum/check_test.go
@@ -1,0 +1,44 @@
+package vacuum_test
+
+import (
+	"testing"
+
+	"github.com/aquaproj/aqua/v2/pkg/vacuum"
+)
+
+func TestTimestampChecker_Expired(t *testing.T) {
+	t.Parallel()
+	data := []struct {
+		name      string
+		timestamp string
+		exp       bool
+	}{
+		{
+			name:      "expired",
+			timestamp: "2025-01-13T00:14:59+09:00",
+			exp:       true,
+		},
+		{
+			name:      "not expired",
+			timestamp: "2025-01-13T00:15:01+09:00",
+		},
+	}
+	now, err := vacuum.ParseTime("2025-01-20T00:15:00+09:00")
+	if err != nil {
+		t.Fatal(err)
+	}
+	checker := vacuum.NewTimestampChecker(now, 7)
+	for _, tt := range data {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ts, err := vacuum.ParseTime(tt.timestamp)
+			if err != nil {
+				t.Fatal(err)
+			}
+			a := checker.Expired(ts)
+			if a != tt.exp {
+				t.Fatalf("wanted %v, got %v", tt.exp, a)
+			}
+		})
+	}
+}

--- a/pkg/vacuum/client.go
+++ b/pkg/vacuum/client.go
@@ -50,10 +50,25 @@ func (c *Client) Remove(pkgPath string) error {
 
 func (c *Client) Update(pkgPath string, timestamp time.Time) error {
 	dir := c.dir(pkgPath)
+	file := filepath.Join(dir, fileName)
+	return c.update(file, dir, timestamp)
+}
+
+func (c *Client) Create(pkgPath string, timestamp time.Time) error {
+	dir := c.dir(pkgPath)
+	file := filepath.Join(dir, fileName)
+	if f, err := afero.Exists(c.fs, file); err != nil {
+		return fmt.Errorf("check whether a package timestamp file exists: %w", err)
+	} else if f {
+		return nil
+	}
+	return c.update(file, dir, timestamp)
+}
+
+func (c *Client) update(file, dir string, timestamp time.Time) error {
 	if err := osfile.MkdirAll(c.fs, dir); err != nil {
 		return fmt.Errorf("create a package metadata directory: %w", err)
 	}
-	file := filepath.Join(dir, fileName)
 	timestampStr := timestamp.Format(time.RFC3339)
 	if err := afero.WriteFile(c.fs, file, []byte(timestampStr+"\n"), filePermission); err != nil {
 		return fmt.Errorf("create a package timestamp file: %w", err)

--- a/pkg/vacuum/client.go
+++ b/pkg/vacuum/client.go
@@ -20,6 +20,14 @@ const (
 	baseDir        = "metadata"
 )
 
+func FormatTime(t time.Time) string {
+	return t.Format(time.RFC3339)
+}
+
+func ParseTime(s string) (time.Time, error) {
+	return time.Parse(time.RFC3339, s) //nolint:wrapcheck
+}
+
 type Client struct {
 	fs      afero.Fs
 	rootDir string
@@ -69,7 +77,7 @@ func (c *Client) update(file, dir string, timestamp time.Time) error {
 	if err := osfile.MkdirAll(c.fs, dir); err != nil {
 		return fmt.Errorf("create a package metadata directory: %w", err)
 	}
-	timestampStr := timestamp.Format(time.RFC3339)
+	timestampStr := FormatTime(timestamp)
 	if err := afero.WriteFile(c.fs, file, []byte(timestampStr+"\n"), filePermission); err != nil {
 		return fmt.Errorf("create a package timestamp file: %w", err)
 	}
@@ -90,7 +98,7 @@ func (c *Client) FindAll(logE *logrus.Entry) (map[string]time.Time, error) {
 		if err != nil {
 			return fmt.Errorf("read a timestamp file: %w", err)
 		}
-		t, err := time.Parse(time.RFC3339, strings.TrimSpace(string(b)))
+		t, err := ParseTime(strings.TrimSpace(string(b)))
 		if err != nil {
 			logerr.WithError(logE, err).WithField("timestamp_file", path).Warn("a timestamp file is broken, so recreating it")
 			if err := c.Update(path, time.Now()); err != nil {

--- a/pkg/vacuum/client.go
+++ b/pkg/vacuum/client.go
@@ -77,9 +77,9 @@ func (c *Client) FindAll(logE *logrus.Entry) (map[string]time.Time, error) {
 		}
 		t, err := time.Parse(time.RFC3339, strings.TrimSpace(string(b)))
 		if err != nil {
-			logerr.WithError(logE, err).WithField("timestamp_file", path).Warn("a timestamp file is broken, so removing it")
-			if err := c.fs.Remove(path); err != nil {
-				return fmt.Errorf("reamove a broken package timestamp file: %w", err)
+			logerr.WithError(logE, err).WithField("timestamp_file", path).Warn("a timestamp file is broken, so recreating it")
+			if err := c.Update(path, time.Now()); err != nil {
+				return fmt.Errorf("recreate a broken package timestamp file: %w", err)
 			}
 			return nil
 		}

--- a/pkg/vacuum/client.go
+++ b/pkg/vacuum/client.go
@@ -1,0 +1,89 @@
+package vacuum
+
+import (
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/aquaproj/aqua/v2/pkg/config"
+	"github.com/aquaproj/aqua/v2/pkg/osfile"
+	"github.com/spf13/afero"
+)
+
+const (
+	filePermission = 0o644
+	fileName       = "timestamp.txt"
+	baseDir        = "metadata"
+)
+
+type Client struct {
+	fs      afero.Fs
+	rootDir string
+}
+
+func New(fs afero.Fs, param *config.Param) *Client {
+	return &Client{
+		fs:      fs,
+		rootDir: filepath.Join(param.RootDir, baseDir),
+	}
+}
+
+func (c *Client) dir(pkgPath string) string {
+	return filepath.Join(c.rootDir, pkgPath)
+}
+
+func (c *Client) file(pkgPath string) string {
+	return filepath.Join(c.dir(pkgPath), fileName)
+}
+
+func (c *Client) Remove(pkgPath string) error {
+	file := c.file(pkgPath)
+	if err := c.fs.Remove(file); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Client) Update(pkgPath string, timestamp time.Time) error {
+	dir := c.dir(pkgPath)
+	if err := osfile.MkdirAll(c.fs, dir); err != nil {
+		return err
+	}
+	file := filepath.Join(dir, fileName)
+	timestampStr := timestamp.Format(time.RFC3339)
+	if err := afero.WriteFile(c.fs, file, []byte(timestampStr), filePermission); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Client) FindAll() (map[string]time.Time, error) {
+	timestamps := map[string]time.Time{}
+	if err := afero.Walk(c.fs, c.rootDir, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		name := info.Name()
+		if name != fileName {
+			return nil
+		}
+		b, err := afero.ReadFile(c.fs, path)
+		if err != nil {
+			return err
+		}
+		t, err := time.Parse(time.RFC3339, strings.TrimSpace(string(b)))
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(c.rootDir, filepath.Dir(path))
+		if err != nil {
+			return err
+		}
+		timestamps[rel] = t
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return timestamps, nil
+}

--- a/pkg/vacuum/client.go
+++ b/pkg/vacuum/client.go
@@ -55,7 +55,7 @@ func (c *Client) Update(pkgPath string, timestamp time.Time) error {
 	}
 	file := filepath.Join(dir, fileName)
 	timestampStr := timestamp.Format(time.RFC3339)
-	if err := afero.WriteFile(c.fs, file, []byte(timestampStr), filePermission); err != nil {
+	if err := afero.WriteFile(c.fs, file, []byte(timestampStr+"\n"), filePermission); err != nil {
 		return fmt.Errorf("create a package timestamp file: %w", err)
 	}
 	return nil

--- a/pkg/vacuum/client_test.go
+++ b/pkg/vacuum/client_test.go
@@ -13,9 +13,10 @@ import (
 	"github.com/spf13/afero"
 )
 
+const rootDir = "/home/foo/.local/share/aquaproj-aqua"
+
 func TestClient_Create(t *testing.T) { //nolint:dupl
 	t.Parallel()
-	rootDir := "/home/foo/.local/share/aquaproj-aqua"
 	data := []struct {
 		name       string
 		pkgPath    string
@@ -77,7 +78,6 @@ func TestClient_Create(t *testing.T) { //nolint:dupl
 
 func TestClient_Update(t *testing.T) { //nolint:dupl
 	t.Parallel()
-	rootDir := "/home/foo/.local/share/aquaproj-aqua"
 	data := []struct {
 		name       string
 		pkgPath    string
@@ -139,7 +139,6 @@ func TestClient_Update(t *testing.T) { //nolint:dupl
 
 func TestClient_Remove(t *testing.T) {
 	t.Parallel()
-	rootDir := "/home/foo/.local/share/aquaproj-aqua"
 	data := []struct {
 		name    string
 		pkgPath string
@@ -184,7 +183,6 @@ func TestClient_Remove(t *testing.T) {
 
 func TestClient_FindAll(t *testing.T) {
 	t.Parallel()
-	rootDir := "/home/foo/.local/share/aquaproj-aqua"
 	data := []struct {
 		name  string
 		files map[string]string

--- a/pkg/vacuum/client_test.go
+++ b/pkg/vacuum/client_test.go
@@ -1,0 +1,234 @@
+package vacuum_test
+
+import (
+	"path"
+	"path/filepath"
+	"testing"
+
+	"github.com/aquaproj/aqua/v2/pkg/config"
+	"github.com/aquaproj/aqua/v2/pkg/osfile"
+	"github.com/aquaproj/aqua/v2/pkg/vacuum"
+	"github.com/google/go-cmp/cmp"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+)
+
+func TestClient_Create(t *testing.T) { //nolint:dupl
+	t.Parallel()
+	rootDir := "/home/foo/.local/share/aquaproj-aqua"
+	data := []struct {
+		name       string
+		pkgPath    string
+		timestamp  string
+		files      map[string]string
+		expPath    string
+		expContent string
+	}{
+		{
+			name:       "create",
+			pkgPath:    "pkgs/github_release/github.com/cli/cli/v2.65.0/gh_2.65.0_macOS_arm64.zip",
+			timestamp:  "2025-01-10T00:15:00+09:00",
+			expPath:    path.Join(rootDir, "metadata", "pkgs/github_release/github.com/cli/cli/v2.65.0/gh_2.65.0_macOS_arm64.zip", "timestamp.txt"),
+			expContent: "2025-01-10T00:15:00+09:00\n",
+		},
+		{
+			name:      "file exists",
+			pkgPath:   "pkgs/github_release/github.com/cli/cli/v2.65.0/gh_2.65.0_macOS_arm64.zip",
+			timestamp: "2025-01-10T00:15:00+09:00",
+			files: map[string]string{
+				path.Join(rootDir, "metadata", "pkgs/github_release/github.com/cli/cli/v2.65.0/gh_2.65.0_macOS_arm64.zip", "timestamp.txt"): "2025-01-01T00:15:00+09:00\n",
+			},
+			expPath:    path.Join(rootDir, "metadata", "pkgs/github_release/github.com/cli/cli/v2.65.0/gh_2.65.0_macOS_arm64.zip", "timestamp.txt"),
+			expContent: "2025-01-01T00:15:00+09:00\n",
+		},
+	}
+	for _, tt := range data {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fs := afero.NewMemMapFs()
+			for k, v := range tt.files {
+				if err := osfile.MkdirAll(fs, filepath.Dir(k)); err != nil {
+					t.Fatal(err)
+				}
+				if err := afero.WriteFile(fs, k, []byte(v), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			client := vacuum.New(fs, &config.Param{
+				RootDir: rootDir,
+			})
+			ts, err := vacuum.ParseTime(tt.timestamp)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := client.Create(tt.pkgPath, ts); err != nil {
+				t.Fatal(err)
+			}
+			b, err := afero.ReadFile(fs, tt.expPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tt.expContent, string(b)); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func TestClient_Update(t *testing.T) { //nolint:dupl
+	t.Parallel()
+	rootDir := "/home/foo/.local/share/aquaproj-aqua"
+	data := []struct {
+		name       string
+		pkgPath    string
+		timestamp  string
+		files      map[string]string
+		expPath    string
+		expContent string
+	}{
+		{
+			name:       "create",
+			pkgPath:    "pkgs/github_release/github.com/cli/cli/v2.65.0/gh_2.65.0_macOS_arm64.zip",
+			timestamp:  "2025-01-10T00:15:00+09:00",
+			expPath:    path.Join(rootDir, "metadata", "pkgs/github_release/github.com/cli/cli/v2.65.0/gh_2.65.0_macOS_arm64.zip", "timestamp.txt"),
+			expContent: "2025-01-10T00:15:00+09:00\n",
+		},
+		{
+			name:      "file exists (overwrite)",
+			pkgPath:   "pkgs/github_release/github.com/cli/cli/v2.65.0/gh_2.65.0_macOS_arm64.zip",
+			timestamp: "2025-01-10T00:15:00+09:00",
+			files: map[string]string{
+				path.Join(rootDir, "metadata", "pkgs/github_release/github.com/cli/cli/v2.65.0/gh_2.65.0_macOS_arm64.zip", "timestamp.txt"): "2025-01-01T00:15:00+09:00\n",
+			},
+			expPath:    path.Join(rootDir, "metadata", "pkgs/github_release/github.com/cli/cli/v2.65.0/gh_2.65.0_macOS_arm64.zip", "timestamp.txt"),
+			expContent: "2025-01-10T00:15:00+09:00\n",
+		},
+	}
+	for _, tt := range data {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fs := afero.NewMemMapFs()
+			for k, v := range tt.files {
+				if err := osfile.MkdirAll(fs, filepath.Dir(k)); err != nil {
+					t.Fatal(err)
+				}
+				if err := afero.WriteFile(fs, k, []byte(v), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			client := vacuum.New(fs, &config.Param{
+				RootDir: rootDir,
+			})
+			ts, err := vacuum.ParseTime(tt.timestamp)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := client.Update(tt.pkgPath, ts); err != nil {
+				t.Fatal(err)
+			}
+			b, err := afero.ReadFile(fs, tt.expPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tt.expContent, string(b)); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func TestClient_Remove(t *testing.T) {
+	t.Parallel()
+	rootDir := "/home/foo/.local/share/aquaproj-aqua"
+	data := []struct {
+		name    string
+		pkgPath string
+		files   map[string]string
+		expPath string
+	}{
+		{
+			name:    "remove",
+			pkgPath: "pkgs/github_release/github.com/cli/cli/v2.65.0/gh_2.65.0_macOS_arm64.zip",
+			files: map[string]string{
+				path.Join(rootDir, "metadata", "pkgs/github_release/github.com/cli/cli/v2.65.0/gh_2.65.0_macOS_arm64.zip", "timestamp.txt"): "2025-01-01T00:15:00+09:00\n",
+			},
+			expPath: path.Join(rootDir, "metadata", "pkgs/github_release/github.com/cli/cli/v2.65.0/gh_2.65.0_macOS_arm64.zip", "timestamp.txt"),
+		},
+	}
+	for _, tt := range data {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fs := afero.NewMemMapFs()
+			for k, v := range tt.files {
+				if err := osfile.MkdirAll(fs, filepath.Dir(k)); err != nil {
+					t.Fatal(err)
+				}
+				if err := afero.WriteFile(fs, k, []byte(v), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			client := vacuum.New(fs, &config.Param{
+				RootDir: rootDir,
+			})
+			if err := client.Remove(tt.pkgPath); err != nil {
+				t.Fatal(err)
+			}
+			if a, err := afero.Exists(fs, tt.expPath); err != nil {
+				t.Fatal(err)
+			} else if a {
+				t.Fatal("the file still exists")
+			}
+		})
+	}
+}
+
+func TestClient_FindAll(t *testing.T) {
+	t.Parallel()
+	rootDir := "/home/foo/.local/share/aquaproj-aqua"
+	data := []struct {
+		name  string
+		files map[string]string
+		exp   map[string]string
+	}{
+		{
+			name: "normal",
+			files: map[string]string{
+				path.Join(rootDir, "metadata", "pkgs/github_release/github.com/cli/cli/v2.65.0/gh_2.65.0_macOS_arm64.zip", "timestamp.txt"): "2025-01-01T00:15:00+09:00\n",
+				path.Join(rootDir, "metadata", "pkgs/github_release/github.com/cli/cli/v2.60.0/gh_2.60.0_macOS_arm64.zip", "timestamp.txt"): "2025-01-20T00:15:00+09:00\n",
+			},
+			exp: map[string]string{
+				"pkgs/github_release/github.com/cli/cli/v2.65.0/gh_2.65.0_macOS_arm64.zip": "2025-01-01T00:15:00+09:00",
+				"pkgs/github_release/github.com/cli/cli/v2.60.0/gh_2.60.0_macOS_arm64.zip": "2025-01-20T00:15:00+09:00",
+			},
+		},
+	}
+	logE := logrus.NewEntry(logrus.New())
+	for _, tt := range data {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fs := afero.NewMemMapFs()
+			for k, v := range tt.files {
+				if err := osfile.MkdirAll(fs, filepath.Dir(k)); err != nil {
+					t.Fatal(err)
+				}
+				if err := afero.WriteFile(fs, k, []byte(v), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			client := vacuum.New(fs, &config.Param{
+				RootDir: rootDir,
+			})
+			timestamps, err := client.FindAll(logE)
+			if err != nil {
+				t.Fatal(err)
+			}
+			a := make(map[string]string, len(timestamps))
+			for k, v := range timestamps {
+				a[k] = vacuum.FormatTime(v)
+			}
+			if diff := cmp.Diff(tt.exp, a); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}

--- a/pkg/vacuum/mock.go
+++ b/pkg/vacuum/mock.go
@@ -1,0 +1,31 @@
+package vacuum
+
+import (
+	"time"
+)
+
+type Mock struct {
+	rootDir    string
+	timestamps map[string]time.Time
+	err        error
+}
+
+func NewMock(rootDir string, timestamps map[string]time.Time, err error) *Mock {
+	return &Mock{
+		rootDir:    rootDir,
+		timestamps: timestamps,
+		err:        err,
+	}
+}
+
+func (m *Mock) Remove(pkgPath string) error {
+	return m.err
+}
+
+func (m *Mock) Update(pkgPath string, timestamp time.Time) error {
+	return m.err
+}
+
+func (m *Mock) FindAll() (map[string]time.Time, error) {
+	return m.timestamps, m.err
+}


### PR DESCRIPTION
Close #2942
- https://github.com/orgs/aquaproj/discussions/3086

```sh
aqua vacuum [--days (-d) 60]
aqua vacuum --init
```

`aqua vacuum` removes packages and timestamp files if timestamp is older than vacuum days.

`aqua vacuum --init` searches packages from aqua.yaml including global configuration files `$AQUA_GLOBAL_CONFIG` and creates timestamp files if they are installed.

## How does it work?

aqua manages each package's last used datetime in `$(aqua root-dir)/metadata/<package path>/timestamp.txt`.
aqua creates or updates these files when packages are installed or executed.
`aqua vacuum` removes packages and timestamp files if timestamp is older than vacuum days.

Until packages are installed or executed, timestamp files aren't created.
If packages don't have timestamp files, `aqua vacuum` doesn't remove those packages.

To solve the problem, `aqua vacuum --init` searches packages from aqua.yaml including global configuration files `$AQUA_GLOBAL_CONFIG` and creates timestamp files if they are installed.

## Compared with #3442

#3442 uses boltDB to manage last used dates.
On the other hand, this pr uses text files to manage them.
This pull request is much simpler than #3442 and the overhead is much cheaper.
We don't need to learn boltDB, and we don't need to maintain complicated asynchronous codes.
Complicated code makes the maintenance hard and raises bugs easily.
So simplicity is justice.

This pull request doesn't implement functions to show timestamps because the feature is used only for debug.
This pull request implements the function to initialize timestamps by the current datetime.

## Performance

```console
$ AQUA_VACUUM_DAYS=5 hyperfine -r 100 -N --warmup 3 '/Users/shunsukesuzuki/go/bin/aqua exec -- cmdx -v' '/Users/shunsukesuzuki/.local/share/aquaproj-aqua/internal/pkgs/github_release/github.com/aquaproj/aqua/v2.42.2/aqua_darwin_arm64.tar.gz/aqua exec -- cmdx -v'

Benchmark 1: /Users/shunsukesuzuki/go/bin/aqua exec -- cmdx -v
  Time (mean ± σ):      38.7 ms ±   0.9 ms    [User: 6.4 ms, System: 1.9 ms]
  Range (min … max):    37.3 ms …  42.1 ms    100 runs
 
Benchmark 2: /Users/shunsukesuzuki/.local/share/aquaproj-aqua/internal/pkgs/github_release/github.com/aquaproj/aqua/v2.42.2/aqua_darwin_arm64.tar.gz/aqua exec -- cmdx -v
  Time (mean ± σ):      41.0 ms ±   1.3 ms    [User: 5.7 ms, System: 1.8 ms]
  Range (min … max):    39.0 ms …  44.3 ms    100 runs
 
Summary
  /Users/shunsukesuzuki/go/bin/aqua exec -- cmdx -v ran
    1.06 ± 0.04 times faster than /Users/shunsukesuzuki/.local/share/aquaproj-aqua/internal/pkgs/github_release/github.com/aquaproj/aqua/v2.42.2/aqua_darwin_arm64.tar.gz/aqua exec -- cmdx -v
```