### PR TITLE
fix(update): fix a bug that `aqua up` fails if `import_dir` is used

### DIFF
--- a/.github/workflows/wc-integration-test.yaml
+++ b/.github/workflows/wc-integration-test.yaml
@@ -173,11 +173,14 @@ jobs:
       - name: Check imports/gh.yaml
         run: cat imports/gh.yaml
         working-directory: tests/import_dir
-      - name: Test import_dir (aqua up)
+      - name: Test import_dir (aqua up <pkg>)
         run: aqua up gh@v2.65.0
         working-directory: tests/import_dir
       - name: Test import_dir version
         run: cat imports/gh.yaml
+        working-directory: tests/import_dir
+      - name: Test import_dir (aqua up)
+        run: aqua up
         working-directory: tests/import_dir
 
       - name: update only registrires

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,4 +22,4 @@ linters:
     - depguard
     - tagalign
     - gomoddirectives # TODO remove
-    - exportloopref # WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar.
+    - tenv # WARN The linter 'tenv' is deprecated (since v1.64.0) due to: Duplicate feature another linter. Replaced by usetesting.

--- a/pkg/config-reader/update.go
+++ b/pkg/config-reader/update.go
@@ -43,7 +43,7 @@ func (r *ConfigReader) ReadToUpdate(configFilePath string, cfg *aqua.Config) (ma
 	return cfgs, nil
 }
 
-func (r *ConfigReader) readImportsToUpdate(configFilePath string, cfg *aqua.Config) (map[string]*aqua.Config, error) {
+func (r *ConfigReader) readImportsToUpdate(configFilePath string, cfg *aqua.Config) (map[string]*aqua.Config, error) { //nolint:cyclop
 	cfgs := map[string]*aqua.Config{}
 	pkgs := []*aqua.Package{}
 	for _, pkg := range cfg.Packages {

--- a/pkg/config-reader/update.go
+++ b/pkg/config-reader/update.go
@@ -63,7 +63,10 @@ func (r *ConfigReader) readImportsToUpdate(configFilePath string, cfg *aqua.Conf
 		}
 	}
 	if cfg.ImportDir != "" {
-		if err := r.readImportToUpdate(configFilePath, cfg.ImportDir, cfg, cfgs); err != nil {
+		if err := r.readImportToUpdate(configFilePath, filepath.Join(cfg.ImportDir, "*.yml"), cfg, cfgs); err != nil {
+			return nil, err
+		}
+		if err := r.readImportToUpdate(configFilePath, filepath.Join(cfg.ImportDir, "*.yaml"), cfg, cfgs); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
This is a bug of aqua [v2.44.0](https://github.com/aquaproj/aqua/releases/tag/v2.44.0).