### PR TITLE
feat: support managing a GitHub access token using Keyring

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	golang.org/x/oauth2 v0.30.0
 	golang.org/x/sync v0.13.0
 	golang.org/x/sys v0.33.0
+	golang.org/x/term v0.31.0
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -88,7 +89,6 @@ require (
 	github.com/ulikunitz/xz v0.5.12 // indirect
 	go4.org v0.0.0-20230225012048-214862532bf5 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
-	golang.org/x/term v0.31.0 // indirect
 	golang.org/x/text v0.24.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/suzuki-shunsuke/urfave-cli-v3-util v0.0.4
 	github.com/urfave/cli/v3 v3.3.2
 	github.com/wk8/go-ordered-map/v2 v2.1.8
+	github.com/zalando/go-keyring v0.2.6
 	golang.org/x/oauth2 v0.30.0
 	golang.org/x/sync v0.13.0
 	golang.org/x/sys v0.33.0
@@ -37,6 +38,7 @@ require (
 )
 
 require (
+	al.essio.dev/pkg/shellescape v1.5.1 // indirect
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.3.0 // indirect
@@ -47,10 +49,12 @@ require (
 	github.com/bodgit/sevenzip v1.6.0 // indirect
 	github.com/bodgit/windows v1.0.1 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
+	github.com/danieljoos/wincred v1.2.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707 // indirect
 	github.com/gdamore/encoding v1.0.1 // indirect
 	github.com/gdamore/tcell/v2 v2.6.0 // indirect
+	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+al.essio.dev/pkg/shellescape v1.5.1 h1:86HrALUujYS/h+GtqoB26SBEdkWfmMI6FubjXlsXyho=
+al.essio.dev/pkg/shellescape v1.5.1/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -48,6 +50,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/danieljoos/wincred v1.2.2 h1:774zMFJrqaeYCK2W57BgAem/MLi6mtSE47MB6BOJ0i0=
+github.com/danieljoos/wincred v1.2.2/go.mod h1:w7w4Utbrz8lqeMbDAK0lkNJUv5sAOkFi7nd/ogr0Uh8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -72,6 +76,8 @@ github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/goccy/go-yaml v1.17.1 h1:LI34wktB2xEE3ONG/2Ar54+/HJVBriAGJ55PHls4YuY=
 github.com/goccy/go-yaml v1.17.1/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
+github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
+github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -105,6 +111,8 @@ github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OI
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -211,6 +219,8 @@ github.com/spf13/cast v1.7.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cA
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -252,6 +262,8 @@ github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+x
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/zalando/go-keyring v0.2.6 h1:r7Yc3+H+Ux0+M72zacZoItR3UDxeWfKTcabvkI8ua9s=
+github.com/zalando/go-keyring v0.2.6/go.mod h1:2TCrxYrbUNYfNS/Kgy/LSrkSQzZ5UPVH85RwfczwvcI=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/pkg/cli/generate/command.go
+++ b/pkg/cli/generate/command.go
@@ -80,7 +80,7 @@ func (i *command) action(ctx context.Context, cmd *cli.Command) error {
 	if err := util.SetParam(cmd, i.r.LogE, "generate", param, i.r.LDFlags); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
-	ctrl := controller.InitializeGenerateCommandController(ctx, param, http.DefaultClient, i.r.Runtime)
+	ctrl := controller.InitializeGenerateCommandController(ctx, i.r.LogE, param, http.DefaultClient, i.r.Runtime)
 	return ctrl.Generate(ctx, i.r.LogE, param, cmd.Args().Slice()...) //nolint:wrapcheck
 }
 

--- a/pkg/cli/genr/command.go
+++ b/pkg/cli/genr/command.go
@@ -142,6 +142,6 @@ func (i *command) action(ctx context.Context, cmd *cli.Command) error {
 	if err := util.SetParam(cmd, i.r.LogE, "generate-registry", param, i.r.LDFlags); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
-	ctrl := controller.InitializeGenerateRegistryCommandController(ctx, param, http.DefaultClient, os.Stdout)
+	ctrl := controller.InitializeGenerateRegistryCommandController(ctx, i.r.LogE, param, http.DefaultClient, os.Stdout)
 	return ctrl.GenerateRegistry(ctx, param, i.r.LogE, cmd.Args().Slice()...) //nolint:wrapcheck
 }

--- a/pkg/cli/initcmd/command.go
+++ b/pkg/cli/initcmd/command.go
@@ -64,7 +64,7 @@ func (ic *initCommand) action(ctx context.Context, cmd *cli.Command) error {
 	if err := util.SetParam(cmd, ic.r.LogE, "init", param, ic.r.LDFlags); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
-	ctrl := controller.InitializeInitCommandController(ctx, param)
+	ctrl := controller.InitializeInitCommandController(ctx, ic.r.LogE, param)
 	cParam := &initcmd.Param{
 		IsDir:     cmd.Bool("create-dir"),
 		ImportDir: cmd.String("import-dir"),

--- a/pkg/cli/list/command.go
+++ b/pkg/cli/list/command.go
@@ -72,6 +72,6 @@ func (i *command) action(ctx context.Context, cmd *cli.Command) error {
 	if err := util.SetParam(cmd, i.r.LogE, "list", param, i.r.LDFlags); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
-	ctrl := controller.InitializeListCommandController(ctx, param, http.DefaultClient, i.r.Runtime)
+	ctrl := controller.InitializeListCommandController(ctx, i.r.LogE, param, http.DefaultClient, i.r.Runtime)
 	return ctrl.List(ctx, i.r.LogE, param) //nolint:wrapcheck
 }

--- a/pkg/cli/remove/command.go
+++ b/pkg/cli/remove/command.go
@@ -89,7 +89,7 @@ func (i *command) action(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
 	param.SkipLink = true
-	ctrl := controller.InitializeRemoveCommandController(ctx, param, http.DefaultClient, i.r.Runtime, mode)
+	ctrl := controller.InitializeRemoveCommandController(ctx, i.r.LogE, param, http.DefaultClient, i.r.Runtime, mode)
 	if err := ctrl.Remove(ctx, i.r.LogE, param); err != nil {
 		return err //nolint:wrapcheck
 	}

--- a/pkg/cli/token/command.go
+++ b/pkg/cli/token/command.go
@@ -1,0 +1,68 @@
+package token
+
+import (
+	"context"
+	"os"
+
+	"github.com/aquaproj/aqua/v2/pkg/controller/rmtoken"
+	"github.com/aquaproj/aqua/v2/pkg/controller/settoken"
+	"github.com/aquaproj/aqua/v2/pkg/keyring"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v3"
+)
+
+func New(logE *logrus.Entry) *cli.Command {
+	r := &runner{
+		logE: logE,
+	}
+	return r.Command()
+}
+
+type runner struct {
+	logE *logrus.Entry
+}
+
+func (r *runner) Command() *cli.Command {
+	return &cli.Command{
+		Name:        "token",
+		Usage:       "Manage GitHub Access token",
+		Description: `Manage GitHub Access token by keyring.`,
+		Commands: []*cli.Command{
+			{
+				Name:        "set",
+				Usage:       "Set GitHub Access token",
+				Description: `Set GitHub Access token to keyring.`,
+				Action:      r.action,
+				Flags: []cli.Flag{
+					&cli.BoolFlag{
+						Name:  "stdin",
+						Usage: "Read GitHub Access token from stdin",
+					},
+				},
+			},
+			{
+				Name:        "remove",
+				Aliases:     []string{"rm"},
+				Usage:       "Remove GitHub Access token",
+				Description: `Remove GitHub Access token from keyring.`,
+				Action:      r.remove,
+			},
+		},
+	}
+}
+
+func (r *runner) action(_ context.Context, c *cli.Command) error {
+	term := settoken.NewPasswordReader(os.Stdout)
+	tokenManager := keyring.NewTokenManager()
+	ctrl := settoken.New(&settoken.Param{
+		IsStdin: c.Bool("stdin"),
+		Stdin:   os.Stdin,
+	}, term, tokenManager)
+	return ctrl.Set(r.logE) //nolint:wrapcheck
+}
+
+func (r *runner) remove(_ context.Context, _ *cli.Command) error {
+	tokenManager := keyring.NewTokenManager()
+	ctrl := rmtoken.New(&rmtoken.Param{}, tokenManager)
+	return ctrl.Remove(r.logE) //nolint:wrapcheck
+}

--- a/pkg/cli/upc/command.go
+++ b/pkg/cli/upc/command.go
@@ -72,6 +72,6 @@ func (i *command) action(ctx context.Context, cmd *cli.Command) error {
 	if err := util.SetParam(cmd, i.r.LogE, "update-checksum", param, i.r.LDFlags); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
-	ctrl := controller.InitializeUpdateChecksumCommandController(ctx, param, http.DefaultClient, i.r.Runtime)
+	ctrl := controller.InitializeUpdateChecksumCommandController(ctx, i.r.LogE, param, http.DefaultClient, i.r.Runtime)
 	return ctrl.UpdateChecksum(ctx, i.r.LogE, param) //nolint:wrapcheck
 }

--- a/pkg/cli/update/command.go
+++ b/pkg/cli/update/command.go
@@ -155,6 +155,6 @@ func (i *command) action(ctx context.Context, cmd *cli.Command) error {
 	if err := util.SetParam(cmd, i.r.LogE, "update", param, i.r.LDFlags); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
-	ctrl := controller.InitializeUpdateCommandController(ctx, param, http.DefaultClient, i.r.Runtime)
+	ctrl := controller.InitializeUpdateCommandController(ctx, i.r.LogE, param, http.DefaultClient, i.r.Runtime)
 	return ctrl.Update(ctx, i.r.LogE, param) //nolint:wrapcheck
 }

--- a/pkg/cli/vacuum/command.go
+++ b/pkg/cli/vacuum/command.go
@@ -85,7 +85,7 @@ func (i *command) action(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	if cmd.Bool("init") {
-		ctrl := controller.InitializeVacuumInitCommandController(ctx, param, i.r.Runtime, &http.Client{})
+		ctrl := controller.InitializeVacuumInitCommandController(ctx, i.r.LogE, param, i.r.Runtime, &http.Client{})
 		if err := ctrl.Init(ctx, logE, param); err != nil {
 			return err //nolint:wrapcheck
 		}

--- a/pkg/cli/which/command.go
+++ b/pkg/cli/which/command.go
@@ -71,7 +71,7 @@ func (i *command) action(ctx context.Context, cmd *cli.Command) error {
 	if err := util.SetParam(cmd, i.r.LogE, "which", param, i.r.LDFlags); err != nil {
 		return fmt.Errorf("parse the command line arguments: %w", err)
 	}
-	ctrl := controller.InitializeWhichCommandController(ctx, param, http.DefaultClient, i.r.Runtime)
+	ctrl := controller.InitializeWhichCommandController(ctx, i.r.LogE, param, http.DefaultClient, i.r.Runtime)
 	exeName, _, err := ParseExecArgs(cmd.Args().Slice())
 	if err != nil {
 		return err

--- a/pkg/controller/rmtoken/controller.go
+++ b/pkg/controller/rmtoken/controller.go
@@ -1,0 +1,21 @@
+package rmtoken
+
+import "github.com/sirupsen/logrus"
+
+type Controller struct {
+	param        *Param
+	tokenManager TokenManager
+}
+
+func New(param *Param, tokenManager TokenManager) *Controller {
+	return &Controller{
+		param:        param,
+		tokenManager: tokenManager,
+	}
+}
+
+type Param struct{}
+
+type TokenManager interface {
+	Remove(logE *logrus.Entry) error
+}

--- a/pkg/controller/rmtoken/rm.go
+++ b/pkg/controller/rmtoken/rm.go
@@ -1,0 +1,14 @@
+package rmtoken
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+)
+
+func (c *Controller) Remove(logE *logrus.Entry) error {
+	if err := c.tokenManager.Remove(logE); err != nil {
+		return fmt.Errorf("remove a GitHub access Token from the secret store: %w", err)
+	}
+	return nil
+}

--- a/pkg/controller/settoken/controller.go
+++ b/pkg/controller/settoken/controller.go
@@ -1,0 +1,30 @@
+package settoken
+
+import "io"
+
+type Controller struct {
+	param        *Param
+	term         Terminal
+	tokenManager TokenManager
+}
+
+func New(param *Param, term Terminal, tokenManager TokenManager) *Controller {
+	return &Controller{
+		param:        param,
+		term:         term,
+		tokenManager: tokenManager,
+	}
+}
+
+type Param struct {
+	IsStdin bool
+	Stdin   io.Reader
+}
+
+type Terminal interface {
+	ReadPassword() ([]byte, error)
+}
+
+type TokenManager interface {
+	Set(token string) error
+}

--- a/pkg/controller/settoken/set.go
+++ b/pkg/controller/settoken/set.go
@@ -1,0 +1,60 @@
+package settoken
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"syscall"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/term"
+)
+
+func (c *Controller) Set(logE *logrus.Entry) error {
+	text, err := c.get(logE)
+	if err != nil {
+		return fmt.Errorf("get a GitHub access Token: %w", err)
+	}
+	if err := c.tokenManager.Set(strings.TrimSpace(string(text))); err != nil {
+		return fmt.Errorf("set a GitHub access Token to the secret store: %w", err)
+	}
+	return nil
+}
+
+func (c *Controller) get(logE *logrus.Entry) ([]byte, error) {
+	if c.param.IsStdin {
+		s, err := io.ReadAll(c.param.Stdin)
+		if err != nil {
+			return nil, fmt.Errorf("read a GitHub access token from stdin: %w", err)
+		}
+		logE.Debug("read a GitHub access token from stdin")
+		return s, nil
+	}
+	text, err := c.term.ReadPassword()
+	if err != nil {
+		return nil, fmt.Errorf("read a GitHub access Token from terminal: %w", err)
+	}
+	return text, nil
+}
+
+type PasswordReader struct {
+	stdout io.Writer
+}
+
+func NewPasswordReader(stdout io.Writer) *PasswordReader {
+	return &PasswordReader{
+		stdout: stdout,
+	}
+}
+
+func (p *PasswordReader) ReadPassword() ([]byte, error) {
+	fmt.Fprint(p.stdout, "Enter a GitHub access token: ")
+	// The conversion is necessary for Windows
+	// https://pkg.go.dev/syscall?GOOS=windows#pkg-variables
+	b, err := term.ReadPassword(int(syscall.Stdin)) //nolint:unconvert
+	fmt.Fprintln(p.stdout, "")
+	if err != nil {
+		return nil, fmt.Errorf("read a GitHub access token from terminal: %w", err)
+	}
+	return b, nil
+}

--- a/pkg/controller/wire.go
+++ b/pkg/controller/wire.go
@@ -56,7 +56,7 @@ import (
 	"github.com/suzuki-shunsuke/go-osenv/osenv"
 )
 
-func InitializeListCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *list.Controller {
+func InitializeListCommandController(ctx context.Context, logE *logrus.Entry, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *list.Controller {
 	wire.Build(
 		list.NewController,
 		wire.NewSet(
@@ -109,7 +109,7 @@ func InitializeListCommandController(ctx context.Context, param *config.Param, h
 	return &list.Controller{}
 }
 
-func InitializeGenerateRegistryCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, stdout io.Writer) *genrgst.Controller {
+func InitializeGenerateRegistryCommandController(ctx context.Context, logE *logrus.Entry, param *config.Param, httpClient *http.Client, stdout io.Writer) *genrgst.Controller {
 	wire.Build(
 		genrgst.NewController,
 		wire.NewSet(
@@ -129,7 +129,7 @@ func InitializeGenerateRegistryCommandController(ctx context.Context, param *con
 	return &genrgst.Controller{}
 }
 
-func InitializeInitCommandController(ctx context.Context, param *config.Param) *initcmd.Controller {
+func InitializeInitCommandController(ctx context.Context, logE *logrus.Entry, param *config.Param) *initcmd.Controller {
 	wire.Build(
 		initcmd.New,
 		wire.NewSet(
@@ -149,7 +149,7 @@ func InitializeInitPolicyCommandController(ctx context.Context) *initpolicy.Cont
 	return &initpolicy.Controller{}
 }
 
-func InitializeGenerateCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *generate.Controller {
+func InitializeGenerateCommandController(ctx context.Context, logE *logrus.Entry, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *generate.Controller {
 	wire.Build(
 		generate.New,
 		wire.NewSet(
@@ -359,7 +359,7 @@ func InitializeInstallCommandController(ctx context.Context, logE *logrus.Entry,
 	return &install.Controller{}, nil
 }
 
-func InitializeWhichCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *which.Controller {
+func InitializeWhichCommandController(ctx context.Context, logE *logrus.Entry, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *which.Controller {
 	wire.Build(
 		which.New,
 		wire.NewSet(
@@ -794,7 +794,7 @@ func InitializeCopyCommandController(ctx context.Context, logE *logrus.Entry, pa
 	return &cp.Controller{}, nil
 }
 
-func InitializeUpdateChecksumCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *updatechecksum.Controller {
+func InitializeUpdateChecksumCommandController(ctx context.Context, logE *logrus.Entry, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *updatechecksum.Controller {
 	wire.Build(
 		updatechecksum.New,
 		wire.NewSet(
@@ -853,7 +853,7 @@ func InitializeUpdateChecksumCommandController(ctx context.Context, param *confi
 	return &updatechecksum.Controller{}
 }
 
-func InitializeUpdateCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *update.Controller {
+func InitializeUpdateCommandController(ctx context.Context, logE *logrus.Entry, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *update.Controller {
 	wire.Build(
 		update.New,
 		wire.NewSet(
@@ -991,7 +991,7 @@ func InitializeInfoCommandController(ctx context.Context, param *config.Param, r
 	return &info.Controller{}
 }
 
-func InitializeRemoveCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime, target *config.RemoveMode) *remove.Controller {
+func InitializeRemoveCommandController(ctx context.Context, logE *logrus.Entry, param *config.Param, httpClient *http.Client, rt *runtime.Runtime, target *config.RemoveMode) *remove.Controller {
 	wire.Build(
 		remove.New,
 		wire.NewSet(
@@ -1077,7 +1077,7 @@ func InitializeVacuumCommandController(ctx context.Context, param *config.Param,
 	return &cvacuum.Controller{}
 }
 
-func InitializeVacuumInitCommandController(ctx context.Context, param *config.Param, rt *runtime.Runtime, httpClient *http.Client) *initialize.Controller {
+func InitializeVacuumInitCommandController(ctx context.Context, logE *logrus.Entry, param *config.Param, rt *runtime.Runtime, httpClient *http.Client) *initialize.Controller {
 	wire.Build(
 		initialize.New,
 		afero.NewOsFs,

--- a/pkg/controller/wire_gen.go
+++ b/pkg/controller/wire_gen.go
@@ -8,6 +8,9 @@ package controller
 
 import (
 	"context"
+	"io"
+	"net/http"
+
 	"github.com/aquaproj/aqua/v2/pkg/cargo"
 	"github.com/aquaproj/aqua/v2/pkg/checksum"
 	"github.com/aquaproj/aqua/v2/pkg/config"
@@ -52,8 +55,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/suzuki-shunsuke/go-osenv/osenv"
-	"io"
-	"net/http"
 )
 
 // Injectors from wire.go:

--- a/pkg/controller/wire_gen.go
+++ b/pkg/controller/wire_gen.go
@@ -8,9 +8,6 @@ package controller
 
 import (
 	"context"
-	"io"
-	"net/http"
-
 	"github.com/aquaproj/aqua/v2/pkg/cargo"
 	"github.com/aquaproj/aqua/v2/pkg/checksum"
 	"github.com/aquaproj/aqua/v2/pkg/config"
@@ -55,15 +52,17 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/suzuki-shunsuke/go-osenv/osenv"
+	"io"
+	"net/http"
 )
 
 // Injectors from wire.go:
 
-func InitializeListCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *list.Controller {
+func InitializeListCommandController(ctx context.Context, logE *logrus.Entry, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *list.Controller {
 	fs := afero.NewOsFs()
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs, param)
-	repositoriesService := github.New(ctx)
+	repositoriesService := github.New(ctx, logE)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
 	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(repositoriesService, httpDownloader)
 	executor := osexec.New()
@@ -76,17 +75,17 @@ func InitializeListCommandController(ctx context.Context, param *config.Param, h
 	return controller
 }
 
-func InitializeGenerateRegistryCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, stdout io.Writer) *genrgst.Controller {
+func InitializeGenerateRegistryCommandController(ctx context.Context, logE *logrus.Entry, param *config.Param, httpClient *http.Client, stdout io.Writer) *genrgst.Controller {
 	fs := afero.NewOsFs()
-	repositoriesService := github.New(ctx)
+	repositoriesService := github.New(ctx, logE)
 	outputter := output.New(stdout, fs)
 	client := cargo.NewClient(httpClient)
 	controller := genrgst.NewController(fs, repositoriesService, outputter, client)
 	return controller
 }
 
-func InitializeInitCommandController(ctx context.Context, param *config.Param) *initcmd.Controller {
-	repositoriesService := github.New(ctx)
+func InitializeInitCommandController(ctx context.Context, logE *logrus.Entry, param *config.Param) *initcmd.Controller {
+	repositoriesService := github.New(ctx, logE)
 	fs := afero.NewOsFs()
 	controller := initcmd.New(repositoriesService, fs)
 	return controller
@@ -98,11 +97,11 @@ func InitializeInitPolicyCommandController(ctx context.Context) *initpolicy.Cont
 	return controller
 }
 
-func InitializeGenerateCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *generate.Controller {
+func InitializeGenerateCommandController(ctx context.Context, logE *logrus.Entry, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *generate.Controller {
 	fs := afero.NewOsFs()
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs, param)
-	repositoriesService := github.New(ctx)
+	repositoriesService := github.New(ctx, logE)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
 	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(repositoriesService, httpDownloader)
 	executor := osexec.New()
@@ -128,7 +127,7 @@ func InitializeInstallCommandController(ctx context.Context, logE *logrus.Entry,
 	fs := afero.NewOsFs()
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs, param)
-	repositoriesService := github.New(ctx)
+	repositoriesService := github.New(ctx, logE)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
 	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(repositoriesService, httpDownloader)
 	executor := osexec.New()
@@ -164,11 +163,11 @@ func InitializeInstallCommandController(ctx context.Context, logE *logrus.Entry,
 	return controller, nil
 }
 
-func InitializeWhichCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *which.Controller {
+func InitializeWhichCommandController(ctx context.Context, logE *logrus.Entry, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *which.Controller {
 	fs := afero.NewOsFs()
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs, param)
-	repositoriesService := github.New(ctx)
+	repositoriesService := github.New(ctx, logE)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
 	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(repositoriesService, httpDownloader)
 	executor := osexec.New()
@@ -184,7 +183,7 @@ func InitializeWhichCommandController(ctx context.Context, param *config.Param, 
 }
 
 func InitializeExecCommandController(ctx context.Context, logE *logrus.Entry, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) (*exec.Controller, error) {
-	repositoriesService := github.New(ctx)
+	repositoriesService := github.New(ctx, logE)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
 	downloader := download.NewDownloader(repositoriesService, httpDownloader)
 	fs := afero.NewOsFs()
@@ -227,7 +226,7 @@ func InitializeExecCommandController(ctx context.Context, logE *logrus.Entry, pa
 
 func InitializeUpdateAquaCommandController(ctx context.Context, logE *logrus.Entry, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) (*updateaqua.Controller, error) {
 	fs := afero.NewOsFs()
-	repositoriesService := github.New(ctx)
+	repositoriesService := github.New(ctx, logE)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
 	downloader := download.NewDownloader(repositoriesService, httpDownloader)
 	linker := link.New()
@@ -258,7 +257,7 @@ func InitializeUpdateAquaCommandController(ctx context.Context, logE *logrus.Ent
 }
 
 func InitializeCopyCommandController(ctx context.Context, logE *logrus.Entry, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) (*cp.Controller, error) {
-	repositoriesService := github.New(ctx)
+	repositoriesService := github.New(ctx, logE)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
 	downloader := download.NewDownloader(repositoriesService, httpDownloader)
 	fs := afero.NewOsFs()
@@ -300,11 +299,11 @@ func InitializeCopyCommandController(ctx context.Context, logE *logrus.Entry, pa
 	return cpController, nil
 }
 
-func InitializeUpdateChecksumCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *updatechecksum.Controller {
+func InitializeUpdateChecksumCommandController(ctx context.Context, logE *logrus.Entry, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *updatechecksum.Controller {
 	fs := afero.NewOsFs()
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs, param)
-	repositoriesService := github.New(ctx)
+	repositoriesService := github.New(ctx, logE)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
 	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(repositoriesService, httpDownloader)
 	executor := osexec.New()
@@ -318,8 +317,8 @@ func InitializeUpdateChecksumCommandController(ctx context.Context, param *confi
 	return controller
 }
 
-func InitializeUpdateCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *update.Controller {
-	repositoriesService := github.New(ctx)
+func InitializeUpdateCommandController(ctx context.Context, logE *logrus.Entry, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *update.Controller {
+	repositoriesService := github.New(ctx, logE)
 	fs := afero.NewOsFs()
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs, param)
@@ -370,11 +369,11 @@ func InitializeInfoCommandController(ctx context.Context, param *config.Param, r
 	return controller
 }
 
-func InitializeRemoveCommandController(ctx context.Context, param *config.Param, httpClient *http.Client, rt *runtime.Runtime, target *config.RemoveMode) *remove.Controller {
+func InitializeRemoveCommandController(ctx context.Context, logE *logrus.Entry, param *config.Param, httpClient *http.Client, rt *runtime.Runtime, target *config.RemoveMode) *remove.Controller {
 	fs := afero.NewOsFs()
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs, param)
-	repositoriesService := github.New(ctx)
+	repositoriesService := github.New(ctx, logE)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
 	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(repositoriesService, httpDownloader)
 	executor := osexec.New()
@@ -399,12 +398,12 @@ func InitializeVacuumCommandController(ctx context.Context, param *config.Param,
 	return controller
 }
 
-func InitializeVacuumInitCommandController(ctx context.Context, param *config.Param, rt *runtime.Runtime, httpClient *http.Client) *initialize.Controller {
+func InitializeVacuumInitCommandController(ctx context.Context, logE *logrus.Entry, param *config.Param, rt *runtime.Runtime, httpClient *http.Client) *initialize.Controller {
 	fs := afero.NewOsFs()
 	client := vacuum.New(fs, param)
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs, param)
-	repositoriesService := github.New(ctx)
+	repositoriesService := github.New(ctx, logE)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
 	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(repositoriesService, httpDownloader)
 	executor := osexec.New()

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -4,11 +4,12 @@ import (
 	"testing"
 
 	"github.com/aquaproj/aqua/v2/pkg/github"
+	"github.com/sirupsen/logrus"
 )
 
 func TestNew(t *testing.T) {
 	t.Parallel()
-	if client := github.New(t.Context()); client == nil {
+	if client := github.New(t.Context(), logrus.NewEntry(logrus.New())); client == nil {
 		t.Fatal("client must not be nil")
 	}
 }

--- a/pkg/keyring/keyring.go
+++ b/pkg/keyring/keyring.go
@@ -28,14 +28,6 @@ func NewTokenManager() *TokenManager {
 	return &TokenManager{}
 }
 
-func (tm *TokenManager) Get() (string, error) {
-	s, err := keyring.Get(keyService, keyName)
-	if err != nil {
-		return "", fmt.Errorf("get a GitHub Access token from keyring: %w", err)
-	}
-	return s, nil
-}
-
 func (tm *TokenManager) Set(token string) error {
 	if err := keyring.Set(keyService, keyName, token); err != nil {
 		return fmt.Errorf("set a GitHub Access token in keyring: %w", err)

--- a/pkg/keyring/keyring.go
+++ b/pkg/keyring/keyring.go
@@ -1,0 +1,81 @@
+// Package keyring provides a way to manage a GitHub access token using the system's keyring.
+package keyring
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/suzuki-shunsuke/logrus-error/logerr"
+	"github.com/zalando/go-keyring"
+	"golang.org/x/oauth2"
+)
+
+const (
+	keyService = "aquaproj.github.io"
+	keyName    = "GITHUB_TOKEN"
+)
+
+func Enabled() bool {
+	return os.Getenv("AQUA_KEYRING_ENABLED") == "true"
+}
+
+type TokenManager struct{}
+
+func NewTokenManager() *TokenManager {
+	return &TokenManager{}
+}
+
+func (tm *TokenManager) Get() (string, error) {
+	s, err := keyring.Get(keyService, keyName)
+	if err != nil {
+		return "", fmt.Errorf("get a GitHub Access token from keyring: %w", err)
+	}
+	return s, nil
+}
+
+func (tm *TokenManager) Set(token string) error {
+	if err := keyring.Set(keyService, keyName, token); err != nil {
+		return fmt.Errorf("set a GitHub Access token in keyring: %w", err)
+	}
+	return nil
+}
+
+func (tm *TokenManager) Remove(logE *logrus.Entry) error {
+	if err := keyring.Delete(keyService, keyName); err != nil {
+		if errors.Is(err, keyring.ErrNotFound) {
+			logerr.WithError(logE, err).Warn("remove a GitHub Access token from keyring")
+			return nil
+		}
+		return fmt.Errorf("delete a GitHub Access token from keyring: %w", err)
+	}
+	return nil
+}
+
+type TokenSource struct {
+	token *oauth2.Token
+	logE  *logrus.Entry
+}
+
+func NewTokenSource(logE *logrus.Entry) *TokenSource {
+	return &TokenSource{
+		logE: logE,
+	}
+}
+
+func (ks *TokenSource) Token() (*oauth2.Token, error) {
+	if ks.token != nil {
+		return ks.token, nil
+	}
+	ks.logE.Debug("getting a GitHub Access toke from keyring")
+	s, err := keyring.Get(keyService, keyName)
+	if err != nil {
+		return nil, fmt.Errorf("get a GitHub Access token from keyring: %w", err)
+	}
+	ks.logE.Debug("got a GitHub Access toke from keyring")
+	ks.token = &oauth2.Token{
+		AccessToken: s,
+	}
+	return ks.token, nil
+}


### PR DESCRIPTION
This pull request enables you to manage a GitHub Access token using secret store such as [Windows Credential Manager](https://support.microsoft.com/en-us/windows/accessing-credential-manager-1b5c916a-6a16-889f-8581-fc16e8165ac0), [macOS Keychain](https://en.wikipedia.org/wiki/Keychain_(software)), and [GNOME Keyring](https://wiki.gnome.org/Projects/GnomeKeyring).

1. Configure a GitHub Access token by `aqua token set` command:

```console
$ aqua token set
Enter a GitHub access token: # Input GitHub Access token
```

or you can also pass a GitHub Access token via standard input:

```sh
echo "<github access token>" | aqua tokn set -stdin
```

2. Enable the feature by setting the environment variable `AQUA_KEYRING_ENABLED`:

```sh
export AQUA_KEYRING_ENABLED=true
```

Note that if the environment variable `GITHUB_TOKEN` is set, this feature gets disabled.

You can remove a GitHub Access token from keyring by `aqua token rm` command:

```sh
aqua token rm
```

## Benchmark

```console
$ hyperfine -N --warmup 3 '/Users/shunsukesuzuki/go/bin/aqua which mkghtag -version' '/Users/shunsukesuzuki/.local/share/aquaproj-aqua/internal/pkgs/github_release/github.com/aquaproj/aqua/v2.50.1/aqua_darwin_arm64.tar.gz/aqua which mkghtag -version'
Benchmark 1: /Users/shunsukesuzuki/go/bin/aqua which mkghtag -version
  Time (mean ± σ):     421.5 ms ±  34.6 ms    [User: 477.9 ms, System: 166.8 ms]
  Range (min … max):   398.3 ms … 490.7 ms    10 runs
 
Benchmark 2: /Users/shunsukesuzuki/.local/share/aquaproj-aqua/internal/pkgs/github_release/github.com/aquaproj/aqua/v2.50.1/aqua_darwin_arm64.tar.gz/aqua which mkghtag -version
  Time (mean ± σ):     414.3 ms ±  16.7 ms    [User: 474.6 ms, System: 161.8 ms]
  Range (min … max):   399.7 ms … 450.5 ms    10 runs
 
Summary
  /Users/shunsukesuzuki/.local/share/aquaproj-aqua/internal/pkgs/github_release/github.com/aquaproj/aqua/v2.50.1/aqua_darwin_arm64.tar.gz/aqua which mkghtag -version ran
    1.02 ± 0.09 times faster than /Users/shunsukesuzuki/go/bin/aqua which mkghtag -version
```