### PR TITLE
feat(ghattestation): non-default predicate type support

### DIFF
--- a/aqua/aqua-policy.yaml
+++ b/aqua/aqua-policy.yaml
@@ -3,7 +3,7 @@
 # aqua Policy
 registries:
   - type: standard
-    ref: semver(">= 3.0.0") or Version in ["f9cce37273a70e2f5664fb4c3708169ffe7e320c", "1f20d0c2211df45694e762fcb20830d5c3cedf95"]
+    ref: semver(">= 3.0.0") or Version in ["f9cce37273a70e2f5664fb4c3708169ffe7e320c", "1f20d0c2211df45694e762fcb20830d5c3cedf95", "98524ca5b420af9115275d110b2cadeab60f49e2"]
   - name: main
     type: local
     path: ../tests/main/registry.yaml

--- a/json-schema/registry.json
+++ b/json-schema/registry.json
@@ -260,6 +260,9 @@
         "enabled": {
           "type": "boolean"
         },
+        "predicate_type": {
+          "type": "string"
+        },
         "signer_workflow": {
           "type": "string"
         },

--- a/pkg/config/registry/github_cli.go
+++ b/pkg/config/registry/github_cli.go
@@ -1,7 +1,8 @@
 package registry
 
 type GitHubArtifactAttestations struct {
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled       *bool  `json:"enabled,omitempty"`
+	PredicateType string `json:"predicate_type,omitempty"`
 	// https://github.com/aquaproj/aqua/issues/3581
 	SignerWorkflow2 string `yaml:"signer_workflow,omitempty" json:"signer_workflow,omitempty"`
 	// Deprecated: We'll remove signer-workflow at aqua v3.

--- a/pkg/config/registry/github_cli.go
+++ b/pkg/config/registry/github_cli.go
@@ -2,7 +2,7 @@ package registry
 
 type GitHubArtifactAttestations struct {
 	Enabled       *bool  `json:"enabled,omitempty"`
-	PredicateType string `json:"predicate_type,omitempty"`
+	PredicateType string `json:"predicate_type,omitempty" yaml:"predicate_type,omitempty"`
 	// https://github.com/aquaproj/aqua/issues/3581
 	SignerWorkflow2 string `yaml:"signer_workflow,omitempty" json:"signer_workflow,omitempty"`
 	// Deprecated: We'll remove signer-workflow at aqua v3.

--- a/pkg/ghattestation/exec.go
+++ b/pkg/ghattestation/exec.go
@@ -88,6 +88,9 @@ func (e *ExecutorImpl) Verify(ctx context.Context, logE *logrus.Entry, param *Pa
 	if param.SignerWorkflow != "" {
 		args = append(args, "--signer-workflow", param.SignerWorkflow)
 	}
+	if param.PredicateType != "" {
+		args = append(args, "--predicate-type", param.PredicateType)
+	}
 	for i := range 5 {
 		err := e.exec(ctx, args)
 		if err == nil {

--- a/pkg/ghattestation/verifier.go
+++ b/pkg/ghattestation/verifier.go
@@ -20,6 +20,7 @@ type ParamVerify struct {
 	ArtifactPath   string
 	Repository     string
 	SignerWorkflow string
+	PredicateType  string
 }
 
 func (v *Verifier) Verify(ctx context.Context, logE *logrus.Entry, param *ParamVerify) error {

--- a/pkg/installpackage/verify_github_artifact_attestation.go
+++ b/pkg/installpackage/verify_github_artifact_attestation.go
@@ -40,6 +40,7 @@ func (g *gitHubArtifactAttestationsVerifier) Verify(ctx context.Context, logE *l
 	if err := g.ghVerifier.Verify(ctx, logE, &ghattestation.ParamVerify{
 		Repository:     g.pkg.PackageInfo.RepoOwner + "/" + g.pkg.PackageInfo.RepoName,
 		ArtifactPath:   file,
+		PredicateType:  g.gaa.PredicateType,
 		SignerWorkflow: g.gaa.SignerWorkflow(),
 	}); err != nil {
 		return fmt.Errorf("verify a package with gh attestation: %w", err)

--- a/tests/cosign/aqua.yaml
+++ b/tests/cosign/aqua.yaml
@@ -9,5 +9,10 @@ checksum:
 registries:
   - type: standard
     ref: f9cce37273a70e2f5664fb4c3708169ffe7e320c # TODO update
+  - type: standard
+    ref: 98524ca5b420af9115275d110b2cadeab60f49e2 # TODO update
+    name: soulshack
 packages:
   - name: suzuki-shunsuke/mkghtag@v0.1.7
+  - name: pkdindustries/soulshack@v0.74
+    registry: soulshack


### PR DESCRIPTION
Closes https://github.com/aquaproj/aqua/issues/3793

Caveat: untested, but I suppose this could work.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: https://github.com/aquaproj/aqua/issues/3793
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->

---

e.g. https://github.com/pkdindustries/soulshack

https://github.com/pkdindustries/soulshack/blob/f625a32a1dd503edc0980eb081a2eae249cab578/.github/workflows/go.yml#L94

```yaml
github_artifact_attestations:
  signer_workflow: pkdindustries/soulshack/.github/workflows/go.yml
  predicate_type: https://in-toto.io/attestation/release/v0.1
```