### PR TITLE
fix: fix the command name

### DIFF
--- a/pkg/controller/exec/exec.go
+++ b/pkg/controller/exec/exec.go
@@ -136,7 +136,9 @@ func (c *Controller) execCommand(ctx context.Context, exePath, name string, args
 		}
 		return false, nil
 	}
-	if exitCode, err := c.executor.Exec(osexec.Command(ctx, exePath, args...)); err != nil {
+	cmd := osexec.Command(ctx, exePath, args...)
+	cmd.Args[0] = name
+	if exitCode, err := c.executor.Exec(cmd); err != nil {
 		// https://pkg.go.dev/os#ProcessState.ExitCode
 		// > ExitCode returns the exit code of the exited process,
 		// > or -1 if the process hasn't exited or was terminated by a signal.

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -111,7 +111,9 @@ func (v *Verifier) exec(ctx context.Context, args []string) (string, error) {
 	// https://github.com/aquaproj/aqua/issues/1555
 	mutex.Lock()
 	defer mutex.Unlock()
-	out, _, err := v.executor.ExecStderrAndGetCombinedOutput(osexec.Command(ctx, v.cosignExePath, args...))
+	cmd := osexec.Command(ctx, v.cosignExePath, args...)
+	cmd.Args[0] = "cosign"
+	out, _, err := v.executor.ExecStderrAndGetCombinedOutput(cmd)
 	return out, err //nolint:wrapcheck
 }
 

--- a/pkg/ghattestation/exec.go
+++ b/pkg/ghattestation/exec.go
@@ -163,6 +163,7 @@ func (e *ExecutorImpl) VerifyRelease(ctx context.Context, logE *logrus.Entry, pa
 
 func (e *ExecutorImpl) exec(ctx context.Context, args []string) error {
 	cmd := osexec.Command(ctx, e.exePath, args...)
+	cmd.Args[0] = "gh"
 
 	// https://github.com/aquaproj/aqua/issues/4035
 	// Set GH_HOST to github.com for GitHub Enterprise

--- a/pkg/minisign/exec.go
+++ b/pkg/minisign/exec.go
@@ -110,6 +110,8 @@ func (e *ExecutorImpl) exec(ctx context.Context, args []string) error {
 	if e.executor == nil {
 		return errors.New("e.executor is nil")
 	}
-	_, err := e.executor.ExecStderr(osexec.Command(ctx, e.minisignExePath, args...))
+	cmd := osexec.Command(ctx, e.minisignExePath, args...)
+	cmd.Args[0] = "minisign"
+	_, err := e.executor.ExecStderr(cmd)
 	return err //nolint:wrapcheck
 }

--- a/pkg/slsa/exec.go
+++ b/pkg/slsa/exec.go
@@ -87,6 +87,8 @@ func (e *ExecutorImpl) exec(ctx context.Context, args []string) (string, error) 
 	mutex := cosign.GetMutex()
 	mutex.Lock()
 	defer mutex.Unlock()
-	out, _, err := e.executor.ExecStderrAndGetCombinedOutput(osexec.Command(ctx, e.verifierExePath, args...))
+	cmd := osexec.Command(ctx, e.verifierExePath, args...)
+	cmd.Args[0] = "slsa-verifier"
+	out, _, err := e.executor.ExecStderrAndGetCombinedOutput(cmd)
 	return out, err //nolint:wrapcheck
 }


### PR DESCRIPTION
## Test

https://aquaproj.github.io/docs/reference/execve-2

Before: aqua v2.55.0

```console
$ AQUA_X_SYS_EXEC=false aqua exec -- envcli --help
NAME:
   EnvCLI - Runs cli commands within docker containers to provide a modern development environment

USAGE:
   darwin_amd64 [global options] command [command options] [arguments...]
```

After:

```console
$ AQUA_X_SYS_EXEC=false go run ./cmd/aqua exec -- envcli --help
NAME:
   EnvCLI - Runs cli commands within docker containers to provide a modern development environment

USAGE:
   envcli [global options] command [command options] [arguments...]
```