### PR TITLE
fix(cp): adds missing .exe on windows

### DIFF
--- a/pkg/installpackage/check_file.go
+++ b/pkg/installpackage/check_file.go
@@ -68,8 +68,13 @@ func (is *Installer) checkAndCopyFile(ctx context.Context, logE *logrus.Entry, p
 			exeNames[alias.Alias] = struct{}{}
 		}
 	}
+
 	for exeName := range exeNames {
-		if err := is.Copy(filepath.Join(is.copyDir, exeName), exePath); err != nil {
+		p := filepath.Join(is.copyDir, exeName)
+		if is.runtime.GOOS == "windows" && filepath.Ext(exeName) == "" {
+			p += ".exe"
+		}
+		if err := is.Copy(p, exePath); err != nil {
 			return err
 		}
 	}

--- a/pkg/installpackage/check_file.go
+++ b/pkg/installpackage/check_file.go
@@ -15,6 +15,8 @@ import (
 	"github.com/suzuki-shunsuke/logrus-error/logerr"
 )
 
+const exeExt = ".exe"
+
 func (is *Installer) checkFilesWrap(ctx context.Context, logE *logrus.Entry, param *ParamInstallPackage, pkgPath string) error {
 	pkg := param.Pkg
 	pkgInfo := pkg.PackageInfo
@@ -72,7 +74,7 @@ func (is *Installer) checkAndCopyFile(ctx context.Context, logE *logrus.Entry, p
 	for exeName := range exeNames {
 		p := filepath.Join(is.copyDir, exeName)
 		if is.runtime.GOOS == "windows" && filepath.Ext(exeName) == "" {
-			p += ".exe"
+			p += exeExt
 		}
 		if err := is.Copy(p, exePath); err != nil {
 			return err
@@ -85,7 +87,7 @@ func (is *Installer) checkFileSrcGo(ctx context.Context, logE *logrus.Entry, pkg
 	pkgInfo := pkg.PackageInfo
 	exePath := filepath.Join(is.rootDir, "pkgs", pkgInfo.Type, "github.com", pkgInfo.RepoOwner, pkgInfo.RepoName, pkg.Package.Version, "bin", file.Name)
 	if is.runtime.IsWindows() {
-		exePath += ".exe"
+		exePath += exeExt
 	}
 	dir, err := pkg.RenderDir(file, is.runtime)
 	if err != nil {
@@ -154,7 +156,7 @@ func (is *Installer) checkFileSrc(ctx context.Context, logE *logrus.Entry, pkg *
 func (is *Installer) createFileHardLink(logE *logrus.Entry, file *registry.File, exePath string) error {
 	link := filepath.Join(filepath.Dir(exePath), file.Link)
 	if is.runtime.IsWindows() && filepath.Ext(link) == "" {
-		link += ".exe"
+		link += exeExt
 	}
 	if f, err := afero.Exists(is.fs, link); err != nil {
 		return fmt.Errorf("check if a hardlink exists: %w", err)

--- a/pkg/installpackage/check_file.go
+++ b/pkg/installpackage/check_file.go
@@ -73,7 +73,7 @@ func (is *Installer) checkAndCopyFile(ctx context.Context, logE *logrus.Entry, p
 
 	for exeName := range exeNames {
 		p := filepath.Join(is.copyDir, exeName)
-		if is.runtime.GOOS == "windows" && filepath.Ext(exeName) == "" {
+		if is.runtime.IsWindows() && filepath.Ext(exeName) == "" {
 			p += exeExt
 		}
 		if err := is.Copy(p, exePath); err != nil {

--- a/pkg/installpackage/link.go
+++ b/pkg/installpackage/link.go
@@ -95,7 +95,7 @@ func (is *Installer) createCmdLink(logE *logrus.Entry, file *registry.File, cmd 
 }
 
 func (is *Installer) createHardLinkToProxy(logE *logrus.Entry, cmd, aquaProxyPathOnWindows string) error {
-	hardLink := filepath.Join(is.rootDir, "bin", cmd+".exe")
+	hardLink := filepath.Join(is.rootDir, "bin", cmd+exeExt)
 	if f, err := afero.Exists(is.fs, hardLink); err != nil {
 		return fmt.Errorf("check if a hard link to aqua-proxy exists: %w", err)
 	} else if f {
@@ -130,7 +130,7 @@ func (is *Installer) recreateHardLinks() error {
 		if err := is.fs.Remove(p); err != nil {
 			return fmt.Errorf("remove a file to replace it with a hard link: %w", err)
 		}
-		if strings.HasSuffix(info.Name(), ".exe") {
+		if strings.HasSuffix(info.Name(), exeExt) {
 			if err := is.linker.Hardlink(a, p); err != nil {
 				return fmt.Errorf("create a hard link: %w", err)
 			}


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x ] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
  - [x ] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x ] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue:
- [x ] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x ] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x ] Do only one thing in one Pull Request

<!-- Please write the description here -->

This PR fixes #4046. The `aqua cp` command (without arguments) copies the executables for all packages to a specific location, however, it failed to add the `.exe` extension for those executables on Windows. It now correctly adds the missing `.exe` extension.

The fix follows the convention established by the `aqua cp <package>` command:

https://github.com/aquaproj/aqua/blob/5492d2cd1762e7cd73d9ab4086bb5b9806778008/pkg/controller/cp/copy.go#L11-L24