### PR TITLE
fix: fix the command name for xsys

### DIFF
--- a/pkg/controller/exec/controller.go
+++ b/pkg/controller/exec/controller.go
@@ -55,7 +55,7 @@ func New(pkgInstaller Installer, whichCtrl WhichController, executor Executor, o
 
 type Executor interface {
 	Exec(cmd *osexec.Cmd) (int, error)
-	ExecXSys(exePath string, args ...string) error
+	ExecXSys(exePath, name string, args ...string) error
 }
 
 type PolicyReader interface {

--- a/pkg/controller/exec/exec_internal_test.go
+++ b/pkg/controller/exec/exec_internal_test.go
@@ -13,12 +13,14 @@ func TestController_execCommand(t *testing.T) {
 	data := []struct {
 		title    string
 		exePath  string
+		exeName  string
 		args     []string
 		executor Executor
 	}{
 		{
 			title:    "normal",
 			exePath:  "/bin/date",
+			exeName:  "date",
 			args:     []string{},
 			executor: &osexec.Mock{},
 		},
@@ -34,7 +36,7 @@ func TestController_execCommand(t *testing.T) {
 				stderr:   os.Stderr,
 				executor: d.executor,
 			}
-			err := ctrl.execCommandWithRetry(ctx, logE, d.exePath, d.args...)
+			err := ctrl.execCommandWithRetry(ctx, logE, d.exePath, d.exeName, d.args...)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/osexec/mock.go
+++ b/pkg/osexec/mock.go
@@ -14,7 +14,7 @@ func (e *Mock) ExecStderr(cmd *Cmd) (int, error) {
 	return e.ExitCode, e.Err
 }
 
-func (e *Mock) ExecXSys(exePath string, args ...string) error {
+func (e *Mock) ExecXSys(_, _ string, _ ...string) error {
 	return e.Err
 }
 

--- a/pkg/osexec/xsys.go
+++ b/pkg/osexec/xsys.go
@@ -5,11 +5,10 @@ package osexec
 
 import (
 	"os"
-	"path/filepath"
 
 	"golang.org/x/sys/unix"
 )
 
-func (e *Executor) ExecXSys(exePath string, args ...string) error {
-	return unix.Exec(exePath, append([]string{filepath.Base(exePath)}, args...), os.Environ()) //nolint:wrapcheck
+func (e *Executor) ExecXSys(exePath, name string, args ...string) error {
+	return unix.Exec(exePath, append([]string{name}, args...), os.Environ()) //nolint:wrapcheck
 }

--- a/pkg/osexec/xsys_windows.go
+++ b/pkg/osexec/xsys_windows.go
@@ -7,6 +7,6 @@ import "errors"
 
 var errXSysNotSupported = errors.New("Windows doesn't support xsys")
 
-func (e *Executor) ExecXSys(exePath string, args ...string) error {
+func (e *Executor) ExecXSys(_, _ string, _ ...string) error {
 	return errXSysNotSupported
 }


### PR DESCRIPTION
## Test

```
aqua g -i EnvCLI/EnvCLI
```

https://github.com/aquaproj/aqua-registry/blob/d6c7f01d928311d52172cc4459fbe6036ee7d537/pkgs/EnvCLI/EnvCLI/registry.yaml#L13-L14

Before: aqua v2.55.0

```console
$ envcli --help
NAME:
   EnvCLI - Runs cli commands within docker containers to provide a modern development environment

USAGE:
   darwin_amd64 [global options] command [command options] [arguments...]
```

The command name in USAGE is `darwin_amd64`.

After:

```console
$ envcli --help                        
NAME:
   EnvCLI - Runs cli commands within docker containers to provide a modern development environment

USAGE:
   envcli [global options] command [command options] [arguments...]
```