### PR TITLE
Add logic to handle `download and unarchive the package`

### DIFF
--- a/pkg/installpackage/download.go
+++ b/pkg/installpackage/download.go
@@ -29,10 +29,10 @@ func (is *Installer) downloadWithRetry(ctx context.Context, logE *logrus.Entry, 
 				errorSubstrings := []string{"file already exists", "download and unarchive the package"}
 				found := false
 				for _, substring := range errorSubstrings {
-				    if strings.Contains(err.Error(), substring) {
-				        found = true
-				        break
-				    }
+					if strings.Contains(err.Error(), substring) {
+						found = true
+						break
+					}
 				}
 				if found {
 					if retryCount >= maxRetryDownload {

--- a/pkg/installpackage/download.go
+++ b/pkg/installpackage/download.go
@@ -29,7 +29,7 @@ func (is *Installer) downloadWithRetry(ctx context.Context, logE *logrus.Entry, 
 				errorSubstrings := []string{"file already exists", "download and unarchive the package"}
 				found := false
 				for _, substring := range errorSubstrings {
-				    if strings.Contains(errorMessage, substring) {
+				    if strings.Contains(err.Error(), substring) {
 				        found = true
 				        break
 				    }

--- a/pkg/installpackage/download.go
+++ b/pkg/installpackage/download.go
@@ -24,9 +24,17 @@ func (is *Installer) downloadWithRetry(ctx context.Context, logE *logrus.Entry, 
 		logE.Debug("check if the package is already installed")
 		finfo, err := is.fs.Stat(param.Dest)
 		if err != nil { //nolint:nestif
-			// file doesn't exist
+			// file doesn't exist or download fails
 			if err := is.download(ctx, logE, param); err != nil {
-				if strings.Contains(err.Error(), "file already exists") {
+				errorSubstrings := []string{"file already exists", "download and unarchive the package"}
+				found := false
+				for _, substring := range errorSubstrings {
+				    if strings.Contains(errorMessage, substring) {
+				        found = true
+				        break
+				    }
+				}
+				if found {
 					if retryCount >= maxRetryDownload {
 						return err
 					}


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - [Link to the issue:](https://github.com/aquaproj/aqua/issues/829)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->


In [this issue](https://github.com/aquaproj/aqua/issues/829), we found that sometimes aqua fails due to flaky-download. The recommended solution (in the noted issue) is to amend the retry logic to additionally handle download-failure.