### PR TITLE
feat(generate-registry): support config file and filter versions and assets

### DIFF
--- a/.github/workflows/wc-integration-test.yaml
+++ b/.github/workflows/wc-integration-test.yaml
@@ -293,6 +293,15 @@ jobs:
         run: aqua gr crates.io/skim
         env:
           GITHUB_TOKEN: ${{github.token}}
+      - name: Test aqua gr -init
+        run: aqua gr -init suzuki-shunsuke/mkghtag
+        env:
+          GITHUB_TOKEN: ${{github.token}}
+      - name: Test aqua gr -c
+        run: aqua gr -l 10 -c aqua-generate-registry.yaml
+        working-directory: tests/gr-config
+        env:
+          GITHUB_TOKEN: ${{github.token}}
 
   integration-test-all-envs:
     timeout-minutes: 30

--- a/cmd/gen-jsonschema/main.go
+++ b/cmd/gen-jsonschema/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aquaproj/aqua/v2/pkg/config/aqua"
 	"github.com/aquaproj/aqua/v2/pkg/config/registry"
+	genrgst "github.com/aquaproj/aqua/v2/pkg/controller/generate-registry"
 	"github.com/aquaproj/aqua/v2/pkg/policy"
 	"github.com/suzuki-shunsuke/gen-go-jsonschema/jsonschema"
 )
@@ -24,6 +25,9 @@ func core() error {
 		return fmt.Errorf("create or update a JSON Schema: %w", err)
 	}
 	if err := jsonschema.Write(&policy.ConfigYAML{}, "json-schema/policy.json"); err != nil {
+		return fmt.Errorf("create or update a JSON Schema: %w", err)
+	}
+	if err := jsonschema.Write(&genrgst.RawConfig{}, "json-schema/aqua-generate-registry.json"); err != nil {
 		return fmt.Errorf("create or update a JSON Schema: %w", err)
 	}
 	return nil

--- a/json-schema/aqua-generate-registry.json
+++ b/json-schema/aqua-generate-registry.json
@@ -10,10 +10,16 @@
         },
         "asset": {
           "type": "string"
+        },
+        "package": {
+          "type": "string"
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "required": [
+        "package"
+      ]
     }
   }
 }

