### PR TITLE
fix(checksum): normalize CRLF line endings in checksum file parser

### DIFF
--- a/pkg/checksum/parser.go
+++ b/pkg/checksum/parser.go
@@ -69,6 +69,7 @@ func ParseChecksumFile(content string, checksumConfig *registry.Checksum) (map[s
 // parseChecksumFile is the internal implementation for parsing checksum files.
 // It handles different file formats: raw, regexp, and default.
 func parseChecksumFile(content string, checksumConfig *registry.Checksum) (map[string]string, string, error) {
+	content = strings.ReplaceAll(content, "\r\n", "\n")
 	switch checksumConfig.FileFormat {
 	case "raw":
 		return nil, strings.TrimSpace(content), nil

--- a/website/docs/guides/checksum.md
+++ b/website/docs/guides/checksum.md
@@ -271,7 +271,7 @@ jobs:
       - name: Fix aqua-checksums.json
         run: aqua upc -prune
       - name: Commit and push
-        uses: securefix-action/action@1301ea990d2c6db9e1bfb3078c925f0d95518080 # v0.5.5
+        uses: securefix-action/action@95bc4acbee15592d68763bd3c1b747aa789c399b # v0.5.6
         with:
           app_id: ${{secrets.APP_ID}}
           app_private_key: ${{secrets.APP_PRIVATE_KEY}}


### PR DESCRIPTION
## Summary

- Normalize `\r\n` (CRLF) line endings to `\n` (LF) in `parseChecksumFile` before splitting checksum file content by lines
- This fixes checksum parsing for files generated on Windows, where line endings are `\r\n`

## Context

`parseChecksumFile` splits checksum file content by `\n` to parse each line. If the checksum file was generated on Windows, lines end with `\r\n`, and splitting by `\n` alone leaves a trailing `\r` on each line. This causes checksum extraction to fail because the parsed values contain an unexpected `\r` character.

Adding `strings.ReplaceAll(content, "\r\n", "\n")` at the entry point of `parseChecksumFile` normalizes line endings before any downstream parsing (`parseDefault`, `parseRegex`), so all three code paths benefit from the fix.

## Test plan

- [ ] `cmdx v` passes
- [ ] `cmdx t` passes (including `pkg/checksum` tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform consistency in checksum processing by normalizing line endings.

* **Documentation**
  * Updated documentation references to the latest Securefix Action version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->