### PR TITLE
fix: get a GitHub access token from AQUA_GITHUB_TOKEN and pass it to gh command if GH_TOKEN and GITHUB_TOKEN aren't set

### DIFF
--- a/pkg/ghattestation/exec.go
+++ b/pkg/ghattestation/exec.go
@@ -30,6 +30,8 @@ type Executor interface {
 type ExecutorImpl struct {
 	executor CommandExecutor
 	exePath  string
+	getEnv   func(string) string
+	environ  func() []string
 }
 
 func NewExecutor(executor CommandExecutor, param *config.Param) (*ExecutorImpl, error) {
@@ -43,6 +45,8 @@ func NewExecutor(executor CommandExecutor, param *config.Param) (*ExecutorImpl, 
 	return &ExecutorImpl{
 		executor: executor,
 		exePath:  exePath,
+		getEnv:   os.Getenv,
+		environ:  os.Environ,
 	}, nil
 }
 
@@ -166,9 +170,14 @@ func (e *ExecutorImpl) exec(ctx context.Context, args []string) error {
 	// GitHub CLI uses the GH_HOST environment variable to determine the host for GitHub API.
 	// But packages are always hosted on github.com.
 	if cmd.Env == nil {
-		cmd.Env = os.Environ()
+		cmd.Env = e.environ()
 	}
 	cmd.Env = append(cmd.Env, "GH_HOST=github.com")
+	if e.getEnv("GITHUB_TOKEN") == "" && e.getEnv("GH_TOKEN") == "" {
+		if token := e.getEnv("AQUA_GITHUB_TOKEN"); token != "" {
+			cmd.Env = append(cmd.Env, fmt.Sprintf("GITHUB_TOKEN=%s", token))
+		}
+	}
 
 	out, _, err := e.executor.ExecStderrAndGetCombinedOutput(cmd)
 	if err == nil {

--- a/pkg/ghattestation/exec.go
+++ b/pkg/ghattestation/exec.go
@@ -175,7 +175,7 @@ func (e *ExecutorImpl) exec(ctx context.Context, args []string) error {
 	cmd.Env = append(cmd.Env, "GH_HOST=github.com")
 	if e.getEnv("GITHUB_TOKEN") == "" && e.getEnv("GH_TOKEN") == "" {
 		if token := e.getEnv("AQUA_GITHUB_TOKEN"); token != "" {
-			cmd.Env = append(cmd.Env, fmt.Sprintf("GITHUB_TOKEN=%s", token))
+			cmd.Env = append(cmd.Env, "GITHUB_TOKEN="+token)
 		}
 	}
 


### PR DESCRIPTION
To prevent API rate limit error.

https://github.com/aquaproj/aqua-registry/actions/runs/23003801708/job/66798149237?pr=50269

```
HTTP 403: API rate limit exceeded for 128.24.162.210. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) (https://api.github.com/repos/suzuki-shunsuke/cmdx/git/ref/tags/v2.0.2)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined environment variable handling to ensure consistent GitHub host configuration across all execution contexts.
  * Enhanced token authentication with improved fallback mechanism for scenarios involving multiple token sources.
  * Better environment consistency and reliability during subprocess execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->