### PR TITLE
fix(gr): fix the support of `sigstore` and `sigstore.json` file extensions

### DIFF
--- a/pkg/checksum/checksum.go
+++ b/pkg/checksum/checksum.go
@@ -86,7 +86,7 @@ func convertChecksumFileName(filename, version string) string {
 // Returns a checksum configuration for github_release type or nil if no pattern matches.
 func GetChecksumConfigFromFilename(filename, version string) *registry.Checksum {
 	s := strings.ToLower(filename)
-	for _, suffix := range []string{"sig", "asc", "pem", "bundle"} {
+	for _, suffix := range []string{"sig", "asc", "pem", "bundle", "sigstore", "sigstore.json"} {
 		if strings.HasSuffix(s, "."+suffix) {
 			return nil
 		}


### PR DESCRIPTION
Close #4392

## Test

```sh
aqua gr -l 1 goreleaser/nfpm
```

### Before

```yaml
packages:
  - type: github_release
    repo_owner: goreleaser
    repo_name: nfpm
    description: "nFPM is Not FPM - a simple deb, rpm, apk, ipk, and arch linux packager written in Go"
    asset: nfpm_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
    format: tar.gz
    overrides:
      - goos: windows
        format: zip
    replacements:
      amd64: x86_64
      darwin: Darwin
      linux: Linux
      windows: Windows
    checksum:
      type: github_release
      asset: checksums.txt.sigstore.json
      algorithm: sha256
```

### After

```yaml
packages:
  - type: github_release
    repo_owner: goreleaser
    repo_name: nfpm
    description: "nFPM is Not FPM - a simple deb, rpm, apk, ipk, and arch linux packager written in Go"
    asset: nfpm_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
    format: tar.gz
    overrides:
      - goos: windows
        format: zip
    replacements:
      amd64: x86_64
      darwin: Darwin
      linux: Linux
      windows: Windows
    checksum:
      type: github_release
      asset: checksums.txt
      algorithm: sha256
      cosign:
        opts:
          - --certificate-identity-regexp
          - "^https://github\\.com/goreleaser/nfpm/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
          - --certificate-oidc-issuer
          - https://token.actions.githubusercontent.com
        bundle:
          type: github_release
          asset: checksums.txt.sigstore.json
```