### PR TITLE
ci: specify config to prevent cosign from being installed before testing

### DIFF
--- a/.github/workflows/wc-integration-test.yaml
+++ b/.github/workflows/wc-integration-test.yaml
@@ -330,7 +330,7 @@ jobs:
       - run: aqua policy allow
 
       - name: Test minisign
-        run: aqua i
+        run: aqua -c aqua.yaml i
         working-directory: tests/minisign
       - name: test Cosign, SLSA, and GitHub Artifact Attestations
         run: aqua i


### PR DESCRIPTION
Close #3524