### PR TITLE
fix: stop replacing hashicorp/go-retryablehttp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-github/v72 v72.0.0
 	github.com/google/wire v0.6.0
-	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/hashicorp/go-version v1.7.0
 	github.com/invopop/jsonschema v0.13.0
 	github.com/ktr0731/go-fuzzyfinder v0.9.0
@@ -25,6 +24,7 @@ require (
 	github.com/suzuki-shunsuke/go-error-with-exit-code v1.0.0
 	github.com/suzuki-shunsuke/go-findconfig v1.2.0
 	github.com/suzuki-shunsuke/go-osenv v0.1.0
+	github.com/suzuki-shunsuke/go-retryablehttp v0.7.8-1
 	github.com/suzuki-shunsuke/go-retryablehttp-logrus v0.0.1
 	github.com/suzuki-shunsuke/logrus-error v0.1.4
 	github.com/suzuki-shunsuke/urfave-cli-v3-util v0.0.5
@@ -38,8 +38,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 )
-
-replace github.com/hashicorp/go-retryablehttp v0.7.7 => github.com/suzuki-shunsuke/go-retryablehttp v0.7.8-0.20250608151404-89ccceec3913
 
 require (
 	al.essio.dev/pkg/shellescape v1.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -249,8 +249,8 @@ github.com/suzuki-shunsuke/go-jsoneq v0.1.2 h1:A4czEbmFqSELTbrEtXVo4dSgfz2e2Z0y6
 github.com/suzuki-shunsuke/go-jsoneq v0.1.2/go.mod h1:ETXAwfruZTqMMKDxc9CYoS34CNSsnzcdcVIAW3+RujI=
 github.com/suzuki-shunsuke/go-osenv v0.1.0 h1:hBQ7yaeO1WBZsEWuDj1wrOWF+N7HSWSOpEiEZqfCjjk=
 github.com/suzuki-shunsuke/go-osenv v0.1.0/go.mod h1:ZlSVi4kYvV51JEtYpdHh9hAxXKLOWExXel3Jo74aacQ=
-github.com/suzuki-shunsuke/go-retryablehttp v0.7.8-0.20250608151404-89ccceec3913 h1:ohyNnPzetlnZI6eIwpMLejsXXMRb9K0hB5mFLocwuBA=
-github.com/suzuki-shunsuke/go-retryablehttp v0.7.8-0.20250608151404-89ccceec3913/go.mod h1:rjiScheydd+CxvumBsIrFKlx3iS0jrZ7LvzFGFmuKbw=
+github.com/suzuki-shunsuke/go-retryablehttp v0.7.8-1 h1:Dh1iJ0QAlYVbbouWgBEty5L5Tnuz+JuLKVx3XbMVuUs=
+github.com/suzuki-shunsuke/go-retryablehttp v0.7.8-1/go.mod h1:fRVZ62p4iY8BxyyhZQ++grjQIDzWtRK02mHQapxm4Kk=
 github.com/suzuki-shunsuke/go-retryablehttp-logrus v0.0.1 h1:Y+pdnQdt4SYyAyr24MHSjcNKccIQhDzL4lg4IZEMv1I=
 github.com/suzuki-shunsuke/go-retryablehttp-logrus v0.0.1/go.mod h1:5AZJWWx3A7KudKLEkW8cwxSKWLHXElP9odOD+721oKQ=
 github.com/suzuki-shunsuke/gomic v0.6.0 h1:oSmoXR1nmt7X05TssjBTcX9BCTNnFCcNlA5yshaTjsk=

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/aquaproj/aqua/v2/pkg/keyring"
 	"github.com/google/go-github/v72/github"
-	"github.com/hashicorp/go-retryablehttp"
 	"github.com/sirupsen/logrus"
+	"github.com/suzuki-shunsuke/go-retryablehttp"
 	"github.com/suzuki-shunsuke/go-retryablehttp-logrus/rlog"
 	"golang.org/x/oauth2"
 )


### PR DESCRIPTION
Close #3931

https://github.com/suzuki-shunsuke/go-retryablehttp/releases/tag/v0.7.8-1
diff: https://github.com/suzuki-shunsuke/go-retryablehttp/commit/547881255cebe9de69e56cd00ad54c04bd103205

Before

```console
$ go install github.com/aquaproj/aqua/v2/cmd/aqua@a8c17eb9e35245bdf6fc9505e75c86d225a87049
go: downloading github.com/aquaproj/aqua/v2 v2.53.1
go: github.com/aquaproj/aqua/v2/cmd/aqua@a8c17eb9e35245bdf6fc9505e75c86d225a87049 (in github.com/aquaproj/aqua/v2@v2.53.1):
	The go.mod file for the module providing named packages contains one or
	more replace directives. It must not contain directives that would cause
	it to be interpreted differently than if it were the main module.
```

```console
$ go install github.com/aquaproj/aqua/v2/cmd/aqua@v2.53.1
go: github.com/aquaproj/aqua/v2/cmd/aqua@v2.53.1 (in github.com/aquaproj/aqua/v2@v2.53.1):
	The go.mod file for the module providing named packages contains one or
	more replace directives. It must not contain directives that would cause
	it to be interpreted differently than if it were the main module.
```

After

```console
$ go install github.com/aquaproj/aqua/v2/cmd/aqua@3debf10d003e145f477c3a10c5e5be4c097577be
go: downloading github.com/aquaproj/aqua/v2 v2.53.2-0.20250612114128-3debf10d003e
```

```console
$ go install github.com/aquaproj/aqua/v2/cmd/aqua@v2.53.2-0
go: downloading github.com/aquaproj/aqua/v2 v2.53.2-0
```