### PR TITLE
fix: support signer_workflow too

### DIFF
--- a/json-schema/registry.json
+++ b/json-schema/registry.json
@@ -254,6 +254,9 @@
         "enabled": {
           "type": "boolean"
         },
+        "signer_workflow": {
+          "type": "string"
+        },
         "signer-workflow": {
           "type": "string"
         }

--- a/pkg/config/registry/github_cli.go
+++ b/pkg/config/registry/github_cli.go
@@ -1,8 +1,21 @@
 package registry
 
 type GitHubArtifactAttestations struct {
-	Enabled        *bool  `json:"enabled,omitempty"`
-	SignerWorkflow string `yaml:"signer-workflow,omitempty" json:"signer-workflow,omitempty"`
+	Enabled *bool `json:"enabled,omitempty"`
+	// https://github.com/aquaproj/aqua/issues/3581
+	SignerWorkflow2 string `yaml:"signer_workflow,omitempty" json:"signer_workflow,omitempty"`
+	// Deprecated: We'll remove signer-workflow at aqua v3.
+	SignerWorkflow3 string `yaml:"signer-workflow,omitempty" json:"signer-workflow,omitempty"`
+}
+
+func (m *GitHubArtifactAttestations) SignerWorkflow() string {
+	if m == nil {
+		return ""
+	}
+	if m.SignerWorkflow2 != "" {
+		return m.SignerWorkflow2
+	}
+	return m.SignerWorkflow3
 }
 
 func (m *GitHubArtifactAttestations) GetEnabled() bool {

--- a/pkg/installpackage/verify_github_artifact_attestation.go
+++ b/pkg/installpackage/verify_github_artifact_attestation.go
@@ -40,7 +40,7 @@ func (g *gitHubArtifactAttestationsVerifier) Verify(ctx context.Context, logE *l
 	if err := g.ghVerifier.Verify(ctx, logE, &ghattestation.ParamVerify{
 		Repository:     g.pkg.PackageInfo.RepoOwner + "/" + g.pkg.PackageInfo.RepoName,
 		ArtifactPath:   file,
-		SignerWorkflow: g.gaa.SignerWorkflow,
+		SignerWorkflow: g.gaa.SignerWorkflow(),
 	}); err != nil {
 		return fmt.Errorf("verify a package with gh attestation: %w", err)
 	}


### PR DESCRIPTION
Close #3581

This pull request enables aqua to support not only `signer-workflow` but also `signer_workflow`.
At aqua v3, we will remove the support of `signer-workflow`.