### PR TITLE
fix: fix a panic on the platform where minisign isn't supported

### DIFF
--- a/.github/workflows/wc-integration-test.yaml
+++ b/.github/workflows/wc-integration-test.yaml
@@ -312,6 +312,7 @@ jobs:
         env:
           - runs-on: windows-latest
           - runs-on: ubuntu-24.04
+          - runs-on: ubuntu-24.04-arm
           - runs-on: macos-13
           - runs-on: macos-14
     env:

--- a/pkg/minisign/exec.go
+++ b/pkg/minisign/exec.go
@@ -70,6 +70,12 @@ func wait(ctx context.Context, logE *logrus.Entry, retryCount int) error {
 }
 
 func (e *ExecutorImpl) exec(ctx context.Context, args []string) error {
+	if e == nil {
+		return errors.New("executor is nil")
+	}
+	if e.executor == nil {
+		return errors.New("e.executor is nil")
+	}
 	_, err := e.executor.ExecStderr(osexec.Command(ctx, e.minisignExePath, args...))
 	return err //nolint:wrapcheck
 }
@@ -77,6 +83,9 @@ func (e *ExecutorImpl) exec(ctx context.Context, args []string) error {
 var errVerify = errors.New("verify with minisign")
 
 func (e *ExecutorImpl) Verify(ctx context.Context, logE *logrus.Entry, param *ParamVerify, signature string) error {
+	if e == nil {
+		return errors.New("executor is nil")
+	}
 	// minisign -Vm myfile.txt -P RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3
 	args := []string{
 		"-Vm",

--- a/pkg/minisign/package.go
+++ b/pkg/minisign/package.go
@@ -4,97 +4,100 @@ import (
 	"github.com/aquaproj/aqua/v2/pkg/config"
 	"github.com/aquaproj/aqua/v2/pkg/config/aqua"
 	"github.com/aquaproj/aqua/v2/pkg/config/registry"
-	"github.com/aquaproj/aqua/v2/pkg/ptr"
 )
 
 func Package() *config.Package { //nolint:funlen
-	return &config.Package{
-		Package: &aqua.Package{
-			Name:    "jedisct1/minisign",
-			Version: Version,
-		},
-		PackageInfo: &registry.PackageInfo{
-			Type:               "github_release",
-			RepoOwner:          "jedisct1",
-			RepoName:           "minisign",
-			VersionConstraints: `false`,
-			VersionOverrides: []*registry.VersionOverride{
-				{
-					VersionConstraints:  `Version == "0.11"`,
-					Asset:               "minisign-{{.Version}}-{{.OS}}.{{.Format}}",
-					Format:              "zip",
-					Rosetta2:            ptr.Bool(true),
-					WindowsARMEmulation: ptr.Bool(true),
-					Replacements: map[string]string{
-						"darwin":  "macos",
-						"windows": "win64",
-						"amd64":   "x86_64",
-						"arm64":   "aarch64",
-					},
-					Overrides: []*registry.Override{
-						{
-							GOOS:   "linux",
-							Format: "tar.gz",
-							Files: []*registry.File{
-								{
-									Name: "minisign",
-									Src:  "minisign-{{.OS}}/{{.Arch}}/minisign",
-								},
-							},
-						},
-						{
-							GOOS: "windows",
-							Files: []*registry.File{
-								{
-									Name: "minisign",
-									Src:  "minisign-win64/minisign.exe",
-								},
+	pkg := &aqua.Package{
+		Name:    "jedisct1/minisign",
+		Version: Version,
+	}
+	if Version == "0.11" {
+		return &config.Package{
+			Package: pkg,
+			PackageInfo: &registry.PackageInfo{
+				Type:                "github_release",
+				RepoOwner:           "jedisct1",
+				RepoName:            "minisign",
+				VersionConstraints:  `false`,
+				Asset:               "minisign-{{.Version}}-{{.OS}}.{{.Format}}",
+				Format:              "zip",
+				Rosetta2:            true,
+				WindowsARMEmulation: true,
+				Replacements: map[string]string{
+					"darwin":  "macos",
+					"windows": "win64",
+					"amd64":   "x86_64",
+					"arm64":   "aarch64",
+				},
+				Overrides: []*registry.Override{
+					{
+						GOOS:   "linux",
+						Format: "tar.gz",
+						Files: []*registry.File{
+							{
+								Name: "minisign",
+								Src:  "minisign-{{.OS}}/{{.Arch}}/minisign",
 							},
 						},
 					},
-					SupportedEnvs: []string{
-						"darwin",
-						"windows",
-						"amd64",
+					{
+						GOOS: "windows",
+						Files: []*registry.File{
+							{
+								Name: "minisign",
+								Src:  "minisign-win64/minisign.exe",
+							},
+						},
 					},
 				},
+				SupportedEnvs: []string{
+					"darwin",
+					"windows",
+					"amd64",
+				},
+			},
+		}
+	}
+	return &config.Package{
+		Package: pkg,
+		PackageInfo: &registry.PackageInfo{
+			Type:                "github_release",
+			RepoOwner:           "jedisct1",
+			RepoName:            "minisign",
+			VersionConstraints:  `false`,
+			Asset:               "minisign-{{.Version}}-{{.OS}}.{{.Format}}",
+			Format:              "zip",
+			WindowsARMEmulation: true,
+			Files: []*registry.File{
 				{
-					VersionConstraints:  `true`,
-					Asset:               "minisign-{{.Version}}-{{.OS}}.{{.Format}}",
-					Format:              "zip",
-					WindowsARMEmulation: ptr.Bool(true),
+					Name: "minisign",
+					Src:  "minisign-{{.OS}}/{{.Arch}}/minisign",
+				},
+			},
+			Replacements: map[string]string{
+				"darwin":  "macos",
+				"windows": "win64",
+				"amd64":   "x86_64",
+				"arm64":   "aarch64",
+			},
+			Overrides: []*registry.Override{
+				{
+					GOOS:   "linux",
+					Format: "tar.gz",
+				},
+				{
+					GOOS: "darwin",
 					Files: []*registry.File{
 						{
 							Name: "minisign",
-							Src:  "minisign-{{.OS}}/{{.Arch}}/minisign",
 						},
-					},
-					Replacements: map[string]string{
-						"darwin":  "macos",
-						"windows": "win64",
-						"amd64":   "x86_64",
-						"arm64":   "aarch64",
-					},
-					Overrides: []*registry.Override{
-						{
-							GOOS:   "linux",
-							Format: "tar.gz",
-						},
-						{
-							GOOS: "darwin",
-							Files: []*registry.File{
-								{
-									Name: "minisign",
-								},
-							},
-						},
-					},
-					SupportedEnvs: []string{
-						"darwin/arm64",
-						"windows",
-						"linux/amd64",
 					},
 				},
+			},
+			SupportedEnvs: []string{
+				"darwin/arm64",
+				"windows",
+				"linux/amd64",
 			},
 		},
 	}


### PR DESCRIPTION
Close #3633

## Test

Looks good.

https://github.com/aquaproj/aqua/actions/runs/14263508431/job/39980128707?pr=3721

```
WARN[0000] minisign doesn't support this environment     aqua_version= env=linux/arm64 package_name=bufbuild/buf package_version=v0.53.0 program=aqua registry=standard
WARN[0000] minisign doesn't support this environment     aqua_version= env=linux/arm64 package_name=bufbuild/buf package_version=v1.51.0 program=aqua registry=standard
```