### PR TITLE
fix(checksum): change the algorithm to sha256 when registry file isn't cached

### DIFF
--- a/pkg/checksum/registry.go
+++ b/pkg/checksum/registry.go
@@ -21,7 +21,7 @@ func RegistryID(regist *aqua.Registry) string {
 func CheckRegistry(regist *aqua.Registry, checksums *Checksums, content []byte) error {
 	checksumID := RegistryID(regist)
 	chksum := checksums.Get(checksumID)
-	algorithm := algoSHA512
+	algorithm := algoSHA256
 	if chksum != nil {
 		algorithm = chksum.Algorithm
 	}
@@ -32,7 +32,7 @@ func CheckRegistry(regist *aqua.Registry, checksums *Checksums, content []byte) 
 	if chksum == nil {
 		chksum = &Checksum{
 			ID:        checksumID,
-			Algorithm: algoSHA512,
+			Algorithm: algorithm,
 			Checksum:  chk,
 		}
 		checksums.Set(checksumID, chksum)

--- a/pkg/checksum/registry.go
+++ b/pkg/checksum/registry.go
@@ -16,7 +16,7 @@ func RegistryID(regist *aqua.Registry) string {
 }
 
 // CheckRegistry validates the integrity of a registry by comparing its content against stored checksums.
-// If no checksum exists for the registry, it calculates and stores a new one using SHA512.
+// If no checksum exists for the registry, it calculates and stores a new one using SHA256.
 // If a checksum exists, it verifies the content matches the expected checksum.
 func CheckRegistry(regist *aqua.Registry, checksums *Checksums, content []byte) error {
 	checksumID := RegistryID(regist)


### PR DESCRIPTION
Close #4785

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Registry checksum verification now defaults to SHA-256 when no prior checksum exists, improving compatibility and consistency.
  * Newly generated checksums are stored with the correct algorithm identifier, preventing mismatches during subsequent verifications.
  * Reduces false verification failures and ensures reliable integrity checks for registry content going forward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->