### PR TITLE
feat(registry)!: rename libc variant value `gnu` to `glibc`

### DIFF
--- a/pkg/config/registry/override_test.go
+++ b/pkg/config/registry/override_test.go
@@ -184,7 +184,7 @@ func TestOverride_Match(t *testing.T) { //nolint:funlen
 			},
 		},
 		{
-			title: "variant libc musl doesn't match gnu runtime",
+			title: "variant libc musl doesn't match glibc runtime",
 			override: &registry.Override{
 				GOOS: "linux",
 				Variants: registry.Variants{
@@ -194,7 +194,7 @@ func TestOverride_Match(t *testing.T) { //nolint:funlen
 			rt: &runtime.Runtime{
 				GOOS:   "linux",
 				GOARCH: "amd64",
-				LibC:   "gnu",
+				LibC:   "glibc",
 			},
 		},
 		{
@@ -221,7 +221,7 @@ func TestOverride_Match(t *testing.T) { //nolint:funlen
 			rt: &runtime.Runtime{
 				GOOS:   "linux",
 				GOARCH: "amd64",
-				LibC:   "gnu",
+				LibC:   "glibc",
 			},
 		},
 		{
@@ -230,7 +230,7 @@ func TestOverride_Match(t *testing.T) { //nolint:funlen
 				GOOS: "linux",
 				Variants: registry.Variants{
 					{Key: "libc", Value: "musl"},
-					{Key: "libc", Value: "gnu"},
+					{Key: "libc", Value: "glibc"},
 				},
 			},
 			rt: &runtime.Runtime{

--- a/pkg/runtime/libc_linux.go
+++ b/pkg/runtime/libc_linux.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	libcMusl = "musl"
-	libcGNU  = "gnu"
+	libcMusl  = "musl"
+	libcGlibc = "glibc"
 )
 
 // muslLdFiles lists well-known paths of the musl dynamic linker / libc alias
@@ -26,7 +26,7 @@ var muslLdFiles = []string{ //nolint:gochecknoglobals
 }
 
 // detectLibC returns the libc implementation in use on the current Linux system.
-// It returns "musl", "gnu", or "" when detection is not possible.
+// It returns "musl", "glibc", or "" when detection is not possible.
 //
 // Detection is tiered:
 //  1. Stat well-known musl ld files. No subprocess and works on distroless or
@@ -55,5 +55,5 @@ func detectLibC(ctx context.Context) string {
 	if out.Len() == 0 {
 		return ""
 	}
-	return libcGNU
+	return libcGlibc
 }

--- a/pkg/runtime/libc_linux_internal_test.go
+++ b/pkg/runtime/libc_linux_internal_test.go
@@ -10,8 +10,8 @@ func TestDetectLibC(t *testing.T) {
 	t.Parallel()
 	got := detectLibC(t.Context())
 	switch got {
-	case "musl", "gnu", "":
+	case "musl", "glibc", "":
 	default:
-		t.Fatalf("unexpected libc value: %q (want one of \"musl\", \"gnu\", \"\")", got)
+		t.Fatalf("unexpected libc value: %q (want one of \"musl\", \"glibc\", \"\")", got)
 	}
 }

--- a/website/docs/develop-registry/registry-style-guide.md
+++ b/website/docs/develop-registry/registry-style-guide.md
@@ -145,7 +145,7 @@ files:
 
 :warning: The author [@suzuki-shunsuke](https://github.com/suzuki-shunsuke) isn't familiar with Rust. If you have any opinion, please let us know.
 
-- linux: use the asset for not `gnu` but `musl` if both of them are supported
+- linux: use the asset for not `glibc` but `musl` if both of them are supported
   - ref: https://github.com/aquaproj/aqua-registry/pull/2153#discussion_r805116879
 - windows: use the asset for not `gnu` but `msvc` if both of them are supported
   - ref: https://rust-lang.github.io/rustup/installation/windows.html

--- a/website/docs/reference/registry-config/overrides.md
+++ b/website/docs/reference/registry-config/overrides.md
@@ -115,15 +115,15 @@ overrides:
     goarch: amd64
     variants:
       - key: libc
-        value: gnu
-    asset: foo-{{.OS}}-{{.Arch}}-gnu.{{.Format}}
+        value: glibc
+    asset: foo-{{.OS}}-{{.Arch}}-glibc.{{.Format}}
 ```
 
 ### Supported keys
 
 | key | values | runtime detection |
 |-----|--------|-------------------|
-| `libc` | `musl`, `gnu` | On Linux: presence of `/lib/ld-musl-*.so.1` or `/lib/libc.musl-*.so.1`, otherwise `ldd --version` output. On non-Linux: not detected (empty). |
+| `libc` | `musl`, `glibc` | On Linux: presence of `/lib/ld-musl-*.so.1` or `/lib/libc.musl-*.so.1`, otherwise `ldd --version` output. On non-Linux: not detected (empty). |
 
 You can override the detected libc with the `AQUA_LIBC` environment variable (e.g. `AQUA_LIBC=musl`).
 
@@ -157,7 +157,7 @@ On aqua `< v2.58.0`, `variants` is ignored, so this override matches every Linux
 
 ##### Correct: preserves older behavior
 
-Put the gnu override **first** so older aqua matches it before reaching the musl entry.
+Put the glibc override **first** so older aqua matches it before reaching the musl entry.
 Its `url` can be omitted because the top-level `url` is inherited when an override does not set its own.
 
 ```yaml
@@ -168,8 +168,8 @@ version_overrides:
       - goos: linux
         variants:
           - key: libc
-            value: gnu
-        # url omitted → inherits the top-level (gnu) URL
+            value: glibc
+        # url omitted → inherits the top-level (glibc) URL
       - goos: linux
         url: https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{{trimV .Version}}/{{.OS}}-{{.Arch}}-musl/claude
         variants:
@@ -181,8 +181,8 @@ version_overrides:
 
 | aqua version | glibc user | musl user |
 |----|----|----|
-| `< v2.58.0` (`variants` ignored) | gnu URL ✅ (unchanged) | gnu URL ⚠️ (unchanged — same as before v2.58.0; the binary may not run on musl) |
-| `>= v2.58.0` | gnu URL ✅ | musl URL ✅ |
+| `< v2.58.0` (`variants` ignored) | glibc URL ✅ (unchanged) | glibc URL ⚠️ (unchanged — same as before v2.58.0; the binary may not run on musl) |
+| `>= v2.58.0` | glibc URL ✅ | musl URL ✅ |
 
 musl users who want the musl binary need to upgrade to aqua `>= v2.58.0`.
 On older aqua they continue to get the glibc URL, which is the same behavior as before `variants` existed — so this is not a regression.


### PR DESCRIPTION
## Summary

Rename the `libc` variant value `gnu` → `glibc` for consistency with `musl`. `gnu` referred to the GNU project as a whole, while the actual library name is glibc (GNU C Library); `glibc` is symmetric with `musl` (both are concrete library names).

This is done as a **clean break** before v2.58.0 is released.

## Why now

`v2.58.0` has not been released yet (latest tag is `v2.56.7`; `v2.58.0-1` is a pre-release). Pre-release users of `v2.58.0-1` who wrote `value: gnu` in their registry are the only affected population. Renaming after the official release would require a long-term dual-acceptance shim; doing it now keeps the code, docs, and JSON Schema clean.

## Approach: clean break (no dual acceptance)

- `value: gnu` will no longer match. Anyone using it must migrate to `value: glibc`.
- Reasons for not accepting both:
  - The `gnu` value is essentially unused (no stable release ever shipped it)
  - Dual acceptance would complicate code, tests, and docs and become long-term debt
  - A single line in the v2.58.0 release notes covers the migration

## Changes

### Source
- `pkg/runtime/libc_linux.go`
  - Constant: `libcGNU = "gnu"` → `libcGlibc = "glibc"` (also rename the identifier)
  - Detection return value follows
  - Doc comment for `detectLibC` updated (`"musl", "gnu", or ""` → `"musl", "glibc", or ""`)
  - Note: the internal comment about glibc's `ldd` output (`"ldd (GNU libc)..."`) is **kept as-is** — that's a literal quote from the glibc `ldd` binary, not the aqua variant value.

### Tests
- `pkg/runtime/libc_linux_internal_test.go` — allowed-values switch and error message
- `pkg/config/registry/override_test.go` — `LibC: "gnu"` (×2), `Value: "gnu"`, and one test title for consistency

### Documentation
- `website/docs/reference/registry-config/overrides.md` — YAML examples, the supported-keys table, the prose reference, and the compatibility matrix all updated
- `website/docs/develop-registry/registry-style-guide.md` — only the linux libc bullet (`use the asset for not gnu but musl` → `not glibc but musl`)

### Intentionally NOT changed
- `pkg/asset/os.go` and `pkg/asset/os_test.go`: occurrences like `unknown-linux-gnu` / `pc-windows-gnu` are Rust target triple strings used for asset name mapping, unrelated to the `libc` variant value.
- `website/docs/develop-registry/registry-style-guide.md` line 150 (`windows-gnu` → MinGW) and lines 165–166 (Rust target triple examples): these refer to the Rust target triple naming convention, not the `libc` variant value.
- `pkg/config/registry/override.go`: matching logic is plain string equality and does not hold any `gnu`/`glibc` literal.
- `json-schema/registry.json`: `Variant.value` is a free-form string (no enum), so no regeneration is needed.

## Test plan

- [x] `cmdx v` (vet) — clean
- [x] `cmdx l` (golangci-lint) — 0 issues
- [x] `cmdx t` (full test suite) — all packages pass
- [x] Targeted: `go test ./pkg/runtime/... ./pkg/config/registry/...` — pass
- [x] `git grep` confirms no stray `libcGNU` / `value: gnu` / `gnu URL` remain (only the intentionally-kept `windows-gnu` / Rust target triple references)

## Release notes (suggested)

> The `libc` variant value `gnu` has been renamed to `glibc` for consistency with `musl`. Pre-release users of `v2.58.0-1` who wrote `value: gnu` in their registry must update to `value: glibc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected libc detection to report "glibc" instead of "gnu"

* **Documentation**
  * Updated registry documentation and style guide to reflect standardized libc terminology

<!-- end of auto-generated comment: release notes by coderabbit.ai -->