### PR TITLE
fix: replace *http.DefaultClient with *http.Client for GitHub

### DIFF
--- a/pkg/download/github_release.go
+++ b/pkg/download/github_release.go
@@ -60,7 +60,7 @@ func (dl *GitHubReleaseDownloader) DownloadGitHubRelease(ctx context.Context, lo
 	if err != nil {
 		return nil, 0, err
 	}
-	body, redirectURL, err := dl.github.DownloadReleaseAsset(ctx, param.RepoOwner, param.RepoName, assetID, github.HTTPClient())
+	body, redirectURL, err := dl.github.DownloadReleaseAsset(ctx, param.RepoOwner, param.RepoName, assetID, github.GetHTTPClient(ctx, logE))
 	if err != nil {
 		return nil, 0, fmt.Errorf("download the release asset (asset id: %d): %w", assetID, err)
 	}

--- a/pkg/download/github_release.go
+++ b/pkg/download/github_release.go
@@ -60,7 +60,7 @@ func (dl *GitHubReleaseDownloader) DownloadGitHubRelease(ctx context.Context, lo
 	if err != nil {
 		return nil, 0, err
 	}
-	body, redirectURL, err := dl.github.DownloadReleaseAsset(ctx, param.RepoOwner, param.RepoName, assetID, http.DefaultClient)
+	body, redirectURL, err := dl.github.DownloadReleaseAsset(ctx, param.RepoOwner, param.RepoName, assetID, github.HTTPClient())
 	if err != nil {
 		return nil, 0, fmt.Errorf("download the release asset (asset id: %d): %w", assetID, err)
 	}

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -31,18 +31,16 @@ const Tarball = github.Tarball
 
 var globalHTTPClient *http.Client //nolint:gochecknoglobals
 
-func HTTPClient() *http.Client {
+func GetHTTPClient(ctx context.Context, logE *logrus.Entry) *http.Client {
 	if globalHTTPClient != nil {
 		return globalHTTPClient
 	}
-	return http.DefaultClient
+	globalHTTPClient = MakeRetryable(getHTTPClientForGitHub(ctx, logE, getGitHubToken()), logE)
+	return globalHTTPClient
 }
 
 func New(ctx context.Context, logE *logrus.Entry) *RepositoriesService {
-	if globalHTTPClient == nil {
-		globalHTTPClient = MakeRetryable(getHTTPClientForGitHub(ctx, logE, getGitHubToken()), logE)
-	}
-	return github.NewClient(globalHTTPClient).Repositories
+	return github.NewClient(GetHTTPClient(ctx, logE)).Repositories
 }
 
 func getGitHubToken() string {

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -29,8 +29,20 @@ type (
 
 const Tarball = github.Tarball
 
+var globalHTTPClient *http.Client //nolint:gochecknoglobals
+
+func HTTPClient() *http.Client {
+	if globalHTTPClient != nil {
+		return globalHTTPClient
+	}
+	return http.DefaultClient
+}
+
 func New(ctx context.Context, logE *logrus.Entry) *RepositoriesService {
-	return github.NewClient(MakeRetryable(getHTTPClientForGitHub(ctx, logE, getGitHubToken()), logE)).Repositories
+	if globalHTTPClient == nil {
+		globalHTTPClient = MakeRetryable(getHTTPClientForGitHub(ctx, logE, getGitHubToken()), logE)
+	}
+	return github.NewClient(globalHTTPClient).Repositories
 }
 
 func getGitHubToken() string {


### PR DESCRIPTION
Close #4005

Use authenticated http client when downloading assets using redirect URL.
Now aqua uses http.DefaultClient, so it doesn't retry downloading assets when HTTP 5xx error, and it doesn't have a GitHub access token, so it can't download assets from private repositories.

- Retry HTTP 5xx error
- Pass a GitHub Access token