--- a/json-schema/aqua-generate-registry.json
+++ b/json-schema/aqua-generate-registry.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/aquaproj/aqua/v2/pkg/controller/generate-registry/raw-config",
+  "$ref": "#/$defs/RawConfig",
+  "$defs": {
+    "RawConfig": {
+      "properties": {
+        "excluded_versions": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "excluded_assets": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/json-schema/aqua-generate-registry.json
+++ b/json-schema/aqua-generate-registry.json
@@ -5,17 +5,11 @@
   "$defs": {
     "RawConfig": {
       "properties": {
-        "excluded_versions": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
+        "version": {
+          "type": "string"
         },
-        "excluded_assets": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
+        "asset": {
+          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/pkg/cli/genr/command.go
+++ b/pkg/cli/genr/command.go
@@ -108,6 +108,11 @@ func New(r *util.Param) *cli.Command {
 				Name:  "cmd",
 				Usage: "A list of commands joined with commas ','",
 			},
+			&cli.StringFlag{
+				Name:    "generate-config",
+				Aliases: []string{"c"},
+				Usage:   "A configuration file path",
+			},
 			&cli.IntFlag{
 				Name:    "limit",
 				Aliases: []string{"l"},
@@ -116,6 +121,10 @@ func New(r *util.Param) *cli.Command {
 			&cli.BoolFlag{
 				Name:  "deep",
 				Usage: "This flag was deprecated and had no meaning from aqua v2.15.0. This flag will be removed in aqua v3.0.0. https://github.com/aquaproj/aqua/issues/2351",
+			},
+			&cli.BoolFlag{
+				Name:  "init-config",
+				Usage: "Generate a configuration file",
 			},
 		},
 	}

--- a/pkg/cli/genr/command.go
+++ b/pkg/cli/genr/command.go
@@ -123,7 +123,7 @@ func New(r *util.Param) *cli.Command {
 				Usage: "This flag was deprecated and had no meaning from aqua v2.15.0. This flag will be removed in aqua v3.0.0. https://github.com/aquaproj/aqua/issues/2351",
 			},
 			&cli.BoolFlag{
-				Name:  "init-config",
+				Name:  "init",
 				Usage: "Generate a configuration file",
 			},
 		},

--- a/pkg/cli/util/util.go
+++ b/pkg/cli/util/util.go
@@ -43,9 +43,11 @@ func SetParam(c *cli.Context, logE *logrus.Entry, commandName string, param *con
 		param.LogLevel = logLevel
 	}
 	param.ConfigFilePath = c.String("config")
+	param.GenerateConfigFilePath = c.String("generate-config")
 	param.Dest = c.String("o")
 	param.OutTestData = c.String("out-testdata")
 	param.OnlyLink = c.Bool("only-link")
+	param.InitConfig = c.Bool("init-config")
 	if commandName == "generate-registry" {
 		param.InsertFile = c.String("i")
 	} else {

--- a/pkg/cli/util/util.go
+++ b/pkg/cli/util/util.go
@@ -47,7 +47,7 @@ func SetParam(c *cli.Context, logE *logrus.Entry, commandName string, param *con
 	param.Dest = c.String("o")
 	param.OutTestData = c.String("out-testdata")
 	param.OnlyLink = c.Bool("only-link")
-	param.InitConfig = c.Bool("init-config")
+	param.InitConfig = c.Bool("init")
 	if commandName == "generate-registry" {
 		param.InsertFile = c.String("i")
 	} else {

--- a/pkg/config/package.go
+++ b/pkg/config/package.go
@@ -259,6 +259,7 @@ type RemoveMode struct {
 
 type Param struct {
 	ConfigFilePath                    string
+	GenerateConfigFilePath            string
 	LogLevel                          string
 	File                              string
 	AQUAVersion                       string
@@ -303,6 +304,7 @@ type Param struct {
 	GitHubArtifactAttestationDisabled bool
 	SLSADisabled                      bool
 	Installed                         bool
+	InitConfig                        bool
 }
 
 func appendExt(s, format string) string {

--- a/pkg/controller/generate-registry/confg.go
+++ b/pkg/controller/generate-registry/confg.go
@@ -27,17 +27,22 @@ func (c *Config) FromRaw(raw *RawConfig) error {
 	}
 
 	c.Package = raw.Package
-	r, err := expr.CompileVersionFilter(raw.Version)
-	if err != nil {
-		return fmt.Errorf("compile a version expression: %w", err)
-	}
-	c.Version = r
 
-	a, err := expr.CompileAssetFilter(raw.Asset)
-	if err != nil {
-		return fmt.Errorf("compile an asset expression: %w", err)
+	if raw.Version != "" {
+		r, err := expr.CompileVersionFilter(raw.Version)
+		if err != nil {
+			return fmt.Errorf("compile a version expression: %w", err)
+		}
+		c.Version = r
 	}
-	c.Asset = a
+
+	if raw.Asset != "" {
+		a, err := expr.CompileAssetFilter(raw.Asset)
+		if err != nil {
+			return fmt.Errorf("compile an asset expression: %w", err)
+		}
+		c.Asset = a
+	}
 
 	return nil
 }

--- a/pkg/controller/generate-registry/confg.go
+++ b/pkg/controller/generate-registry/confg.go
@@ -12,11 +12,13 @@ import (
 type Config struct {
 	Version *vm.Program
 	Asset   *vm.Program
+	Package string
 }
 
 type RawConfig struct {
 	Version string `json:"version,omitempty"`
 	Asset   string `json:"asset,omitempty"`
+	Package string `json:"package"`
 }
 
 func (c *Config) FromRaw(raw *RawConfig) error {
@@ -24,6 +26,7 @@ func (c *Config) FromRaw(raw *RawConfig) error {
 		return nil
 	}
 
+	c.Package = raw.Package
 	r, err := expr.CompileVersionFilter(raw.Version)
 	if err != nil {
 		return fmt.Errorf("compile a version expression: %w", err)

--- a/pkg/controller/generate-registry/confg.go
+++ b/pkg/controller/generate-registry/confg.go
@@ -1,0 +1,56 @@
+package genrgst
+
+import (
+	"fmt"
+
+	"github.com/aquaproj/aqua/v2/pkg/expr"
+	"github.com/expr-lang/expr/vm"
+	"github.com/spf13/afero"
+	"gopkg.in/yaml.v3"
+)
+
+type Config struct {
+	Version *vm.Program
+	Asset   *vm.Program
+}
+
+type RawConfig struct {
+	Version string `json:"version,omitempty"`
+	Asset   string `json:"asset,omitempty"`
+}
+
+func (c *Config) FromRaw(raw *RawConfig) error {
+	if raw == nil {
+		return nil
+	}
+
+	r, err := expr.CompileVersionFilter(raw.Version)
+	if err != nil {
+		return fmt.Errorf("compile a version expression: %w", err)
+	}
+	c.Version = r
+
+	a, err := expr.CompileAssetFilter(raw.Asset)
+	if err != nil {
+		return fmt.Errorf("compile an asset expression: %w", err)
+	}
+	c.Asset = a
+
+	return nil
+}
+
+func readConfig(fs afero.Fs, path string, cfg *Config) error {
+	if path == "" {
+		return nil
+	}
+	f, err := fs.Open(path)
+	if err != nil {
+		return fmt.Errorf("open a generate configuration file: %w", err)
+	}
+	defer f.Close()
+	raw := &RawConfig{}
+	if err := yaml.NewDecoder(f).Decode(raw); err != nil {
+		return fmt.Errorf("decode a generate configuration file as YAML: %w", err)
+	}
+	return cfg.FromRaw(raw)
+}

--- a/pkg/controller/generate-registry/generate.go
+++ b/pkg/controller/generate-registry/generate.go
@@ -75,7 +75,7 @@ func (c *Controller) GenerateRegistry(ctx context.Context, param *config.Param, 
 func parseArgs(args []string, cfg *Config) ([]string, error) {
 	if len(args) == 0 {
 		if cfg.Package == "" {
-			return nil, nil //nolint:nilnil
+			return nil, nil
 		}
 		return []string{cfg.Package}, nil
 	}

--- a/pkg/controller/generate-registry/generate.go
+++ b/pkg/controller/generate-registry/generate.go
@@ -183,8 +183,17 @@ func (c *Controller) getPackageInfoMain(ctx context.Context, logE *logrus.Entry,
 		return pkgInfo, []string{version}
 	}
 	logE.WithField("version", release.GetTagName()).Debug("got the release")
-	assets := c.listReleaseAssets(ctx, logE, pkgInfo, release.GetID())
-	logE.WithField("num_of_assets", len(assets)).Debug("got assets")
+
+	arr := c.listReleaseAssets(ctx, logE, pkgInfo, release.GetID())
+	logE.WithField("num_of_assets", len(arr)).Debug("got assets")
+	assets := make([]*github.ReleaseAsset, 0, len(arr))
+	for _, asset := range arr {
+		if excludeAsset(logE, asset.GetName(), cfg) {
+			continue
+		}
+		assets = append(assets, asset)
+	}
+
 	c.patchRelease(logE, pkgInfo, pkgName, release.GetTagName(), assets)
 	return pkgInfo, []string{version}
 }

--- a/pkg/controller/generate-registry/generate.go
+++ b/pkg/controller/generate-registry/generate.go
@@ -58,7 +58,7 @@ func (c *Controller) GenerateRegistry(ctx context.Context, param *config.Param, 
 		}
 		args = []string{cfg.Package}
 	} else {
-		if cfg.Package != args[0] {
+		if cfg.Package != "" && cfg.Package != args[0] {
 			return logerr.WithFields(errors.New("a given package name is different from the package name in the configuration file"), logrus.Fields{ //nolint:wrapcheck
 				"arg":               args[0],
 				"package_in_config": cfg.Package,

--- a/pkg/controller/generate-registry/generate.go
+++ b/pkg/controller/generate-registry/generate.go
@@ -52,18 +52,12 @@ func (c *Controller) GenerateRegistry(ctx context.Context, param *config.Param, 
 		}
 	}
 
+	args, err := parseArgs(args, cfg)
+	if err != nil {
+		return err
+	}
 	if len(args) == 0 {
-		if cfg.Package == "" {
-			return nil
-		}
-		args = []string{cfg.Package}
-	} else {
-		if cfg.Package != "" && cfg.Package != args[0] {
-			return logerr.WithFields(errors.New("a given package name is different from the package name in the configuration file"), logrus.Fields{ //nolint:wrapcheck
-				"arg":               args[0],
-				"package_in_config": cfg.Package,
-			})
-		}
+		return nil
 	}
 
 	if param.Limit < 0 {
@@ -76,6 +70,22 @@ func (c *Controller) GenerateRegistry(ctx context.Context, param *config.Param, 
 		}
 	}
 	return nil
+}
+
+func parseArgs(args []string, cfg *Config) ([]string, error) {
+	if len(args) == 0 {
+		if cfg.Package == "" {
+			return nil, nil //nolint:nilnil
+		}
+		return []string{cfg.Package}, nil
+	}
+	if cfg.Package != "" && cfg.Package != args[0] {
+		return nil, logerr.WithFields(errors.New("a given package name is different from the package name in the configuration file"), logrus.Fields{ //nolint:wrapcheck
+			"arg":               args[0],
+			"package_in_config": cfg.Package,
+		})
+	}
+	return args, nil
 }
 
 func (c *Controller) genRegistry(ctx context.Context, param *config.Param, logE *logrus.Entry, cfg *Config, pkgName string) error {

--- a/pkg/controller/generate-registry/generate_internal_test.go
+++ b/pkg/controller/generate-registry/generate_internal_test.go
@@ -140,7 +140,7 @@ func TestController_getPackageInfo(t *testing.T) { //nolint:funlen
 				CratePayload: d.crate,
 			}
 			ctrl := NewController(nil, gh, nil, cargoClient)
-			pkgInfo, _ := ctrl.getPackageInfo(ctx, logE, d.pkgName, &config.Param{})
+			pkgInfo, _ := ctrl.getPackageInfo(ctx, logE, d.pkgName, &config.Param{}, &Config{})
 			if diff := cmp.Diff(d.exp, pkgInfo); diff != "" {
 				t.Fatal(diff)
 			}

--- a/pkg/controller/generate-registry/version_overrides.go
+++ b/pkg/controller/generate-registry/version_overrides.go
@@ -48,6 +48,9 @@ func listPkgsFromVersions(pkgName string, versions []string) []*aqua.Package {
 }
 
 func excludeVersion(logE *logrus.Entry, tag string, cfg *Config) bool {
+	if cfg.Version == nil {
+		return false
+	}
 	f, err := expr.EvaluateVersionFilter(cfg.Version, tag)
 	if err != nil {
 		logerr.WithError(logE, err).WithField("tag_name", tag).Warn("evaluate a version filter")
@@ -57,6 +60,9 @@ func excludeVersion(logE *logrus.Entry, tag string, cfg *Config) bool {
 }
 
 func excludeAsset(logE *logrus.Entry, asset string, cfg *Config) bool {
+	if cfg.Asset == nil {
+		return false
+	}
 	f, err := expr.EvaluateAssetFilter(cfg.Asset, asset)
 	if err != nil {
 		logerr.WithError(logE, err).WithField("asset", asset).Warn("evaluate an asset filter")

--- a/pkg/expr/asset_filter.go
+++ b/pkg/expr/asset_filter.go
@@ -1,0 +1,18 @@
+package expr
+
+import (
+	"github.com/expr-lang/expr"
+	"github.com/expr-lang/expr/vm"
+)
+
+func CompileAssetFilter(assetFilter string) (*vm.Program, error) {
+	return expr.Compile(assetFilter, expr.AsBool(), expr.Env(map[string]any{ //nolint:wrapcheck
+		"Asset": "",
+	}))
+}
+
+func EvaluateAssetFilter(prog *vm.Program, asset string) (bool, error) {
+	return evaluateBoolProg(prog, map[string]any{
+		"Asset": asset,
+	})
+}

--- a/tests/gr-config/aqua-generate-registry.yaml
+++ b/tests/gr-config/aqua-generate-registry.yaml
@@ -1,0 +1,6 @@
+---
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+package: fission/fission
+version: Version matches "^v?\\d"
+asset: not ((Asset matches "\\.json$") or (Asset matches "\\.yaml$"))


### PR DESCRIPTION
Close #3561

This pull request enables you to filter versions and assets when running `aqua gr` command.

Scaffold configuration file `aqua-generate-registry.yaml`:

```sh
aqua gr -init <package name>
```

aqua-generate-registry.yaml:

```yaml
# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
# aqua - Declarative CLI Version Manager
# https://aquaproj.github.io/
package: <package name>
version: not (Version matches "-rc$")
asset: not (Asset matches "-cli")
```

The fields `version` and `asset` are expr's expressions.

https://expr-lang.org/docs/language-definition

These expressions must return boolean.
If they return true, the version and asset are used.
Otherwise, they are ignored.

```yaml
- version:
  - inputs:
    - Version: A package version
  - Available functions:
    - semver
    - semverWithVersion
- asset
  - inputs:
    - Asset: An asset name
``` 

For instance, `version: not (Version matches "-rc$")` excludes versions with the suffix `-rc`.

```sh
aqua gr -c aqua-generate-registry.yaml
```

## Example

In this example, we create the registry for fission/fission.

1. Generate aqua-generate-registry.yaml.

```sh
aqua gr -init fission/fission
```

aqua-generate-registry.yaml is generated:

```yaml
---
# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
# aqua - Declarative CLI Version Manager
# https://aquaproj.github.io/
package: fission/fission
version: not (Version matches "-rc$")
asset: not (Asset matches "-cli")
```

2. Update version and asset:

```yaml
---
# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
# aqua - Declarative CLI Version Manager
# https://aquaproj.github.io/
package: fission/fission
version: Version matches "^v?\\d"
asset: not ((Asset matches "\\.json$") or (Asset matches "\\.yaml$")) # Ignore JSON and YAML
```

3. Generate registry:

```sh
aqua gr -c aqua-generate-registry.yaml
```

## Practice

I think `asset` should be an expression to negate.

⭕ 

```yaml
asset: not (Asset matches "bar")
```

❌ 

```yaml
asset: Asset matches "foo"
```

Because `Asset matches "foo"` excludes assets like `SHA256SUM` and `multiple.intoto.jsonl`.
And it's hard to find the mistake.
So you should specify excluded assets explicitly.