### PR TITLE
fix(gr): exclude eabihf

### DIFF
--- a/pkg/asset/exclude.go
+++ b/pkg/asset/exclude.go
@@ -17,6 +17,7 @@ func Exclude(pkgName, assetName string) bool {
 		"armv6",
 		"armv7",
 		"changelog",
+		"eabihf",
 		"freebsd",
 		"i386",
 		"license",


### PR DESCRIPTION
eabihf is for 32 bit.