### PR TITLE
fix(update-aqua): use NewAquaVersion field for version argument

### DIFF
--- a/pkg/cli/updateaqua/command.go
+++ b/pkg/cli/updateaqua/command.go
@@ -79,7 +79,7 @@ func (ua *updateAquaCommand) action(ctx context.Context, args *Args) error {
 	if err := util.SetParam(args.GlobalArgs, ua.r.Logger, param, ua.r.Version); err != nil {
 		return fmt.Errorf("set param: %w", err)
 	}
-	param.AQUAVersion = args.Version
+	param.NewAquaVersion = args.Version
 	ctrl, err := controller.InitializeUpdateAquaCommandController(ctx, ua.r.Logger.Logger, param, http.DefaultClient, ua.r.Runtime)
 	if err != nil {
 		return fmt.Errorf("initialize an UpdateAquaController: %w", err)

--- a/pkg/config/package.go
+++ b/pkg/config/package.go
@@ -342,6 +342,7 @@ type Param struct {
 	LogLevel                          string
 	File                              string
 	AQUAVersion                       string
+	NewAquaVersion                    string
 	RootDir                           string
 	PWD                               string
 	InsertFile                        string

--- a/pkg/controller/updateaqua/update_aqua.go
+++ b/pkg/controller/updateaqua/update_aqua.go
@@ -2,7 +2,6 @@ package updateaqua
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"path/filepath"
@@ -34,16 +33,12 @@ func (c *Controller) UpdateAqua(ctx context.Context, logger *slog.Logger, param 
 }
 
 func (c *Controller) getVersion(ctx context.Context, param *config.Param) (string, error) {
-	switch len(param.Args) {
-	case 0:
-		release, _, err := c.github.GetLatestRelease(ctx, "aquaproj", "aqua")
-		if err != nil {
-			return "", fmt.Errorf("get the latest version of aqua: %w", err)
-		}
-		return release.GetTagName(), nil
-	case 1:
-		return param.Args[0], nil
-	default:
-		return "", errors.New("too many arguments")
+	if param.NewAquaVersion != "" {
+		return param.NewAquaVersion, nil
 	}
+	release, _, err := c.github.GetLatestRelease(ctx, "aquaproj", "aqua")
+	if err != nil {
+		return "", fmt.Errorf("get the latest version of aqua: %w", err)
+	}
+	return release.GetTagName(), nil
 }


### PR DESCRIPTION
The update-aqua command was setting param.AQUAVersion but the controller was checking param.Args. Added NewAquaVersion field to config.Param and updated both sides to use it consistently.

- https://github.com/aquaproj/aqua/issues/4474
- https://github.com/aquaproj/aqua/pull/4450