### PR TITLE
✏️ Typos in github-immutable-release.md and keyring.md

### DIFF
--- a/website/docs/reference/security/github-immutable-release.md
+++ b/website/docs/reference/security/github-immutable-release.md
@@ -19,7 +19,7 @@ aqua uses [GitHub CLI](https://cli.github.com/) internally, but aqua installs it
 We recommend enabling the verification for security, but you can disable the verification by the environment variable.
 
 ```sh
-export AQUA_DISABLE_GITHUB_IMMUTABLE_RElEASE=true
+export AQUA_DISABLE_GITHUB_IMMUTABLE_RELEASE=true
 ```
 
 ## Registry Settings

--- a/website/docs/reference/security/keyring.md
+++ b/website/docs/reference/security/keyring.md
@@ -5,7 +5,7 @@ sidebar_position: 410
 # Manage a GitHub access token using Keyring
 
 :::info
-We recommend [ghtkn integration](./ghtkn.md) because it is securer than managing a long-lived personal access token using Keyring.
+We recommend [ghtkn integration](./ghtkn.md) because it is more secure than managing a long-lived personal access token using Keyring.
 :::
 
 aqua >= v2.51.0 [#3852](https://github.com/aquaproj/aqua/pull/3852)
@@ -22,7 +22,7 @@ Enter a GitHub access token: # Input GitHub Access token
 or you can also pass a GitHub Access token via standard input:
 
 ```sh
-echo "<github access token>" | aqua tokn set -stdin
+echo "<github access token>" | aqua token set --stdin
 ```
 
 2. Enable the feature by setting the environment variable `AQUA_KEYRING_ENABLED`:


### PR DESCRIPTION
- **✏️ Typos in github-immutable-release.md and keyring.md**

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue:
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

I've found another typos in github-immutable-release.md and keyring.md

