### PR TITLE
feat(init): add an option `-d` and fix the duplication check

### DIFF
--- a/pkg/cli/initcmd/command.go
+++ b/pkg/cli/initcmd/command.go
@@ -29,6 +29,7 @@ $ aqua init # create "aqua.yaml"
 $ aqua init foo.yaml # create foo.yaml
 $ aqua init -u # Replace "packages:" with "import_dir: imports"
 $ aqua init -i <directory path> # Replace "packages:" with "import_dir: <directory path>"
+$ aqua init -d # Create a directory "aqua" and create "aqua/aqua.yaml"
 `,
 		Action: ic.action,
 		Flags: []cli.Flag{
@@ -41,6 +42,11 @@ $ aqua init -i <directory path> # Replace "packages:" with "import_dir: <directo
 				Name:    "import-dir",
 				Aliases: []string{"i"},
 				Usage:   "import_dir",
+			},
+			&cli.BoolFlag{
+				Name:    "create-dir",
+				Aliases: []string{"d"},
+				Usage:   "Create a directory named aqua and create aqua.yaml in it",
 			},
 		},
 	}
@@ -58,8 +64,10 @@ func (ic *initCommand) action(c *cli.Context) error {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
 	ctrl := controller.InitializeInitCommandController(c.Context, param)
-	cParam := &initcmd.Param{}
-	cParam.ImportDir = c.String("import-dir")
+	cParam := &initcmd.Param{
+		IsDir:     c.Bool("create-dir"),
+		ImportDir: c.String("import-dir"),
+	}
 	if cParam.ImportDir == "" && c.Bool("use-import-dir") {
 		cParam.ImportDir = "imports"
 	}

--- a/pkg/config-finder/config_finder_test.go
+++ b/pkg/config-finder/config_finder_test.go
@@ -165,3 +165,46 @@ func Test_configFinderFinds(t *testing.T) {
 		})
 	}
 }
+
+func Test_DuplicateFilePaths(t *testing.T) {
+	t.Parallel()
+	cfgFilePaths := finder.ConfigFileNames()
+	data := []struct {
+		name     string
+		filePath string
+		exp      []string
+	}{
+		{
+			name:     "not file",
+			filePath: "yoo.yaml",
+			exp:      nil,
+		},
+		{
+			name:     "aqua.yaml",
+			filePath: "aqua.yaml",
+			exp:      cfgFilePaths,
+		},
+		{
+			name:     "aqua/aqua.yaml",
+			filePath: "aqua/aqua.yaml",
+			exp:      cfgFilePaths,
+		},
+	}
+	for _, d := range data {
+		t.Run(d.name, func(t *testing.T) {
+			t.Parallel()
+			arr := finder.DuplicateFilePaths(d.filePath)
+			m := make(map[string]struct{}, len(arr))
+			for _, p := range arr {
+				m[p] = struct{}{}
+			}
+			m2 := make(map[string]struct{}, len(d.exp))
+			for _, p := range d.exp {
+				m2[p] = struct{}{}
+			}
+			if diff := cmp.Diff(m2, m); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/initcmd/init.go
+++ b/pkg/controller/initcmd/init.go
@@ -60,21 +60,18 @@ type Param struct {
 	IsDir     bool
 }
 
-func (c *Controller) cfgFilePath(cfgFilePath string, param *Param) (string, error) {
+func (c *Controller) cfgFilePath(cfgFilePath string, param *Param) string {
 	if cfgFilePath != "" {
-		return cfgFilePath, nil
+		return cfgFilePath
 	}
 	if !param.IsDir {
-		return "aqua.yaml", nil
+		return "aqua.yaml"
 	}
-	return filepath.Join("aqua", "aqua.yaml"), nil
+	return filepath.Join("aqua", "aqua.yaml")
 }
 
 func (c *Controller) Init(ctx context.Context, logE *logrus.Entry, cfgFilePath string, param *Param) error {
-	cfgFilePath, err := c.cfgFilePath(cfgFilePath, param)
-	if err != nil {
-		return err
-	}
+	cfgFilePath = c.cfgFilePath(cfgFilePath, param)
 
 	for _, name := range append(finder.DuplicateFilePaths(cfgFilePath), cfgFilePath) {
 		if _, err := c.fs.Stat(name); err == nil {

--- a/pkg/controller/initcmd/init.go
+++ b/pkg/controller/initcmd/init.go
@@ -3,8 +3,10 @@ package initcmd
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 
+	finder "github.com/aquaproj/aqua/v2/pkg/config-finder"
 	"github.com/aquaproj/aqua/v2/pkg/osfile"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
@@ -55,21 +57,42 @@ func New(gh RepositoriesService, fs afero.Fs) *Controller {
 
 type Param struct {
 	ImportDir string
+	IsDir     bool
+}
+
+func (c *Controller) cfgFilePath(cfgFilePath string, param *Param) (string, error) {
+	if cfgFilePath != "" {
+		return cfgFilePath, nil
+	}
+	if !param.IsDir {
+		return "aqua.yaml", nil
+	}
+	return filepath.Join("aqua", "aqua.yaml"), nil
 }
 
 func (c *Controller) Init(ctx context.Context, logE *logrus.Entry, cfgFilePath string, param *Param) error {
-	if cfgFilePath == "" {
-		cfgFilePath = "aqua.yaml"
-	}
-	if _, err := c.fs.Stat(cfgFilePath); err == nil {
-		// configuration file already exists, then do nothing.
-		logE.WithFields(logrus.Fields{
-			"configuration_file_path": cfgFilePath,
-		}).Info("configuration file already exists")
-		return nil
+	cfgFilePath, err := c.cfgFilePath(cfgFilePath, param)
+	if err != nil {
+		return err
 	}
 
-	registryVersion := "v4.311.0" // renovate: depName=aquaproj/aqua-registry
+	for _, name := range append(finder.DuplicateFilePaths(cfgFilePath), cfgFilePath) {
+		if _, err := c.fs.Stat(name); err == nil {
+			// configuration file already exists, then do nothing.
+			logE.WithFields(logrus.Fields{
+				"configuration_file_path": name,
+			}).Info("configuration file already exists")
+			return nil
+		}
+	}
+
+	if param.IsDir {
+		if err := osfile.MkdirAll(c.fs, "aqua"); err != nil {
+			return err //nolint:wrapcheck
+		}
+	}
+
+	registryVersion := "v4.310.0" // renovate: depName=aquaproj/aqua-registry
 	release, _, err := c.github.GetLatestRelease(ctx, "aquaproj", "aqua-registry")
 	if err != nil {
 		logerr.WithError(logE, err).WithFields(logrus.Fields{


### PR DESCRIPTION
This pull request adds a command line option `-d` to `aqua init` command.

```sh
aqua init -d # Create a directory `aqua` and create `aqua/aqua.yaml`
```

Furthermore, this pull request fixes the logic to check if configuration files already exist.
`aqua init` skips creating a configuration file if configuration files already exist.