### PR TITLE
perf: cache a map of packages

### DIFF
--- a/pkg/config/registry/registry.go
+++ b/pkg/config/registry/registry.go
@@ -1,5 +1,17 @@
 package registry
 
+import "github.com/sirupsen/logrus"
+
 type Config struct {
 	PackageInfos PackageInfos `yaml:"packages" json:"packages"`
+	m            map[string]*PackageInfo
+}
+
+func (c *Config) Packages(logE *logrus.Entry) map[string]*PackageInfo {
+	if c.m != nil {
+		return c.m
+	}
+	m := c.PackageInfos.ToMap(logE)
+	c.m = m
+	return m
 }

--- a/pkg/controller/which/which.go
+++ b/pkg/controller/which/which.go
@@ -128,7 +128,7 @@ func (c *Controller) findExecFileFromPkg(logE *logrus.Entry, registries map[stri
 		return nil, nil //nolint:nilnil
 	}
 
-	m := registry.PackageInfos.ToMap(logE)
+	m := registry.Packages(logE)
 
 	pkgInfo, ok := m[pkg.Name]
 	if !ok {

--- a/pkg/install-registry/install_test.go
+++ b/pkg/install-registry/install_test.go
@@ -179,7 +179,7 @@ func TestInstaller_InstallRegistries(t *testing.T) { //nolint:funlen
 			if d.isErr {
 				t.Fatal("error must be returned")
 			}
-			if diff := cmp.Diff(d.exp, registries); diff != "" {
+			if diff := cmp.Diff(d.exp, registries, cmp.AllowUnexported(cfgRegistry.Config{})); diff != "" {
 				t.Fatal(diff)
 			}
 		})


### PR DESCRIPTION
## Benchmark

```console
$ hyperfine --warmup 3 "/Users/shunsukesuzuki/go/bin/aqua which mkghtag" "/Users/shunsukesuzuki/.local/share/aquaproj-aqua/internal/pkgs/github_release/github.com/aquaproj/aqua/v2.50.0/aqua_darwin_arm64.tar.gz/aqua which mkghtag"
Benchmark 1: /Users/shunsukesuzuki/go/bin/aqua which mkghtag
  Time (mean ± σ):     445.4 ms ±  36.2 ms    [User: 502.7 ms, System: 170.1 ms]
  Range (min … max):   423.5 ms … 518.1 ms    10 runs
 
  Warning: The first benchmarking run for this command was significantly slower than the rest (518.1 ms). This could be caused by (filesystem) caches that were not filled until after the first run. You are already using the '--warmup' option which helps to fill these caches before the actual benchmark. You can either try to increase the warmup count further or re-run this benchmark on a quiet system in case it was a random outlier. Alternatively, consider using the '--prepare' option to clear the caches before each timing run.
 
Benchmark 2: /Users/shunsukesuzuki/.local/share/aquaproj-aqua/internal/pkgs/github_release/github.com/aquaproj/aqua/v2.50.0/aqua_darwin_arm64.tar.gz/aqua which mkghtag
  Time (mean ± σ):     908.6 ms ±  43.0 ms    [User: 1286.2 ms, System: 204.7 ms]
  Range (min … max):   867.3 ms … 972.6 ms    10 runs
 
Summary
  /Users/shunsukesuzuki/go/bin/aqua which mkghtag ran
    2.04 ± 0.19 times faster than /Users/shunsukesuzuki/.local/share/aquaproj-aqua/internal/pkgs/github_release/github.com/aquaproj/aqua/v2.50.0/aqua_darwin_arm64.tar.gz/aqua which mkghtag
```