### PR TITLE
refactor(registry): improve GitHub release attestations control naming

### DIFF
--- a/json-schema/registry.json
+++ b/json-schema/registry.json
@@ -558,8 +558,13 @@
         "github_artifact_attestations": {
           "$ref": "#/$defs/GitHubArtifactAttestations"
         },
+        "github_release_attestations": {
+          "type": "boolean",
+          "description": "For backwards compatibility, if this is false, github_immutable_release will be used instead"
+        },
         "github_immutable_release": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Deprecated: use github_release_attestations instead"
         },
         "vars": {
           "items": {
@@ -786,8 +791,12 @@
         "github_artifact_attestations": {
           "$ref": "#/$defs/GitHubArtifactAttestations"
         },
-        "github_immutable_release": {
+        "github_release_attestations": {
           "type": "boolean"
+        },
+        "github_immutable_release": {
+          "type": "boolean",
+          "description": "Deprecated: use github_release_attestations instead"
         },
         "build": {
           "$ref": "#/$defs/Build"

--- a/pkg/config/registry/package_info.go
+++ b/pkg/config/registry/package_info.go
@@ -84,10 +84,19 @@ type PackageInfo struct {
 	SLSAProvenance             *SLSAProvenance             `yaml:"slsa_provenance,omitempty" json:"slsa_provenance,omitempty"`
 	Minisign                   *Minisign                   `yaml:",omitempty" json:"minisign,omitempty"`
 	GitHubArtifactAttestations *GitHubArtifactAttestations `yaml:"github_artifact_attestations,omitempty" json:"github_artifact_attestations,omitempty"`
-	GitHubImmutableRelease     bool                        `yaml:"github_immutable_release,omitempty" json:"github_immutable_release,omitempty"`
-	Vars                       []*Var                      `yaml:",omitempty" json:"vars,omitempty"`
-	VersionConstraints         string                      `yaml:"version_constraint,omitempty" json:"version_constraint,omitempty"`
-	VersionOverrides           []*VersionOverride          `yaml:"version_overrides,omitempty" json:"version_overrides,omitempty"`
+	GitHubReleaseAttestations  bool                        `yaml:"github_release_attestations,omitempty" json:"github_release_attestations,omitempty" jsonschema:"description=For backwards compatibility\\, if this is false\\, github_immutable_release will be used instead"`
+	// Deprecated: use GitHubReleaseAttestations instead
+	GitHubImmutableRelease bool               `yaml:"github_immutable_release,omitempty" json:"github_immutable_release,omitempty" jsonschema:"description=Deprecated: use github_release_attestations instead"`
+	Vars                   []*Var             `yaml:",omitempty" json:"vars,omitempty"`
+	VersionConstraints     string             `yaml:"version_constraint,omitempty" json:"version_constraint,omitempty"`
+	VersionOverrides       []*VersionOverride `yaml:"version_overrides,omitempty" json:"version_overrides,omitempty"`
+}
+
+// GitHubReleaseAttestationsAvailable returns true if GitHub release attestations are available.
+// For some backwards compatibility to times where GitHubReleaseAttestations did not exist and GitHubImmutableRelease did, it returns true if either field is true,
+// meaning that explicitly setting GitHubReleaseAttestations to false does not necessarily disable them, due to fallback to GitHubImmutableRelease.
+func (p *PackageInfo) GitHubReleaseAttestationsAvailable() bool {
+	return p.GitHubReleaseAttestations || p.GitHubImmutableRelease
 }
 
 // Var represents a template variable that can be used in package configurations
@@ -171,11 +180,13 @@ type VersionOverride struct {
 	SLSAProvenance             *SLSAProvenance             `yaml:"slsa_provenance,omitempty" json:"slsa_provenance,omitempty"`
 	Minisign                   *Minisign                   `yaml:",omitempty" json:"minisign,omitempty"`
 	GitHubArtifactAttestations *GitHubArtifactAttestations `yaml:"github_artifact_attestations,omitempty" json:"github_artifact_attestations,omitempty"`
-	GitHubImmutableRelease     *bool                       `yaml:"github_immutable_release,omitempty" json:"github_immutable_release,omitempty"`
-	Build                      *Build                      `yaml:",omitempty" json:"build,omitempty"`
-	Vars                       []*Var                      `yaml:",omitempty" json:"vars,omitempty"`
-	Overrides                  Overrides                   `yaml:",omitempty" json:"overrides,omitempty"`
-	SupportedEnvs              SupportedEnvs               `yaml:"supported_envs,omitempty" json:"supported_envs,omitempty"`
+	GitHubReleaseAttestations  *bool                       `yaml:"github_release_attestations,omitempty" json:"github_release_attestations,omitempty"`
+	// Deprecated: use GitHubReleaseAttestations instead
+	GitHubImmutableRelease *bool         `yaml:"github_immutable_release,omitempty" json:"github_immutable_release,omitempty" jsonschema:"description=Deprecated: use github_release_attestations instead"`
+	Build                  *Build        `yaml:",omitempty" json:"build,omitempty"`
+	Vars                   []*Var        `yaml:",omitempty" json:"vars,omitempty"`
+	Overrides              Overrides     `yaml:",omitempty" json:"overrides,omitempty"`
+	SupportedEnvs          SupportedEnvs `yaml:"supported_envs,omitempty" json:"supported_envs,omitempty"`
 }
 
 // Override provides platform-specific package configuration that overrides
@@ -243,6 +254,7 @@ func (p *PackageInfo) Copy() *PackageInfo {
 		SLSAProvenance:             p.SLSAProvenance,
 		Minisign:                   p.Minisign,
 		GitHubArtifactAttestations: p.GitHubArtifactAttestations,
+		GitHubReleaseAttestations:  p.GitHubReleaseAttestations,
 		GitHubImmutableRelease:     p.GitHubImmutableRelease,
 		Private:                    p.Private,
 		ErrorMessage:               p.ErrorMessage,
@@ -821,7 +833,11 @@ func (p *PackageInfo) overrideVersion(child *VersionOverride) *PackageInfo { //n
 	if child.GitHubArtifactAttestations != nil {
 		pkg.GitHubArtifactAttestations = child.GitHubArtifactAttestations
 	}
-	if child.GitHubImmutableRelease != nil {
+	if child.GitHubReleaseAttestations != nil {
+		pkg.GitHubReleaseAttestations = *child.GitHubReleaseAttestations
+		pkg.GitHubImmutableRelease = *child.GitHubReleaseAttestations
+	} else if child.GitHubImmutableRelease != nil {
+		pkg.GitHubReleaseAttestations = *child.GitHubImmutableRelease
 		pkg.GitHubImmutableRelease = *child.GitHubImmutableRelease
 	}
 	if child.ErrorMessage != nil {
@@ -881,6 +897,7 @@ func (p *PackageInfo) resetByPkgType(typ string) { //nolint:funlen
 		p.SLSAProvenance = nil
 		p.Minisign = nil
 		p.GitHubArtifactAttestations = nil
+		p.GitHubReleaseAttestations = false
 		p.GitHubImmutableRelease = false
 		p.Format = ""
 		p.Rosetta2 = false
@@ -897,6 +914,7 @@ func (p *PackageInfo) resetByPkgType(typ string) { //nolint:funlen
 		p.SLSAProvenance = nil
 		p.Minisign = nil
 		p.GitHubArtifactAttestations = nil
+		p.GitHubReleaseAttestations = false
 		p.GitHubImmutableRelease = false
 		p.Format = ""
 		p.Rosetta2 = false
@@ -912,6 +930,7 @@ func (p *PackageInfo) resetByPkgType(typ string) { //nolint:funlen
 		p.SLSAProvenance = nil
 		p.Minisign = nil
 		p.GitHubArtifactAttestations = nil
+		p.GitHubReleaseAttestations = false
 		p.GitHubImmutableRelease = false
 		p.Format = ""
 		p.Rosetta2 = false

--- a/pkg/config/registry/package_info_test.go
+++ b/pkg/config/registry/package_info_test.go
@@ -417,17 +417,17 @@ func TestPackageInfo_JSONEncode_VersionOverrides_ImmutableRelease(t *testing.T) 
 		Asset:     "asset.tar.gz",
 		VersionOverrides: []*registry.VersionOverride{
 			{
-				VersionConstraints:     ">=v1.0.0",
-				GitHubImmutableRelease: new(true),
+				VersionConstraints:        ">=v1.0.0",
+				GitHubReleaseAttestations: new(true),
 			},
 			{
-				VersionConstraints:     ">=v2.0.0",
-				GitHubImmutableRelease: new(false),
+				VersionConstraints:        ">=v2.0.0",
+				GitHubReleaseAttestations: new(false),
 			},
 			{
 				VersionConstraints: ">=v3.0.0",
-				// ImmutableRelease with nil (should be omitted due to omitempty)
-				GitHubImmutableRelease: nil,
+				// ReleaseAttestations with nil (should be omitted due to omitempty)
+				GitHubReleaseAttestations: nil,
 			},
 		},
 	}
@@ -460,31 +460,31 @@ func TestPackageInfo_JSONEncode_VersionOverrides_ImmutableRelease(t *testing.T) 
 		t.Fatal("first version override is not a map")
 	}
 
-	immutableRelease1, ok := vo1["github_immutable_release"].(bool)
-	if !ok || !immutableRelease1 {
-		t.Errorf("expected github_immutable_release: true in first version override, got %v", vo1["github_immutable_release"])
+	releaseAttestations1, ok := vo1["github_release_attestations"].(bool)
+	if !ok || !releaseAttestations1 {
+		t.Errorf("expected github_release_attestations: true in first version override, got %v", vo1["github_release_attestations"])
 	}
 
-	// Test second version override (github_immutable_release: false)
+	// Test second version override (github_release_attestations: false)
 	vo2, ok := versionOverrides[1].(map[string]any)
 	if !ok {
 		t.Fatal("second version override is not a map")
 	}
 
-	immutableRelease2, ok := vo2["github_immutable_release"].(bool)
-	if !ok || immutableRelease2 {
-		t.Errorf("expected github_immutable_release: false in second version override, got %v", vo2["github_immutable_release"])
+	releaseAttestations2, ok := vo2["github_release_attestations"].(bool)
+	if !ok || releaseAttestations2 {
+		t.Errorf("expected github_release_attestations: false in second version override, got %v", vo2["github_release_attestations"])
 	}
 
-	// Test third version override (github_immutable_release: nil - should be omitted due to omitempty)
+	// Test third version override (github_release_attestations: nil - should be omitted due to omitempty)
 	vo3, ok := versionOverrides[2].(map[string]any)
 	if !ok {
 		t.Fatal("third version override is not a map")
 	}
 
-	// With omitempty, nil github_immutable_release should be omitted from JSON
-	if _, exists := vo3["github_immutable_release"]; exists {
-		t.Errorf("expected github_immutable_release field to be omitted in third version override, but found: %v", vo3["github_immutable_release"])
+	// With omitempty, nil github_release_attestations should be omitted from JSON
+	if _, exists := vo3["github_release_attestations"]; exists {
+		t.Errorf("expected github_release_attestations field to be omitted in third version override, but found: %v", vo3["github_release_attestations"])
 	}
 }
 
@@ -499,9 +499,9 @@ func TestPackageInfo_JSONEncode_RoundTrip(t *testing.T) {
 		Asset:     "kubectl",
 		VersionOverrides: []*registry.VersionOverride{
 			{
-				VersionConstraints:     ">=v1.25.0",
-				Asset:                  "kubectl-new",
-				GitHubImmutableRelease: new(true),
+				VersionConstraints:        ">=v1.25.0",
+				Asset:                     "kubectl-new",
+				GitHubReleaseAttestations: new(true),
 			},
 		},
 	}
@@ -524,18 +524,18 @@ func TestPackageInfo_JSONEncode_RoundTrip(t *testing.T) {
 	}
 
 	vo := decoded.VersionOverrides[0]
-	if vo.GitHubImmutableRelease == nil {
-		t.Fatal("ImmutableRelease should not be nil after JSON round trip")
+	if vo.GitHubReleaseAttestations == nil {
+		t.Fatal("ReleaseAttestations should not be nil after JSON round trip")
 	}
 
-	if !*vo.GitHubImmutableRelease {
-		t.Error("ImmutableRelease should be true after JSON round trip")
+	if !*vo.GitHubReleaseAttestations {
+		t.Error("ReleaseAttestations should be true after JSON round trip")
 	}
 
 	// Compare original and decoded using deep comparison
-	if diff := cmp.Diff(*original.VersionOverrides[0].GitHubImmutableRelease,
-		*decoded.VersionOverrides[0].GitHubImmutableRelease); diff != "" {
-		t.Errorf("ImmutableRelease value differs after JSON round trip (-want +got):\n%s", diff)
+	if diff := cmp.Diff(*original.VersionOverrides[0].GitHubReleaseAttestations,
+		*decoded.VersionOverrides[0].GitHubReleaseAttestations); diff != "" {
+		t.Errorf("ReleaseAttestations value differs after JSON round trip (-want +got):\n%s", diff)
 	}
 }
 
@@ -551,11 +551,11 @@ repo_name: repo
 asset: asset.tar.gz
 version_overrides:
   - version_constraint: ">=v1.0.0"
-    github_immutable_release: true
+    github_release_attestations: true
   - version_constraint: ">=v2.0.0"
-    github_immutable_release: false
+    github_release_attestations: false
   - version_constraint: ">=v3.0.0"
-    # No github_immutable_release field (should be nil)
+    # No github_release_attestations field (should be nil)
 `
 
 	var pkgInfo registry.PackageInfo
@@ -583,12 +583,12 @@ version_overrides:
 		t.Errorf("expected version constraint '>=v1.0.0', got %q", vo1.VersionConstraints)
 	}
 
-	if vo1.GitHubImmutableRelease == nil {
-		t.Fatal("ImmutableRelease should not be nil in first version override")
+	if vo1.GitHubReleaseAttestations == nil {
+		t.Fatal("ReleaseAttestations should not be nil in first version override")
 	}
 
-	if !*vo1.GitHubImmutableRelease {
-		t.Error("ImmutableRelease should be true in first version override")
+	if !*vo1.GitHubReleaseAttestations {
+		t.Error("ReleaseAttestations should be true in first version override")
 	}
 
 	// Test second version override (github_immutable_release: false)
@@ -597,12 +597,12 @@ version_overrides:
 		t.Errorf("expected version constraint '>=v2.0.0', got %q", vo2.VersionConstraints)
 	}
 
-	if vo2.GitHubImmutableRelease == nil {
-		t.Fatal("ImmutableRelease should not be nil in second version override")
+	if vo2.GitHubReleaseAttestations == nil {
+		t.Fatal("ReleaseAttestations should not be nil in second version override")
 	}
 
-	if *vo2.GitHubImmutableRelease {
-		t.Error("ImmutableRelease should be false in second version override")
+	if *vo2.GitHubReleaseAttestations {
+		t.Error("ReleaseAttestations should be false in second version override")
 	}
 
 	// Test third version override (github_immutable_release: nil)
@@ -611,8 +611,8 @@ version_overrides:
 		t.Errorf("expected version constraint '>=v3.0.0', got %q", vo3.VersionConstraints)
 	}
 
-	if vo3.GitHubImmutableRelease != nil {
-		t.Errorf("ImmutableRelease should be nil in third version override, got %v", *vo3.GitHubImmutableRelease)
+	if vo3.GitHubReleaseAttestations != nil {
+		t.Errorf("ReleaseAttestations should be nil in third version override, got %v", *vo3.GitHubReleaseAttestations)
 	}
 }
 
@@ -627,9 +627,9 @@ func TestPackageInfo_YAMLDecode_RoundTrip(t *testing.T) {
 		Asset:     "kubectl",
 		VersionOverrides: []*registry.VersionOverride{
 			{
-				VersionConstraints:     ">=v1.25.0",
-				Asset:                  "kubectl-new",
-				GitHubImmutableRelease: new(true),
+				VersionConstraints:        ">=v1.25.0",
+				Asset:                     "kubectl-new",
+				GitHubReleaseAttestations: new(true),
 			},
 		},
 	}
@@ -652,18 +652,18 @@ func TestPackageInfo_YAMLDecode_RoundTrip(t *testing.T) {
 	}
 
 	vo := decoded.VersionOverrides[0]
-	if vo.GitHubImmutableRelease == nil {
-		t.Fatal("ImmutableRelease should not be nil after YAML round trip")
+	if vo.GitHubReleaseAttestations == nil {
+		t.Fatal("ReleaseAttestations should not be nil after YAML round trip")
 	}
 
-	if !*vo.GitHubImmutableRelease {
-		t.Error("ImmutableRelease should be true after YAML round trip")
+	if !*vo.GitHubReleaseAttestations {
+		t.Error("ReleaseAttestations should be true after YAML round trip")
 	}
 
 	// Compare original and decoded using deep comparison
-	if diff := cmp.Diff(*original.VersionOverrides[0].GitHubImmutableRelease,
-		*decoded.VersionOverrides[0].GitHubImmutableRelease); diff != "" {
-		t.Errorf("ImmutableRelease value differs after YAML round trip (-want +got):\n%s", diff)
+	if diff := cmp.Diff(*original.VersionOverrides[0].GitHubReleaseAttestations,
+		*decoded.VersionOverrides[0].GitHubReleaseAttestations); diff != "" {
+		t.Errorf("ReleaseAttestations value differs after YAML round trip (-want +got):\n%s", diff)
 	}
 
 	// Verify other fields are preserved
@@ -689,14 +689,14 @@ asset: package.tar.gz
 version_overrides:
   - version_constraint: ">=v1.0.0"
     asset: package-v1.tar.gz
-    github_immutable_release: true
+    github_release_attestations: true
     cosign:
       enabled: true
     minisign:
       enabled: false
   - version_constraint: ">=v2.0.0"
     asset: package-v2.tar.gz
-    github_immutable_release: false
+    github_release_attestations: false
     slsa_provenance:
       enabled: true
       type: github_release
@@ -718,12 +718,12 @@ version_overrides:
 		t.Errorf("expected asset 'package-v1.tar.gz', got %q", vo1.Asset)
 	}
 
-	if vo1.GitHubImmutableRelease == nil {
-		t.Fatal("ImmutableRelease should not be nil in first version override")
+	if vo1.GitHubReleaseAttestations == nil {
+		t.Fatal("ReleaseAttestations should not be nil in first version override")
 	}
 
-	if !*vo1.GitHubImmutableRelease {
-		t.Error("ImmutableRelease should be true in first version override")
+	if !*vo1.GitHubReleaseAttestations {
+		t.Error("ReleaseAttestations should be true in first version override")
 	}
 
 	if vo1.Cosign == nil {
@@ -748,12 +748,12 @@ version_overrides:
 		t.Errorf("expected asset 'package-v2.tar.gz', got %q", vo2.Asset)
 	}
 
-	if vo2.GitHubImmutableRelease == nil {
-		t.Fatal("ImmutableRelease should not be nil in second version override")
+	if vo2.GitHubReleaseAttestations == nil {
+		t.Fatal("ReleaseAttestations should not be nil in second version override")
 	}
 
-	if *vo2.GitHubImmutableRelease {
-		t.Error("ImmutableRelease should be false in second version override")
+	if *vo2.GitHubReleaseAttestations {
+		t.Error("ReleaseAttestations should be false in second version override")
 	}
 
 	if vo2.SLSAProvenance == nil {

--- a/pkg/installpackage/checksum.go
+++ b/pkg/installpackage/checksum.go
@@ -27,7 +27,7 @@ func (is *Installer) newChecksumVerifiers(pkg *config.Package, assetName string)
 		},
 		&gitHubReleaseAttestationsVerifier{
 			disabled:    is.graDisabled,
-			gra:         pkgInfo.GitHubImmutableRelease,
+			gra:         pkgInfo.GitHubReleaseAttestationsAvailable(),
 			pkg:         pkg,
 			ghInstaller: is.ghInstaller,
 			ghVerifier:  is.ghVerifier,

--- a/pkg/installpackage/download.go
+++ b/pkg/installpackage/download.go
@@ -99,7 +99,7 @@ func (is *Installer) download(ctx context.Context, logger *slog.Logger, param *D
 		},
 		&gitHubReleaseAttestationsVerifier{
 			disabled:    is.graDisabled,
-			gra:         pkgInfo.GitHubImmutableRelease,
+			gra:         pkgInfo.GitHubReleaseAttestationsAvailable(),
 			pkg:         ppkg,
 			ghInstaller: is.ghInstaller,
 			ghVerifier:  is.ghVerifier,


### PR DESCRIPTION
Refs https://github.com/aquaproj/aqua/issues/4626

Caveat: untested.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
  - [ ] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: https://github.com/aquaproj/aqua/issues/4626
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added github_release_attestations configuration and support in installer (with legacy fallback).

* **Deprecations**
  * github_immutable_release is deprecated in favor of github_release_attestations (backward compatible).

* **Tests**
  * Updated fixtures and round-trip checks to use github_release_attestations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->