### PR TITLE
feat: support disabling slsa-verifier's --source-tag

### DIFF
--- a/json-schema/registry.json
+++ b/json-schema/registry.json
@@ -624,6 +624,9 @@
         },
         "source_uri": {
           "type": "string"
+        },
+        "source_tag": {
+          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/pkg/config/registry/slsa_provenance.go
+++ b/pkg/config/registry/slsa_provenance.go
@@ -10,6 +10,7 @@ type SLSAProvenance struct {
 	Asset     *string `json:"asset,omitempty" yaml:",omitempty"`
 	URL       *string `json:"url,omitempty" yaml:",omitempty"`
 	SourceURI *string `json:"source_uri,omitempty" yaml:"source_uri,omitempty"`
+	SourceTag string  `json:"source_tag,omitempty" yaml:"source_tag,omitempty"`
 }
 
 func (sp *SLSAProvenance) ToDownloadedFile() *DownloadedFile {

--- a/pkg/installpackage/verify_slsa.go
+++ b/pkg/installpackage/verify_slsa.go
@@ -38,6 +38,10 @@ func (s *slsaVerifier) Verify(ctx context.Context, logE *logrus.Entry, file stri
 	pkgInfo := s.pkg.PackageInfo
 
 	art := pkg.TemplateArtifact(s.runtime, s.asset)
+	sourceTag := pkgInfo.SLSAProvenance.SourceTag
+	if sourceTag == "" {
+		sourceTag = pkg.Package.Version
+	}
 
 	if err := s.verifier.Verify(ctx, logE, s.runtime, pkgInfo.SLSAProvenance, art, &download.File{
 		RepoOwner: pkgInfo.RepoOwner,
@@ -45,7 +49,7 @@ func (s *slsaVerifier) Verify(ctx context.Context, logE *logrus.Entry, file stri
 		Version:   pkg.Package.Version,
 	}, &slsa.ParamVerify{
 		SourceURI:    pkgInfo.SLSASourceURI(),
-		SourceTag:    pkg.Package.Version,
+		SourceTag:    sourceTag,
 		ArtifactPath: file,
 	}); err != nil {
 		return fmt.Errorf("verify a package with slsa-verifier: %w", err)

--- a/pkg/slsa/exec.go
+++ b/pkg/slsa/exec.go
@@ -63,6 +63,9 @@ func (e *ExecutorImpl) exec(ctx context.Context, args []string) (string, error) 
 var errVerify = errors.New("verify with slsa-verifier")
 
 func (e *ExecutorImpl) Verify(ctx context.Context, logE *logrus.Entry, param *ParamVerify, provenancePath string) error {
+	if param.SourceTag == "" {
+		return errors.New("source tag is empty")
+	}
 	args := []string{
 		"verify-artifact",
 		param.ArtifactPath,
@@ -70,8 +73,9 @@ func (e *ExecutorImpl) Verify(ctx context.Context, logE *logrus.Entry, param *Pa
 		provenancePath,
 		"--source-uri",
 		param.SourceURI,
-		"--source-tag",
-		param.SourceTag,
+	}
+	if param.SourceTag != "-" {
+		args = append(args, "--source-tag", param.SourceTag)
 	}
 	for i := range 5 {
 		if _, err := e.exec(ctx, args); err == nil {


### PR DESCRIPTION
Close #3613

```yaml
slsa_provenance:
  type: github_release
  asset: multiple.intoto.jsonl
  source_tag: "-"
```

If `source_tag` is `-`, `--source-tag` isn't set.