### PR TITLE
fix: bash and zsh completion command generation

### DIFF
--- a/pkg/cli/completion/bash.go
+++ b/pkg/cli/completion/bash.go
@@ -17,9 +17,9 @@ _cli_bash_autocomplete() {
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     if [[ "$cur" == "-"* ]]; then
-      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} ${cur} --generate-bash-completion )
+      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} ${cur} --generate-shell-completion )
     else
-      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-shell-completion )
     fi
     COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
     return 0

--- a/pkg/cli/completion/zsh.go
+++ b/pkg/cli/completion/zsh.go
@@ -17,9 +17,9 @@ _aqua() {
   local cur
   cur=${words[-1]}
   if [[ "$cur" == "-"* ]]; then
-    opts=("${(@f)$(${words[@]:0:#words[@]-1} ${cur} --generate-bash-completion)}")
+    opts=("${(@f)$(${words[@]:0:#words[@]-1} ${cur} --generate-shell-completion)}")
   else
-    opts=("${(@f)$(${words[@]:0:#words[@]-1} --generate-bash-completion)}")
+    opts=("${(@f)$(${words[@]:0:#words[@]-1} --generate-shell-completion)}")
   fi
 
   if [[ "${opts[1]}" != "" ]]; then


### PR DESCRIPTION
- use --generate-shell-completion instead of --generate-bash-completion

see also: https://github.com/urfave/cli/blob/main/docs/v3/examples/completions/shell-completions.md#customization

> The default shell completion flag (--generate-shell-completion) is defined

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [ ] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue:
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->
