### PR TITLE
feat: generate checksum cosign config

### DIFF
--- a/pkg/controller/generate-registry/group.go
+++ b/pkg/controller/generate-registry/group.go
@@ -238,7 +238,7 @@ func groupByExcludedAsset(groups []*Group) []*Group {
 	return newGroups
 }
 
-func (c *Controller) group(logE *logrus.Entry, pkgName string, releases []*Release) []*Group {
+func (c *Controller) group(logE *logrus.Entry, pkgInfo *registry.PackageInfo, pkgName string, releases []*Release) []*Group {
 	if len(releases) == 0 {
 		return nil
 	}
@@ -248,7 +248,10 @@ func (c *Controller) group(logE *logrus.Entry, pkgName string, releases []*Relea
 
 	for _, group := range groups {
 		release := group.releases[0]
-		pkgInfo := &registry.PackageInfo{}
+		pkgInfo := &registry.PackageInfo{
+			RepoOwner: pkgInfo.RepoOwner,
+			RepoName:  pkgInfo.RepoName,
+		}
 		c.patchRelease(logE, pkgInfo, pkgName, release.Tag, release.assets)
 		group.pkg = &Package{
 			Info:    pkgInfo,
@@ -283,5 +286,5 @@ func (c *Controller) group(logE *logrus.Entry, pkgName string, releases []*Relea
 }
 
 func (c *Controller) generatePackage(logE *logrus.Entry, pkgInfo *registry.PackageInfo, pkgName string, releases []*Release) []string {
-	return mergeGroups(pkgInfo, c.group(logE, pkgName, releases))
+	return mergeGroups(pkgInfo, c.group(logE, pkgInfo, pkgName, releases))
 }


### PR DESCRIPTION
This adds support for generating cosign configs for checksum files in `gr`.

Lightly tested, may have bugs. But a happy path exists: https://github.com/aquaproj/aqua-registry/pull/33234

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: https://github.com/aquaproj/aqua-registry/issues/32207#issuecomment-2661324286
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [ ] Do only one thing in one Pull Request

<!-- Please write the description here -->
