### PR TITLE
fix(checksum): don't treat *.bundle as checksum

### DIFF
--- a/pkg/checksum/checksum.go
+++ b/pkg/checksum/checksum.go
@@ -67,7 +67,7 @@ func convertChecksumFileName(filename, version string) string {
 
 func GetChecksumConfigFromFilename(filename, version string) *registry.Checksum {
 	s := strings.ToLower(filename)
-	for _, suffix := range []string{"sig", "asc", "pem"} {
+	for _, suffix := range []string{"sig", "asc", "pem", "bundle"} {
 		if strings.HasSuffix(s, "."+suffix) {
 			return nil
 		}


### PR DESCRIPTION
These are typically cosign bundles, example in
https://github.com/cert-manager/cmctl/releases/tag/v2.1.1

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue:
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->
