### PR TITLE
fix: fix fish completion

### DIFF
--- a/pkg/cli/completion/command.go
+++ b/pkg/cli/completion/command.go
@@ -6,17 +6,20 @@ import (
 )
 
 type command struct {
-	r *util.Param
+	r   *util.Param
+	cmd *cli.Command
 }
 
-func New(r *util.Param) *cli.Command {
-	i := &command{
-		r: r,
-	}
-	return &cli.Command{
-		Name:  "completion",
-		Usage: "Output shell completion script for bash, zsh, or fish",
-		Description: `Output shell completion script for bash, zsh, or fish.
+func New(cmd *cli.Command) func(r *util.Param) *cli.Command {
+	return func(r *util.Param) *cli.Command {
+		i := &command{
+			r:   r,
+			cmd: cmd,
+		}
+		return &cli.Command{
+			Name:  "completion",
+			Usage: "Output shell completion script for bash, zsh, or fish",
+			Description: `Output shell completion script for bash, zsh, or fish.
 Source the output to enable completion.
 
 e.g.
@@ -37,22 +40,23 @@ fi
 
 aqua completion fish > ~/.config/fish/completions/aqua.fish
 `,
-		Commands: []*cli.Command{
-			{
-				Name:   "bash",
-				Usage:  "Output shell completion script for bash",
-				Action: i.bash,
+			Commands: []*cli.Command{
+				{
+					Name:   "bash",
+					Usage:  "Output shell completion script for bash",
+					Action: i.bash,
+				},
+				{
+					Name:   "zsh",
+					Usage:  "Output shell completion script for zsh",
+					Action: i.zsh,
+				},
+				{
+					Name:   "fish",
+					Usage:  "Output shell completion script for fish",
+					Action: i.fish,
+				},
 			},
-			{
-				Name:   "zsh",
-				Usage:  "Output shell completion script for zsh",
-				Action: i.zsh,
-			},
-			{
-				Name:   "fish",
-				Usage:  "Output shell completion script for fish",
-				Action: i.fish,
-			},
-		},
+		}
 	}
 }

--- a/pkg/cli/completion/fish.go
+++ b/pkg/cli/completion/fish.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (cm *command) fish(_ context.Context, cmd *cli.Command) error {
-	s, err := cmd.ToFishCompletion()
+	s, err := cm.cmd.ToFishCompletion()
 	if err != nil {
 		return fmt.Errorf("generate fish completion: %w", err)
 	}

--- a/pkg/cli/completion/fish.go
+++ b/pkg/cli/completion/fish.go
@@ -7,7 +7,7 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-func (cm *command) fish(_ context.Context, cmd *cli.Command) error {
+func (cm *command) fish(_ context.Context, _ *cli.Command) error {
 	s, err := cm.cmd.ToFishCompletion()
 	if err != nil {
 		return fmt.Errorf("generate fish completion: %w", err)

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -31,23 +31,18 @@ type Runner struct{}
 type newC func(r *util.Param) *cli.Command
 
 func commands(param *util.Param, newCs ...newC) []*cli.Command {
-	cs := make([]*cli.Command, 0, len(newCs))
-	for _, newC := range newCs {
-		cs = append(cs, newC(param))
+	cs := make([]*cli.Command, len(newCs))
+	for i, newC := range newCs {
+		cs[i] = newC(param)
 	}
-	return append(cs,
-		vcmd.New(&vcmd.Command{
-			Name:    "aqua",
-			Version: param.LDFlags.GetVersion(),
-			SHA:     param.LDFlags.Commit,
-		}))
+	return cs
 }
 
 func Run(ctx context.Context, param *util.Param, args ...string) error { //nolint:funlen
-	return helpall.With(&cli.Command{ //nolint:wrapcheck
+	cmd := helpall.With(vcmd.With(&cli.Command{
 		Name:           "aqua",
 		Usage:          "Version Manager of CLI. https://aquaproj.github.io/",
-		Version:        param.LDFlags.GetVersion(),
+		Version:        param.LDFlags.Version,
 		ExitErrHandler: exitErrHandlerFunc,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
@@ -86,28 +81,29 @@ func Run(ctx context.Context, param *util.Param, args ...string) error { //nolin
 			},
 		},
 		EnableShellCompletion: true,
-		Commands: commands(
-			param,
-			initcmd.New,
-			install.New,
-			generate.New,
-			updateaqua.New,
-			upc.New,
-			update.New,
-			completion.New,
-			which.New,
-			info.New,
-			remove.New,
-			vacuum.New,
-			cp.New,
-			cpolicy.New,
-			cpolicy.NewInitPolicy,
-			exec.New,
-			list.New,
-			genr.New,
-			root.New,
-		),
-	}, nil).Run(ctx, args)
+	}, param.LDFlags.Commit), nil)
+	cmd.Commands = commands(
+		param,
+		initcmd.New,
+		install.New,
+		generate.New,
+		updateaqua.New,
+		upc.New,
+		update.New,
+		completion.New(cmd),
+		which.New,
+		info.New,
+		remove.New,
+		vacuum.New,
+		cp.New,
+		cpolicy.New,
+		cpolicy.NewInitPolicy,
+		exec.New,
+		list.New,
+		genr.New,
+		root.New,
+	)
+	return cmd.Run(ctx, args) //nolint:wrapcheck
 }
 
 func exitErrHandlerFunc(_ context.Context, cmd *cli.Command, err error) {

--- a/pkg/cli/util/util.go
+++ b/pkg/cli/util/util.go
@@ -33,10 +33,6 @@ type LDFlags struct {
 	Date    string
 }
 
-func (l *LDFlags) GetVersion() string {
-	return l.Version + " (" + l.Commit + ")"
-}
-
 func SetParam(cmd *cli.Command, logE *logrus.Entry, commandName string, param *config.Param, ldFlags *LDFlags) error { //nolint:funlen,cyclop
 	wd, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
Close #3769

```sh
cmdx i
~/go/bin/aqua fish shell completion
```

<details>
<summary>output</summary>

```
function __fish_aqua_no_subcommand --description 'Test if there has been any subcommand yet'
    for i in (commandline -opc)
        if contains -- $i init help h install i help h generate g help h update-aqua upa help h update-checksum upc help h update up help h completion bash help h zsh help h fish help h help h which help h info help h remove rm help h vacuum help h cp help h policy allow help h deny help h init help h help h init-policy help h exec help h list help h generate-registry gr help h root-dir help h
            return 1
        end
    end
    return 0
end

complete -c aqua -n '__fish_aqua_no_subcommand' -f -l log-level -r -d 'log level'
complete -c aqua -n '__fish_aqua_no_subcommand' -f -l config -s c -r -d 'configuration file path'
complete -c aqua -n '__fish_aqua_no_subcommand' -f -l disable-cosign -d 'Disable Cosign verification'
complete -c aqua -n '__fish_aqua_no_subcommand' -f -l disable-slsa -d 'Disable SLSA verification'
complete -c aqua -n '__fish_aqua_no_subcommand' -f -l disable-github-artifact-attestation -d 'Disable GitHub Artifact Attestations verification'
complete -c aqua -n '__fish_aqua_no_subcommand' -f -l trace -r -d 'trace output file path'
complete -c aqua -n '__fish_aqua_no_subcommand' -f -l cpu-profile -r -d 'cpu profile output file path'
complete -c aqua -n '__fish_aqua_no_subcommand' -f -l help -s h -d 'show help'
complete -c aqua -n '__fish_aqua_no_subcommand' -f -l version -s v -d 'print the version'
complete -c aqua -n '__fish_aqua_no_subcommand' -f -l help -s h -d 'show help'
complete -c aqua -n '__fish_aqua_no_subcommand' -f -l version -s v -d 'print the version'
complete -c aqua -n '__fish_seen_subcommand_from init' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_aqua_no_subcommand' -a 'init' -d 'Create a configuration file if it doesn\'t exist'
complete -c aqua -n '__fish_seen_subcommand_from init' -f -l use-import-dir -s u -d 'Use import_dir'
complete -c aqua -n '__fish_seen_subcommand_from init' -f -l import-dir -s i -r -d 'import_dir'
complete -c aqua -n '__fish_seen_subcommand_from init' -f -l create-dir -s d -d 'Create a directory named aqua and create aqua.yaml in it'
complete -c aqua -n '__fish_seen_subcommand_from init' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_seen_subcommand_from init' -a 'help h' -d 'Shows a list of commands or help for one command'
complete -c aqua -n '__fish_seen_subcommand_from install i' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_aqua_no_subcommand' -a 'install i' -d 'Install tools'
complete -c aqua -n '__fish_seen_subcommand_from install i' -f -l only-link -s l -d 'create links but skip downloading packages'
complete -c aqua -n '__fish_seen_subcommand_from install i' -f -l test -d 'This flag was deprecated and had no meaning from aqua v2.0.0. This flag will be removed in aqua v3.0.0. https://github.com/aquaproj/aqua/issues/1691'
complete -c aqua -n '__fish_seen_subcommand_from install i' -f -l all -s a -d 'install all aqua configuration packages'
complete -c aqua -n '__fish_seen_subcommand_from install i' -f -l tags -s t -r -d 'filter installed packages with tags'
complete -c aqua -n '__fish_seen_subcommand_from install i' -f -l exclude-tags -r -d 'exclude installed packages with tags'
complete -c aqua -n '__fish_seen_subcommand_from install i' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_seen_subcommand_from install i' -a 'help h' -d 'Shows a list of commands or help for one command'
complete -c aqua -n '__fish_seen_subcommand_from generate g' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_aqua_no_subcommand' -a 'generate g' -d 'Search packages in registries and output the configuration interactively'
complete -c aqua -n '__fish_seen_subcommand_from generate g' -f -l f -r -d 'the file path of packages list. When the value is "-", the list is passed from the standard input'
complete -c aqua -n '__fish_seen_subcommand_from generate g' -f -l i -d 'Insert packages to configuration file'
complete -c aqua -n '__fish_seen_subcommand_from generate g' -f -l pin -d 'Pin version'
complete -c aqua -n '__fish_seen_subcommand_from generate g' -f -l g -d 'Insert packages in a global configuration file'
complete -c aqua -n '__fish_seen_subcommand_from generate g' -f -l detail -s d -d 'Output additional fields such as description and link'
complete -c aqua -n '__fish_seen_subcommand_from generate g' -f -l o -r -d 'inserted file'
complete -c aqua -n '__fish_seen_subcommand_from generate g' -f -l select-version -s s -d 'Select the installed version interactively. Default to display 30 versions, use --limit/-l to change it.'
complete -c aqua -n '__fish_seen_subcommand_from generate g' -f -l limit -s l -r -d 'The maximum number of versions. Non-positive number refers to no limit.'
complete -c aqua -n '__fish_seen_subcommand_from generate g' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_seen_subcommand_from generate g' -a 'help h' -d 'Shows a list of commands or help for one command'
complete -c aqua -n '__fish_seen_subcommand_from update-aqua upa' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_aqua_no_subcommand' -a 'update-aqua upa' -d 'Update aqua'
complete -c aqua -n '__fish_seen_subcommand_from update-aqua upa' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_seen_subcommand_from update-aqua upa' -a 'help h' -d 'Shows a list of commands or help for one command'
complete -c aqua -n '__fish_seen_subcommand_from update-checksum upc' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_aqua_no_subcommand' -a 'update-checksum upc' -d 'Create or Update aqua-checksums.json'
complete -c aqua -n '__fish_seen_subcommand_from update-checksum upc' -f -l all -s a -d 'Create or Update all aqua-checksums.json including global configuration'
complete -c aqua -n '__fish_seen_subcommand_from update-checksum upc' -f -l deep -d 'This flag was deprecated and had no meaning from aqua v2.0.0. This flag will be removed in aqua v3.0.0. https://github.com/aquaproj/aqua/issues/1769'
complete -c aqua -n '__fish_seen_subcommand_from update-checksum upc' -f -l prune -d 'Remove unused checksums'
complete -c aqua -n '__fish_seen_subcommand_from update-checksum upc' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_seen_subcommand_from update-checksum upc' -a 'help h' -d 'Shows a list of commands or help for one command'
complete -c aqua -n '__fish_seen_subcommand_from update up' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_aqua_no_subcommand' -a 'update up' -d 'Update registries and packages'
complete -c aqua -n '__fish_seen_subcommand_from update up' -f -l i -d 'Select packages with fuzzy finder'
complete -c aqua -n '__fish_seen_subcommand_from update up' -f -l select-version -s s -d 'Select the version with fuzzy finder. Default to display 30 versions, use --limit/-l to change it.'
complete -c aqua -n '__fish_seen_subcommand_from update up' -f -l only-registry -s r -d 'Update only registries'
complete -c aqua -n '__fish_seen_subcommand_from update up' -f -l only-package -s p -d 'Update only packages'
complete -c aqua -n '__fish_seen_subcommand_from update up' -f -l limit -s l -r -d 'The maximum number of versions. Non-positive number refers to no limit.'
complete -c aqua -n '__fish_seen_subcommand_from update up' -f -l tags -s t -r -d 'filter installed packages with tags'
complete -c aqua -n '__fish_seen_subcommand_from update up' -f -l exclude-tags -r -d 'exclude installed packages with tags'
complete -c aqua -n '__fish_seen_subcommand_from update up' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_seen_subcommand_from update up' -a 'help h' -d 'Shows a list of commands or help for one command'
complete -c aqua -n '__fish_seen_subcommand_from completion' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_aqua_no_subcommand' -a 'completion' -d 'Output shell completion script for bash, zsh, or fish'
complete -c aqua -n '__fish_seen_subcommand_from completion' -f -l help -s h -d 'show help'
complete -c aqua -n '__fish_seen_subcommand_from bash' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_seen_subcommand_from completion' -a 'bash' -d 'Output shell completion script for bash'
complete -c aqua -n '__fish_seen_subcommand_from bash' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_seen_subcommand_from bash' -a 'help h' -d 'Shows a list of commands or help for one command'
complete -c aqua -n '__fish_seen_subcommand_from zsh' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_seen_subcommand_from completion' -a 'zsh' -d 'Output shell completion script for zsh'
complete -c aqua -n '__fish_seen_subcommand_from zsh' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_seen_subcommand_from zsh' -a 'help h' -d 'Shows a list of commands or help for one command'
complete -c aqua -n '__fish_seen_subcommand_from fish' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_seen_subcommand_from completion' -a 'fish' -d 'Output shell completion script for fish'
complete -c aqua -n '__fish_seen_subcommand_from fish' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_seen_subcommand_from fish' -a 'help h' -d 'Shows a list of commands or help for one command'
complete -r -c aqua -n '__fish_seen_subcommand_from completion' -a 'help h' -d 'Shows a list of commands or help for one command'
complete -c aqua -n '__fish_seen_subcommand_from which' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_aqua_no_subcommand' -a 'which' -d 'Output the absolute file path of the given command'
complete -c aqua -n '__fish_seen_subcommand_from which' -f -l version -s v -d 'Output the given package version'
complete -c aqua -n '__fish_seen_subcommand_from which' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_seen_subcommand_from which' -a 'help h' -d 'Shows a list of commands or help for one command'
complete -c aqua -n '__fish_seen_subcommand_from info' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_aqua_no_subcommand' -a 'info' -d 'Show information'
complete -c aqua -n '__fish_seen_subcommand_from info' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_seen_subcommand_from info' -a 'help h' -d 'Shows a list of commands or help for one command'
complete -c aqua -n '__fish_seen_subcommand_from remove rm' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_aqua_no_subcommand' -a 'remove rm' -d 'Uninstall packages'
complete -c aqua -n '__fish_seen_subcommand_from remove rm' -f -l all -s a -d 'uninstall all packages'
complete -c aqua -n '__fish_seen_subcommand_from remove rm' -f -l mode -s m -r -d 'Removed target modes. l: link, p: package'
complete -c aqua -n '__fish_seen_subcommand_from remove rm' -f -l i -d 'Select packages with a Fuzzy Finder'
complete -c aqua -n '__fish_seen_subcommand_from remove rm' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_seen_subcommand_from remove rm' -a 'help h' -d 'Shows a list of commands or help for one command'
complete -c aqua -n '__fish_seen_subcommand_from vacuum' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_aqua_no_subcommand' -a 'vacuum' -d 'Remove unused installed packages'
complete -c aqua -n '__fish_seen_subcommand_from vacuum' -f -l init -d 'Create timestamp files.'
complete -c aqua -n '__fish_seen_subcommand_from vacuum' -f -l days -s d -r -d 'Expiration days'
complete -c aqua -n '__fish_seen_subcommand_from vacuum' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_seen_subcommand_from vacuum' -a 'help h' -d 'Shows a list of commands or help for one command'
complete -c aqua -n '__fish_seen_subcommand_from cp' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_aqua_no_subcommand' -a 'cp' -d 'Copy executable files in a directory'
complete -c aqua -n '__fish_seen_subcommand_from cp' -f -l o -r -d 'destination directory'
complete -c aqua -n '__fish_seen_subcommand_from cp' -f -l all -s a -d 'install all aqua configuration packages'
complete -c aqua -n '__fish_seen_subcommand_from cp' -f -l tags -s t -r -d 'filter installed packages with tags'
complete -c aqua -n '__fish_seen_subcommand_from cp' -f -l exclude-tags -r -d 'exclude installed packages with tags'
complete -c aqua -n '__fish_seen_subcommand_from cp' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_seen_subcommand_from cp' -a 'help h' -d 'Shows a list of commands or help for one command'
complete -c aqua -n '__fish_seen_subcommand_from policy' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_aqua_no_subcommand' -a 'policy' -d 'Manage Policy'
complete -c aqua -n '__fish_seen_subcommand_from policy' -f -l help -s h -d 'show help'
complete -c aqua -n '__fish_seen_subcommand_from allow' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_seen_subcommand_from policy' -a 'allow' -d 'Allow a policy file'
complete -c aqua -n '__fish_seen_subcommand_from allow' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_seen_subcommand_from allow' -a 'help h' -d 'Shows a list of commands or help for one command'
complete -c aqua -n '__fish_seen_subcommand_from deny' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_seen_subcommand_from policy' -a 'deny' -d 'Deny a policy file'
complete -c aqua -n '__fish_seen_subcommand_from deny' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_seen_subcommand_from deny' -a 'help h' -d 'Shows a list of commands or help for one command'
complete -c aqua -n '__fish_seen_subcommand_from init' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_seen_subcommand_from policy' -a 'init' -d 'Create a policy file if it doesn\'t exist'
complete -c aqua -n '__fish_seen_subcommand_from init' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_seen_subcommand_from init' -a 'help h' -d 'Shows a list of commands or help for one command'
complete -r -c aqua -n '__fish_seen_subcommand_from policy' -a 'help h' -d 'Shows a list of commands or help for one command'
complete -c aqua -n '__fish_seen_subcommand_from init-policy' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_aqua_no_subcommand' -a 'init-policy' -d '[Deprecated] Create a policy file if it doesn\'t exist'
complete -c aqua -n '__fish_seen_subcommand_from init-policy' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_seen_subcommand_from init-policy' -a 'help h' -d 'Shows a list of commands or help for one command'
complete -c aqua -n '__fish_seen_subcommand_from exec' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_aqua_no_subcommand' -a 'exec' -d 'Execute tool'
complete -c aqua -n '__fish_seen_subcommand_from exec' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_seen_subcommand_from exec' -a 'help h' -d 'Shows a list of commands or help for one command'
complete -c aqua -n '__fish_seen_subcommand_from list' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_aqua_no_subcommand' -a 'list' -d 'List packages in Registries'
complete -c aqua -n '__fish_seen_subcommand_from list' -f -l installed -s i -d 'List installed packages'
complete -c aqua -n '__fish_seen_subcommand_from list' -f -l all -s a -d 'List global configuration packages too'
complete -c aqua -n '__fish_seen_subcommand_from list' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_seen_subcommand_from list' -a 'help h' -d 'Shows a list of commands or help for one command'
complete -c aqua -n '__fish_seen_subcommand_from generate-registry gr' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_aqua_no_subcommand' -a 'generate-registry gr' -d 'Generate a registry\'s package configuration'
complete -c aqua -n '__fish_seen_subcommand_from generate-registry gr' -f -l out-testdata -r -d 'A file path where the testdata is outputted'
complete -c aqua -n '__fish_seen_subcommand_from generate-registry gr' -f -l cmd -r -d 'A list of commands joined with commas \',\''
complete -c aqua -n '__fish_seen_subcommand_from generate-registry gr' -f -l generate-config -s c -r -d 'A configuration file path'
complete -c aqua -n '__fish_seen_subcommand_from generate-registry gr' -f -l limit -s l -r -d 'the maximum number of versions'
complete -c aqua -n '__fish_seen_subcommand_from generate-registry gr' -f -l deep -d 'This flag was deprecated and had no meaning from aqua v2.15.0. This flag will be removed in aqua v3.0.0. https://github.com/aquaproj/aqua/issues/2351'
complete -c aqua -n '__fish_seen_subcommand_from generate-registry gr' -f -l init -d 'Generate a configuration file'
complete -c aqua -n '__fish_seen_subcommand_from generate-registry gr' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_seen_subcommand_from generate-registry gr' -a 'help h' -d 'Shows a list of commands or help for one command'
complete -c aqua -n '__fish_seen_subcommand_from root-dir' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_aqua_no_subcommand' -a 'root-dir' -d 'Output the aqua root directory (AQUA_ROOT_DIR)'
complete -c aqua -n '__fish_seen_subcommand_from root-dir' -f -l help -s h -d 'show help'
complete -r -c aqua -n '__fish_seen_subcommand_from root-dir' -a 'help h' -d 'Shows a list of commands or help for one command'
```

</details>

## Test

```console
root@464ba5a0bf43:~/workspace# mkdir -p ~/.config/fish/completions/
root@464ba5a0bf43:~/workspace# aqua completion fish > ~/.config/fish/completions/aqua.fish
root@464ba5a0bf43:~/workspace# fish  
Welcome to fish, the friendly interactive shell
Type help for instructions on how to use fish
root@464ba5a0bf43 ~/workspace# aqua in
info                                 (Show information)  init-policy  ([Deprecated] Create a policy file if it doesn't exist)
init  (Create a configuration file if it doesn't exist)  install                                              (Install tools)
```