### PR TITLE
bind given stdout correctly for generate-registry controller

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -113,7 +113,6 @@ github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hf
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
-github.com/google/subcommands v1.2.0 h1:vWQspBTo2nEqTUFita5/KeEWlUL8kQObDFbub/EN9oE=
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -309,8 +308,6 @@ golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
-golang.org/x/mod v0.17.0 h1:zY54UmvipHiNd+pm+m0x9KhZ9hl1/7QNMyxXbc6ICqA=
-golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -425,8 +422,6 @@ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/tools v0.13.0/go.mod h1:HvlwmtVNQAhOuCjW7xxvovg8wbNq7LwfXh/k7wXUl58=
 golang.org/x/tools v0.17.0/go.mod h1:xsh6VxdV005rRVaS6SSAf9oiAqljS7UZUacMZ8Bnsps=
-golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d h1:vU5i/LfpvrRCpgM/VPfJLg5KjxD3E+hfT1SH+d9zLwg=
-golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,7 @@ github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hf
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
+github.com/google/subcommands v1.2.0 h1:vWQspBTo2nEqTUFita5/KeEWlUL8kQObDFbub/EN9oE=
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -308,6 +309,8 @@ golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/mod v0.17.0 h1:zY54UmvipHiNd+pm+m0x9KhZ9hl1/7QNMyxXbc6ICqA=
+golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -422,6 +425,8 @@ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/tools v0.13.0/go.mod h1:HvlwmtVNQAhOuCjW7xxvovg8wbNq7LwfXh/k7wXUl58=
 golang.org/x/tools v0.17.0/go.mod h1:xsh6VxdV005rRVaS6SSAf9oiAqljS7UZUacMZ8Bnsps=
+golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d h1:vU5i/LfpvrRCpgM/VPfJLg5KjxD3E+hfT1SH+d9zLwg=
+golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/controller/generate-registry/controller.go
+++ b/pkg/controller/generate-registry/controller.go
@@ -3,7 +3,6 @@ package genrgst
 import (
 	"context"
 	"io"
-	"os"
 
 	"github.com/aquaproj/aqua/v2/pkg/cargo"
 	"github.com/aquaproj/aqua/v2/pkg/controller/generate/output"
@@ -22,9 +21,9 @@ type TestdataOutputter interface {
 	Output(param *output.Param) error
 }
 
-func NewController(fs afero.Fs, gh RepositoriesService, testdataOutputter TestdataOutputter, cargoClient CargoClient) *Controller {
+func NewController(fs afero.Fs, gh RepositoriesService, testdataOutputter TestdataOutputter, cargoClient CargoClient, stdout io.Writer) *Controller {
 	return &Controller{
-		stdout:            os.Stdout,
+		stdout:            stdout,
 		fs:                fs,
 		github:            gh,
 		testdataOutputter: testdataOutputter,

--- a/pkg/controller/generate-registry/generate_internal_test.go
+++ b/pkg/controller/generate-registry/generate_internal_test.go
@@ -1,6 +1,7 @@
 package genrgst
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/aquaproj/aqua/v2/pkg/cargo"
@@ -138,7 +139,8 @@ func TestController_getPackageInfo(t *testing.T) { //nolint:funlen
 			cargoClient := &cargo.MockClient{
 				CratePayload: d.crate,
 			}
-			ctrl := NewController(nil, gh, nil, cargoClient)
+			var buf bytes.Buffer
+			ctrl := NewController(nil, gh, nil, cargoClient, &buf)
 			pkgInfo, _ := ctrl.getPackageInfo(ctx, logE, d.pkgName, &config.Param{}, &Config{})
 			if diff := cmp.Diff(d.exp, pkgInfo); diff != "" {
 				t.Fatal(diff)

--- a/pkg/controller/wire_gen.go
+++ b/pkg/controller/wire_gen.go
@@ -8,6 +8,9 @@ package controller
 
 import (
 	"context"
+	"io"
+	"net/http"
+
 	"github.com/aquaproj/aqua/v2/pkg/cargo"
 	"github.com/aquaproj/aqua/v2/pkg/checksum"
 	"github.com/aquaproj/aqua/v2/pkg/config"
@@ -52,8 +55,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/suzuki-shunsuke/go-osenv/osenv"
-	"io"
-	"net/http"
 )
 
 // Injectors from wire.go:

--- a/pkg/controller/wire_gen.go
+++ b/pkg/controller/wire_gen.go
@@ -8,9 +8,6 @@ package controller
 
 import (
 	"context"
-	"io"
-	"net/http"
-
 	"github.com/aquaproj/aqua/v2/pkg/cargo"
 	"github.com/aquaproj/aqua/v2/pkg/checksum"
 	"github.com/aquaproj/aqua/v2/pkg/config"
@@ -55,6 +52,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/suzuki-shunsuke/go-osenv/osenv"
+	"io"
+	"net/http"
 )
 
 // Injectors from wire.go:
@@ -63,11 +62,11 @@ func InitializeListCommandController(ctx context.Context, logE *logrus.Entry, pa
 	fs := afero.NewOsFs()
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs, param)
-	repositoriesService := github.New(ctx, logE)
+	v := github.New(ctx, logE)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
-	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(repositoriesService, httpDownloader)
+	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(v, httpDownloader)
 	executor := osexec.New()
-	downloader := download.NewDownloader(repositoriesService, httpDownloader)
+	downloader := download.NewDownloader(v, httpDownloader)
 	verifier := cosign.NewVerifier(executor, fs, downloader, param)
 	executorImpl := slsa.NewExecutor(executor, param)
 	slsaVerifier := slsa.New(downloader, fs, executorImpl)
@@ -78,17 +77,17 @@ func InitializeListCommandController(ctx context.Context, logE *logrus.Entry, pa
 
 func InitializeGenerateRegistryCommandController(ctx context.Context, logE *logrus.Entry, param *config.Param, httpClient *http.Client, stdout io.Writer) *genrgst.Controller {
 	fs := afero.NewOsFs()
-	repositoriesService := github.New(ctx, logE)
+	v := github.New(ctx, logE)
 	outputter := output.New(stdout, fs)
 	client := cargo.NewClient(httpClient)
-	controller := genrgst.NewController(fs, repositoriesService, outputter, client)
+	controller := genrgst.NewController(fs, v, outputter, client, stdout)
 	return controller
 }
 
 func InitializeInitCommandController(ctx context.Context, logE *logrus.Entry, param *config.Param) *initcmd.Controller {
-	repositoriesService := github.New(ctx, logE)
+	v := github.New(ctx, logE)
 	fs := afero.NewOsFs()
-	controller := initcmd.New(repositoriesService, fs)
+	controller := initcmd.New(v, fs)
 	return controller
 }
 
@@ -102,11 +101,11 @@ func InitializeGenerateCommandController(ctx context.Context, logE *logrus.Entry
 	fs := afero.NewOsFs()
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs, param)
-	repositoriesService := github.New(ctx, logE)
+	v := github.New(ctx, logE)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
-	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(repositoriesService, httpDownloader)
+	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(v, httpDownloader)
 	executor := osexec.New()
-	downloader := download.NewDownloader(repositoriesService, httpDownloader)
+	downloader := download.NewDownloader(v, httpDownloader)
 	verifier := cosign.NewVerifier(executor, fs, downloader, param)
 	executorImpl := slsa.NewExecutor(executor, param)
 	slsaVerifier := slsa.New(downloader, fs, executorImpl)
@@ -114,13 +113,13 @@ func InitializeGenerateCommandController(ctx context.Context, logE *logrus.Entry
 	fuzzyfinderFinder := fuzzyfinder.New()
 	client := cargo.NewClient(httpClient)
 	cargoVersionGetter := versiongetter.NewCargo(client)
-	gitHubTagVersionGetter := versiongetter.NewGitHubTag(repositoriesService)
-	gitHubReleaseVersionGetter := versiongetter.NewGitHubRelease(repositoriesService)
+	gitHubTagVersionGetter := versiongetter.NewGitHubTag(v)
+	gitHubReleaseVersionGetter := versiongetter.NewGitHubRelease(v)
 	goproxyClient := goproxy.New(httpClient)
 	goGetter := versiongetter.NewGoGetter(goproxyClient)
 	generalVersionGetter := versiongetter.NewGeneralVersionGetter(cargoVersionGetter, gitHubTagVersionGetter, gitHubReleaseVersionGetter, goGetter)
 	fuzzyGetter := versiongetter.NewFuzzy(fuzzyfinderFinder, generalVersionGetter)
-	controller := generate.New(configFinder, configReader, installer, repositoriesService, fs, fuzzyfinderFinder, fuzzyGetter)
+	controller := generate.New(configFinder, configReader, installer, v, fs, fuzzyfinderFinder, fuzzyGetter)
 	return controller
 }
 
@@ -128,17 +127,17 @@ func InitializeInstallCommandController(ctx context.Context, logE *logrus.Entry,
 	fs := afero.NewOsFs()
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs, param)
-	repositoriesService := github.New(ctx, logE)
+	v := github.New(ctx, logE)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
-	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(repositoriesService, httpDownloader)
+	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(v, httpDownloader)
 	executor := osexec.New()
-	downloader := download.NewDownloader(repositoriesService, httpDownloader)
+	downloader := download.NewDownloader(v, httpDownloader)
 	verifier := cosign.NewVerifier(executor, fs, downloader, param)
 	executorImpl := slsa.NewExecutor(executor, param)
 	slsaVerifier := slsa.New(downloader, fs, executorImpl)
 	installer := registry.New(param, gitHubContentFileDownloader, fs, rt, verifier, slsaVerifier)
 	linker := link.New()
-	checksumDownloaderImpl := download.NewChecksumDownloader(repositoriesService, rt, httpDownloader)
+	checksumDownloaderImpl := download.NewChecksumDownloader(v, rt, httpDownloader)
 	calculator := checksum.NewCalculator()
 	unarchiver := unarchive.New(executor, fs)
 	minisignExecutorImpl, err := minisign.NewExecutor(logE, executor, param)
@@ -168,11 +167,11 @@ func InitializeWhichCommandController(ctx context.Context, logE *logrus.Entry, p
 	fs := afero.NewOsFs()
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs, param)
-	repositoriesService := github.New(ctx, logE)
+	v := github.New(ctx, logE)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
-	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(repositoriesService, httpDownloader)
+	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(v, httpDownloader)
 	executor := osexec.New()
-	downloader := download.NewDownloader(repositoriesService, httpDownloader)
+	downloader := download.NewDownloader(v, httpDownloader)
 	verifier := cosign.NewVerifier(executor, fs, downloader, param)
 	executorImpl := slsa.NewExecutor(executor, param)
 	slsaVerifier := slsa.New(downloader, fs, executorImpl)
@@ -184,12 +183,12 @@ func InitializeWhichCommandController(ctx context.Context, logE *logrus.Entry, p
 }
 
 func InitializeExecCommandController(ctx context.Context, logE *logrus.Entry, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) (*exec.Controller, error) {
-	repositoriesService := github.New(ctx, logE)
+	v := github.New(ctx, logE)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
-	downloader := download.NewDownloader(repositoriesService, httpDownloader)
+	downloader := download.NewDownloader(v, httpDownloader)
 	fs := afero.NewOsFs()
 	linker := link.New()
-	checksumDownloaderImpl := download.NewChecksumDownloader(repositoriesService, rt, httpDownloader)
+	checksumDownloaderImpl := download.NewChecksumDownloader(v, rt, httpDownloader)
 	calculator := checksum.NewCalculator()
 	executor := osexec.New()
 	unarchiver := unarchive.New(executor, fs)
@@ -213,7 +212,7 @@ func InitializeExecCommandController(ctx context.Context, logE *logrus.Entry, pa
 	installer := installpackage.New(param, downloader, rt, fs, linker, checksumDownloaderImpl, calculator, unarchiver, verifier, slsaVerifier, minisignVerifier, ghattestationVerifier, goInstallInstallerImpl, goBuildInstallerImpl, cargoPackageInstallerImpl, client)
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs, param)
-	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(repositoriesService, httpDownloader)
+	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(v, httpDownloader)
 	registryInstaller := registry.New(param, gitHubContentFileDownloader, fs, rt, verifier, slsaVerifier)
 	osEnv := osenv.New()
 	controller := which.New(param, configFinder, configReader, registryInstaller, rt, osEnv, fs, linker)
@@ -227,11 +226,11 @@ func InitializeExecCommandController(ctx context.Context, logE *logrus.Entry, pa
 
 func InitializeUpdateAquaCommandController(ctx context.Context, logE *logrus.Entry, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) (*updateaqua.Controller, error) {
 	fs := afero.NewOsFs()
-	repositoriesService := github.New(ctx, logE)
+	v := github.New(ctx, logE)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
-	downloader := download.NewDownloader(repositoriesService, httpDownloader)
+	downloader := download.NewDownloader(v, httpDownloader)
 	linker := link.New()
-	checksumDownloaderImpl := download.NewChecksumDownloader(repositoriesService, rt, httpDownloader)
+	checksumDownloaderImpl := download.NewChecksumDownloader(v, rt, httpDownloader)
 	calculator := checksum.NewCalculator()
 	executor := osexec.New()
 	unarchiver := unarchive.New(executor, fs)
@@ -253,17 +252,17 @@ func InitializeUpdateAquaCommandController(ctx context.Context, logE *logrus.Ent
 	cargoPackageInstallerImpl := installpackage.NewCargoPackageInstallerImpl(executor, fs)
 	client := vacuum.New(fs, param)
 	installer := installpackage.New(param, downloader, rt, fs, linker, checksumDownloaderImpl, calculator, unarchiver, verifier, slsaVerifier, minisignVerifier, ghattestationVerifier, goInstallInstallerImpl, goBuildInstallerImpl, cargoPackageInstallerImpl, client)
-	controller := updateaqua.New(param, fs, rt, repositoriesService, installer)
+	controller := updateaqua.New(param, fs, rt, v, installer)
 	return controller, nil
 }
 
 func InitializeCopyCommandController(ctx context.Context, logE *logrus.Entry, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) (*cp.Controller, error) {
-	repositoriesService := github.New(ctx, logE)
+	v := github.New(ctx, logE)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
-	downloader := download.NewDownloader(repositoriesService, httpDownloader)
+	downloader := download.NewDownloader(v, httpDownloader)
 	fs := afero.NewOsFs()
 	linker := link.New()
-	checksumDownloaderImpl := download.NewChecksumDownloader(repositoriesService, rt, httpDownloader)
+	checksumDownloaderImpl := download.NewChecksumDownloader(v, rt, httpDownloader)
 	calculator := checksum.NewCalculator()
 	executor := osexec.New()
 	unarchiver := unarchive.New(executor, fs)
@@ -287,7 +286,7 @@ func InitializeCopyCommandController(ctx context.Context, logE *logrus.Entry, pa
 	installer := installpackage.New(param, downloader, rt, fs, linker, checksumDownloaderImpl, calculator, unarchiver, verifier, slsaVerifier, minisignVerifier, ghattestationVerifier, goInstallInstallerImpl, goBuildInstallerImpl, cargoPackageInstallerImpl, client)
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs, param)
-	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(repositoriesService, httpDownloader)
+	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(v, httpDownloader)
 	registryInstaller := registry.New(param, gitHubContentFileDownloader, fs, rt, verifier, slsaVerifier)
 	osEnv := osenv.New()
 	controller := which.New(param, configFinder, configReader, registryInstaller, rt, osEnv, fs, linker)
@@ -304,29 +303,29 @@ func InitializeUpdateChecksumCommandController(ctx context.Context, logE *logrus
 	fs := afero.NewOsFs()
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs, param)
-	repositoriesService := github.New(ctx, logE)
+	v := github.New(ctx, logE)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
-	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(repositoriesService, httpDownloader)
+	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(v, httpDownloader)
 	executor := osexec.New()
-	downloader := download.NewDownloader(repositoriesService, httpDownloader)
+	downloader := download.NewDownloader(v, httpDownloader)
 	verifier := cosign.NewVerifier(executor, fs, downloader, param)
 	executorImpl := slsa.NewExecutor(executor, param)
 	slsaVerifier := slsa.New(downloader, fs, executorImpl)
 	installer := registry.New(param, gitHubContentFileDownloader, fs, rt, verifier, slsaVerifier)
-	checksumDownloaderImpl := download.NewChecksumDownloader(repositoriesService, rt, httpDownloader)
+	checksumDownloaderImpl := download.NewChecksumDownloader(v, rt, httpDownloader)
 	controller := updatechecksum.New(param, configFinder, configReader, installer, fs, rt, checksumDownloaderImpl, downloader, gitHubContentFileDownloader)
 	return controller
 }
 
 func InitializeUpdateCommandController(ctx context.Context, logE *logrus.Entry, param *config.Param, httpClient *http.Client, rt *runtime.Runtime) *update.Controller {
-	repositoriesService := github.New(ctx, logE)
+	v := github.New(ctx, logE)
 	fs := afero.NewOsFs()
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs, param)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
-	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(repositoriesService, httpDownloader)
+	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(v, httpDownloader)
 	executor := osexec.New()
-	downloader := download.NewDownloader(repositoriesService, httpDownloader)
+	downloader := download.NewDownloader(v, httpDownloader)
 	verifier := cosign.NewVerifier(executor, fs, downloader, param)
 	executorImpl := slsa.NewExecutor(executor, param)
 	slsaVerifier := slsa.New(downloader, fs, executorImpl)
@@ -334,8 +333,8 @@ func InitializeUpdateCommandController(ctx context.Context, logE *logrus.Entry, 
 	fuzzyfinderFinder := fuzzyfinder.New()
 	client := cargo.NewClient(httpClient)
 	cargoVersionGetter := versiongetter.NewCargo(client)
-	gitHubTagVersionGetter := versiongetter.NewGitHubTag(repositoriesService)
-	gitHubReleaseVersionGetter := versiongetter.NewGitHubRelease(repositoriesService)
+	gitHubTagVersionGetter := versiongetter.NewGitHubTag(v)
+	gitHubReleaseVersionGetter := versiongetter.NewGitHubRelease(v)
 	goproxyClient := goproxy.New(httpClient)
 	goGetter := versiongetter.NewGoGetter(goproxyClient)
 	generalVersionGetter := versiongetter.NewGeneralVersionGetter(cargoVersionGetter, gitHubTagVersionGetter, gitHubReleaseVersionGetter, goGetter)
@@ -343,7 +342,7 @@ func InitializeUpdateCommandController(ctx context.Context, logE *logrus.Entry, 
 	osEnv := osenv.New()
 	linker := link.New()
 	controller := which.New(param, configFinder, configReader, installer, rt, osEnv, fs, linker)
-	updateController := update.New(param, repositoriesService, configFinder, configReader, installer, fs, rt, fuzzyGetter, fuzzyfinderFinder, controller)
+	updateController := update.New(param, v, configFinder, configReader, installer, fs, rt, fuzzyGetter, fuzzyfinderFinder, controller)
 	return updateController
 }
 
@@ -374,11 +373,11 @@ func InitializeRemoveCommandController(ctx context.Context, logE *logrus.Entry, 
 	fs := afero.NewOsFs()
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs, param)
-	repositoriesService := github.New(ctx, logE)
+	v := github.New(ctx, logE)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
-	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(repositoriesService, httpDownloader)
+	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(v, httpDownloader)
 	executor := osexec.New()
-	downloader := download.NewDownloader(repositoriesService, httpDownloader)
+	downloader := download.NewDownloader(v, httpDownloader)
 	verifier := cosign.NewVerifier(executor, fs, downloader, param)
 	executorImpl := slsa.NewExecutor(executor, param)
 	slsaVerifier := slsa.New(downloader, fs, executorImpl)
@@ -404,11 +403,11 @@ func InitializeVacuumInitCommandController(ctx context.Context, logE *logrus.Ent
 	client := vacuum.New(fs, param)
 	configFinder := finder.NewConfigFinder(fs)
 	configReader := reader.New(fs, param)
-	repositoriesService := github.New(ctx, logE)
+	v := github.New(ctx, logE)
 	httpDownloader := download.NewHTTPDownloader(httpClient)
-	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(repositoriesService, httpDownloader)
+	gitHubContentFileDownloader := download.NewGitHubContentFileDownloader(v, httpDownloader)
 	executor := osexec.New()
-	downloader := download.NewDownloader(repositoriesService, httpDownloader)
+	downloader := download.NewDownloader(v, httpDownloader)
 	verifier := cosign.NewVerifier(executor, fs, downloader, param)
 	executorImpl := slsa.NewExecutor(executor, param)
 	slsaVerifier := slsa.New(downloader, fs, executorImpl)


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request) (I guess it's not applicable to this PR)
  - Link to the issue:
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->

Even though `InitializeGenerateRegistryCommandController` accepts stdout as an argument, the passed stdout was not correctly used. 
https://github.com/aquaproj/aqua/blob/d772eb40ac35ab8f4cef96dab82de6a7209d5d89/pkg/cli/genr/command.go#L145

This PR fixed the problem.


Note that I used `go generate ./...` to generate wire_gen.go file. It seems it produces needless diff since it uses the latest wire code.
I don't know what wire version was used previously, so I just left it as is. We may want to consider managing wire with aqua config?
