### PR TITLE
feat(registry): implement IsZeroer for Variants

### DIFF
--- a/pkg/config/registry/package_info.go
+++ b/pkg/config/registry/package_info.go
@@ -193,6 +193,12 @@ type Variant struct {
 // containing Override to apply.
 type Variants []*Variant
 
+// IsZero implements the [go.yaml.in/yaml/v3.IsZeroer] interface.
+// It returns true if the Variants slice is nil.
+func (v Variants) IsZero() bool {
+	return v == nil
+}
+
 // Override provides platform-specific package configuration that overrides
 // the default settings when the specified OS/architecture conditions are met.
 type Override struct {


### PR DESCRIPTION
## Summary

Adds an `IsZero` method to the `Variants` slice type so it follows the same pattern as the sibling collection types in `pkg/config/registry/package_info.go` (`Overrides`, `FormatOverrides`, `Replacements`), all of which implement `go.yaml.in/yaml/v3.IsZeroer`.

## Why

`Variants` was added in #4733 as a named slice type — `type Variants []*Variant` — but it was the only collection type in the package without an `IsZero` method. That made the API surface inconsistent with how the rest of the package opts into yaml.v3's zero detection.

`go.yaml.in/yaml/v3` calls `IsZero() bool` during marshal to decide whether a field tagged with `omitempty` should be emitted. The other collection types in this file each implement it the same way:

```go
// IsZero implements the [go.yaml.in/yaml/v3.IsZeroer] interface.
// It returns true if the Overrides slice is nil.
func (o Overrides) IsZero() bool {
    return o == nil
}
```

The encoder is exercised by, for example, `pkg/controller/generate-registry/generate.go` (`yaml.NewEncoder(c.stdout, yaml.IndentSequence(true))`) when aqua re-emits registry YAML. Without an explicit `IsZeroer` implementation, behaviour relied on the encoder's reflect-based fallback, which differs subtly from the other collection types — they only treat `nil` as empty (so an explicit `Variants{}` would be marshalled as `variants: []`), while reflection considers a length-0 slice zero too.

## What changed

`pkg/config/registry/package_info.go`:

```diff
 // Variants is a list of Variant conditions that must all match for the
 // containing Override to apply.
 type Variants []*Variant

+// IsZero implements the [go.yaml.in/yaml/v3.IsZeroer] interface.
+// It returns true if the Variants slice is nil.
+func (v Variants) IsZero() bool {
+	return v == nil
+}
+
 // Override provides platform-specific package configuration that overrides
```

That's the entire diff — 6 lines, single file.

## Test plan

- [x] `cmdx v` (go vet) — passes
- [x] `cmdx l` (golangci-lint) — 0 issues
- [x] `go test -count=1 ./pkg/config/registry/...` — passes
- [ ] Manual: re-emit a registry that contains `variants` via `aqua generate-registry` and confirm `nil` Variants are omitted while explicit empty `[]` would still be emitted (matches `Overrides`/`FormatOverrides` semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YAML configuration serialization to omit empty variant configurations from output files, resulting in cleaner and more readable configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->