### PR TITLE
feat: support cosign veryf-blob's --bundle option

### DIFF
--- a/json-schema/registry.json
+++ b/json-schema/registry.json
@@ -156,6 +156,9 @@
         },
         "key": {
           "$ref": "#/$defs/DownloadedFile"
+        },
+        "bundle": {
+          "$ref": "#/$defs/DownloadedFile"
         }
       },
       "additionalProperties": false,

--- a/pkg/config/registry/cosign.go
+++ b/pkg/config/registry/cosign.go
@@ -13,6 +13,7 @@ type Cosign struct {
 	Signature   *DownloadedFile `json:"signature,omitempty"`
 	Certificate *DownloadedFile `json:"certificate,omitempty"`
 	Key         *DownloadedFile `json:"key,omitempty"`
+	Bundle      *DownloadedFile `json:"bundle,omitempty"`
 }
 
 type DownloadedFile struct {

--- a/pkg/config/registry/cosign.go
+++ b/pkg/config/registry/cosign.go
@@ -31,7 +31,7 @@ func (c *Cosign) GetEnabled() bool {
 	if c.Enabled != nil {
 		return *c.Enabled
 	}
-	return len(c.Opts) != 0 || c.Signature != nil || c.Certificate != nil || c.Key != nil
+	return len(c.Opts) != 0 || c.Signature != nil || c.Certificate != nil || c.Key != nil || c.Bundle != nil
 }
 
 func (c *Cosign) RenderOpts(rt *runtime.Runtime, art *template.Artifact) ([]string, error) {

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -86,6 +86,7 @@ func (v *Verifier) Verify(ctx context.Context, logE *logrus.Entry, rt *runtime.R
 		"signature":   cos.Signature,
 		"key":         cos.Key,
 		"certificate": cos.Certificate,
+		"bundle":      cos.Bundle,
 	}
 	for name, df := range files {
 		if df == nil {


### PR DESCRIPTION
Close https://github.com/aquaproj/aqua/issues/3682

https://aquaproj.github.io/docs/reference/registry-config/cosign/

This pull request adds a field `.cosign.bundle` to support `cosign verify-blob`'s `--bundle` option.
This is same with cosign's other settings such as `key`, `certificate`, and `signature`.

e.g. https://github.com/cert-manager/cmctl/releases/tag/v2.1.1

```yaml
cosign:
  bundle:
    type: github_release
    asset: checksums.txt.cosign.bundle
```