### PR TITLE
fix(asset): map x86-64 to amd64

### DIFF
--- a/pkg/asset/arch.go
+++ b/pkg/asset/arch.go
@@ -23,6 +23,10 @@ func SetArch(assetName, lowAssetName string, assetInfo *AssetInfo) {
 			Arch: "amd64",
 		},
 		{
+			Name: "x86-64",
+			Arch: "amd64",
+		},
+		{
 			Name: "x64",
 			Arch: "amd64",
 		},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced architecture detection to recognize x86-64 assets and properly identify them as amd64 architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->