### PR TITLE
feat: make trimAssetExt available in templates

### DIFF
--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -7,6 +7,8 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
+
+	"github.com/aquaproj/aqua/v2/pkg/asset"
 )
 
 func Compile(s string) (*template.Template, error) {
@@ -16,6 +18,10 @@ func Compile(s string) (*template.Template, error) {
 	delete(fncs, "expandenv")
 	delete(fncs, "getHostByName")
 	return template.New("_").Funcs(fncs).Funcs(template.FuncMap{ //nolint:wrapcheck
+		"trimAssetExt": func(s string) string {
+			s, _ = asset.RemoveExtFromAsset(s)
+			return s
+		},
 		"trimV": func(s string) string {
 			return strings.TrimPrefix(s, "v")
 		},

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -35,6 +35,14 @@ func TestExecute(t *testing.T) {
 			},
 			isErr: true,
 		},
+		{
+			name: "asset ext",
+			s:    "{{trimAssetExt .Asset}}",
+			input: map[string]string{
+				"Asset": "foo-1.0.0-darwin-amd64.tar.gz",
+			},
+			exp: "foo-1.0.0-darwin-amd64",
+		},
 	}
 	for _, d := range data {
 		t.Run(d.name, func(t *testing.T) {


### PR DESCRIPTION
For example for use in cosign options. Another alternative is to make AssetWithoutExt more widely available, but this would sound like a more general way to handle it.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
  - [ ] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [ ] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue:
- [ ] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [ ] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [ ] Do only one thing in one Pull Request

<!-- Please write the description here -->
