### PR TITLE
fix(gr): use cosign cert if sig is keyless, not pubkey even if available

### DIFF
--- a/pkg/controller/generate-registry/generate.go
+++ b/pkg/controller/generate-registry/generate.go
@@ -316,7 +316,7 @@ func findCertificate(assetNames map[string]struct{}, checksumAssetName string) s
 	return ""
 }
 
-func checkChecksumCosign(pkgInfo *registry.PackageInfo, checksumAssetName string, assetNames map[string]struct{}) *registry.Cosign { //nolint:cyclop
+func checkChecksumCosign(pkgInfo *registry.PackageInfo, checksumAssetName string, assetNames map[string]struct{}) *registry.Cosign {
 	signatureAssetName := findSignature(assetNames, checksumAssetName)
 	if signatureAssetName == "" {
 		return nil

--- a/pkg/controller/generate-registry/generate.go
+++ b/pkg/controller/generate-registry/generate.go
@@ -305,16 +305,19 @@ func checkChecksumCosign(pkgInfo *registry.PackageInfo, checksumAssetName string
 			break
 		}
 	}
-	if pubKeyAssetName == "" {
-		for _, suf := range []string{"-keyless.pem", ".pem"} {
-			if _, ok := assetNames[checksumAssetName+suf]; ok {
-				certificateAssetName = checksumAssetName + suf
-				break
-			}
+	for _, suf := range []string{"-keyless.pem", ".pem"} {
+		if _, ok := assetNames[checksumAssetName+suf]; ok {
+			certificateAssetName = checksumAssetName + suf
+			break
 		}
-		if certificateAssetName == "" {
-			return nil
-		}
+	}
+
+	if strings.HasSuffix(signatureAssetName, "-keyless.sig") {
+		// Do not try with pubkey
+		pubKeyAssetName = ""
+	}
+	if pubKeyAssetName == "" && certificateAssetName == "" {
+		return nil
 	}
 
 	downloadURL := fmt.Sprintf("https://github.com/%s/%s/releases/download/{{.Version}}/",


### PR DESCRIPTION
For example in https://github.com/sigstore/cosign/releases/tag/v2.4.3

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [ ] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue:
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->
