### PR TITLE
feat(generate-registry): generate github_immutable_release

### DIFF
--- a/pkg/controller/generate-registry/generate.go
+++ b/pkg/controller/generate-registry/generate.go
@@ -178,7 +178,7 @@ func (c *Controller) getPackageInfoMain(ctx context.Context, logger *slog.Logger
 		assetNames = append(assetNames, asset.GetName())
 	}
 
-	c.patchRelease(logger, pkgInfo, pkgName, release.GetTagName(), assetNames)
+	c.patchRelease(logger, pkgInfo, pkgName, release.GetTagName(), assetNames, release.GetImmutable())
 	return pkgInfo, []string{version}
 }
 
@@ -201,11 +201,17 @@ func getChecksum(checksumNames map[string]struct{}, assetName string) *registry.
 	return nil
 }
 
-func (c *Controller) patchRelease(logger *slog.Logger, pkgInfo *registry.PackageInfo, pkgName, tagName string, assets []string) { //nolint:cyclop
+func (c *Controller) patchRelease(logger *slog.Logger, pkgInfo *registry.PackageInfo, pkgName, tagName string, assets []string, immutable bool) { //nolint:cyclop
 	if len(assets) == 0 {
 		pkgInfo.NoAsset = true
 		return
 	}
+	// Corner case: it is possible to have immutable releases without release attestations.
+	// This happens at least if the release was marked immutable after the fact,
+	// such as with https://github.com/suzuki-shunsuke/ghir
+	// There is no way as of 2026-05-08 in the GitHub API to check release attestation availability directly,
+	// so we assume here that all releases marked as immutable have release attestations.
+	pkgInfo.GitHubReleaseAttestations = immutable
 	assetInfos := make([]*asset.AssetInfo, 0, len(assets))
 	pkgNameContainChecksum := strings.Contains(strings.ToLower(pkgName), "checksum")
 	assetNames := map[string]struct{}{}

--- a/pkg/controller/generate-registry/group.go
+++ b/pkg/controller/generate-registry/group.go
@@ -22,7 +22,7 @@ type Group struct {
 }
 
 func ConvertPkgToVO(pkgInfo *registry.PackageInfo) *registry.VersionOverride {
-	return &registry.VersionOverride{
+	vo := &registry.VersionOverride{
 		Asset:              pkgInfo.Asset,
 		Files:              pkgInfo.Files,
 		Format:             pkgInfo.Format,
@@ -33,6 +33,10 @@ func ConvertPkgToVO(pkgInfo *registry.PackageInfo) *registry.VersionOverride {
 		Checksum:           pkgInfo.Checksum,
 		SLSAProvenance:     pkgInfo.SLSAProvenance,
 	}
+	if pkgInfo.GitHubReleaseAttestations {
+		vo.GitHubReleaseAttestations = &pkgInfo.GitHubReleaseAttestations
+	}
+	return vo
 }
 
 func toVersionInString(releases []*Release) string {
@@ -285,7 +289,7 @@ func (c *Controller) group(logger *slog.Logger, pkgInfo *registry.PackageInfo, p
 			RepoOwner: pkgInfo.RepoOwner,
 			RepoName:  pkgInfo.RepoName,
 		}
-		c.patchRelease(logger, pkgInfo, pkgName, release.Tag, group.assetNames)
+		c.patchRelease(logger, pkgInfo, pkgName, release.Tag, group.assetNames, release.Immutable)
 		group.pkg = &Package{
 			Info:    pkgInfo,
 			Version: release.Tag,

--- a/pkg/controller/generate-registry/version_overrides.go
+++ b/pkg/controller/generate-registry/version_overrides.go
@@ -27,6 +27,7 @@ type Release struct {
 	Tag           string
 	Version       *version.Version
 	VersionPrefix string
+	Immutable     bool
 	assets        []*github.ReleaseAsset
 }
 
@@ -118,6 +119,7 @@ func (c *Controller) getPackageInfoWithVersionOverrides(ctx context.Context, log
 			Tag:           tag,
 			Version:       v,
 			VersionPrefix: prefix,
+			Immutable:     release.GetImmutable(),
 		})
 	}
 	sort.Slice(releases, func(i, j int) bool {


### PR DESCRIPTION
Adds support for generating github_immutable_release.

Draft/TODO:
- [ ] Does not actually work, something wrong with grouping/generating version overrides? For example for `Songmu/laminate`

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: https://github.com/aquaproj/aqua/issues/4262
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->
