### PR TITLE
refactor(expr): replace panic with debug log on semver parse error

### DIFF
--- a/pkg/config/registry/version_override.go
+++ b/pkg/config/registry/version_override.go
@@ -17,14 +17,15 @@ func (p *PackageInfo) setTopVersion(logger *slog.Logger, v string) *PackageInfo 
 		}
 		sv = strings.TrimPrefix(v, prefix)
 	}
-	a, err := expr.EvaluateVersionConstraints(p.VersionConstraints, v, sv)
+	a, err := expr.EvaluateVersionConstraints(logger, p.VersionConstraints, v, sv)
 	if err != nil {
 		// If it fails to evaluate version_constraint, output a debug log and treats as version_constraint is false.
 		slogerr.WithError(logger, err).Debug("evaluate the version_constraint")
 		return nil
 	}
 	if a {
-		logger.Debug("match the version_constraint",
+		logger.Debug(
+			"match the version_constraint",
 			"version_constraint", p.VersionConstraints,
 			"package_version", v,
 			"package_semver", sv,
@@ -57,14 +58,15 @@ func (p *PackageInfo) SetVersion(logger *slog.Logger, v string) (*PackageInfo, e
 			}
 			sv = strings.TrimPrefix(v, prefix)
 		}
-		a, err := expr.EvaluateVersionConstraints(vo.VersionConstraints, v, sv)
+		a, err := expr.EvaluateVersionConstraints(logger, vo.VersionConstraints, v, sv)
 		if err != nil {
 			// If it fails to evaluate version_constraint, output a debug log and treats as version_constraint is false.
 			slogerr.WithError(logger, err).Debug("evaluate the version_constraint")
 			continue
 		}
 		if a {
-			logger.Debug("match the version_constraint",
+			logger.Debug(
+				"match the version_constraint",
 				"version_constraint", vo.VersionConstraints,
 				"package_version", v,
 				"package_semver", sv,
@@ -72,7 +74,8 @@ func (p *PackageInfo) SetVersion(logger *slog.Logger, v string) (*PackageInfo, e
 			return p.overrideVersion(vo), nil
 		}
 	}
-	logger.Debug("no version_constraint matches",
+	logger.Debug(
+		"no version_constraint matches",
 		"version_constraint", p.VersionConstraints,
 		"package_version", v,
 	)

--- a/pkg/controller/generate-registry/version_overrides.go
+++ b/pkg/controller/generate-registry/version_overrides.go
@@ -72,7 +72,7 @@ func excludeVersion(logger *slog.Logger, tag string, cfg *Config) bool {
 		return true
 	}
 	if cfg.VersionFilter != nil {
-		f, err := expr.EvaluateVersionFilter(cfg.VersionFilter, tag)
+		f, err := expr.EvaluateVersionFilter(logger, cfg.VersionFilter, tag)
 		if err != nil {
 			slogerr.WithError(logger, err).Warn("evaluate a version filter", "tag_name", tag)
 			return false
@@ -177,7 +177,8 @@ func (c *Controller) listReleases(ctx context.Context, logger *slog.Logger, pkgI
 	for range 10 {
 		releases, resp, err := c.github.ListReleases(ctx, repoOwner, repoName, opt)
 		if err != nil {
-			slogerr.WithError(logger, err).Warn("list releases",
+			slogerr.WithError(logger, err).Warn(
+				"list releases",
 				"repo_owner", repoOwner,
 				"repo_name", repoName,
 			)

--- a/pkg/expr/version_compare.go
+++ b/pkg/expr/version_compare.go
@@ -1,10 +1,12 @@
 package expr
 
 import (
+	"log/slog"
 	"regexp"
 	"strings"
 
 	"github.com/hashicorp/go-version"
+	"github.com/suzuki-shunsuke/slog-error/slogerr"
 )
 
 type Compare struct {
@@ -43,21 +45,32 @@ func comparisons(sv1 *version.Version) []*Compare {
 	}
 }
 
-func getCompareFunc(v string) func(s string) bool {
+func getCompareFunc(logger *slog.Logger, v string) func(s string) bool {
 	return func(s string) bool {
-		return compare(s, v)
+		return compare(logger, s, v)
+	}
+}
+
+func emptySemverWithVersion(_, _ string) bool {
+	return false
+}
+
+func compareFunc(logger *slog.Logger) func(string, string) bool {
+	return func(constr, ver string) bool {
+		return compare(logger, constr, ver)
 	}
 }
 
 var commitHash = regexp.MustCompile(`^[0-9a-f]{40}$`)
 
-func compare(constr, ver string) bool {
+func compare(logger *slog.Logger, constr, ver string) bool {
 	if commitHash.MatchString(ver) {
 		return false
 	}
 	sv1, err := version.NewVersion(ver)
 	if err != nil {
-		panic(err)
+		slogerr.WithError(logger, err).Debug("parse a version as semver", "parsed_version", ver)
+		return false
 	}
 	for constraint := range strings.SplitSeq(strings.TrimSpace(constr), ",") {
 		c := strings.TrimSpace(constraint)
@@ -69,7 +82,8 @@ func compare(constr, ver string) bool {
 			}
 			sv2, err := version.NewVersion(strings.TrimSpace(s))
 			if err != nil {
-				panic(err)
+				slogerr.WithError(logger, err).Debug("parse a version as semver", "parsed_version", s)
+				return false
 			}
 			if !comp.compare(sv2) {
 				return false

--- a/pkg/expr/version_compare_internal_test.go
+++ b/pkg/expr/version_compare_internal_test.go
@@ -1,6 +1,9 @@
 package expr
 
-import "testing"
+import (
+	"log/slog"
+	"testing"
+)
 
 func Test_compare(t *testing.T) {
 	t.Parallel()
@@ -20,7 +23,7 @@ func Test_compare(t *testing.T) {
 	for _, d := range data {
 		t.Run(d.name, func(t *testing.T) {
 			t.Parallel()
-			f := compare(d.constraint, d.version)
+			f := compare(slog.Default(), d.constraint, d.version)
 			if f != d.exp {
 				t.Fatalf("wanted %v, got %v", d.exp, f)
 			}

--- a/pkg/expr/version_constraint.go
+++ b/pkg/expr/version_constraint.go
@@ -1,19 +1,21 @@
 package expr
 
+import "log/slog"
+
 func emptySemver(_ string) bool {
 	return false
 }
 
-func EvaluateVersionConstraints(constraint, v, semver string) (bool, error) {
+func EvaluateVersionConstraints(logger *slog.Logger, constraint, v, semver string) (bool, error) {
 	return evaluateBool(constraint, map[string]any{
 		keyVersion:           "",
 		"SemVer":             "",
 		keySemver:            emptySemver,
-		keySemverWithVersion: compare,
+		keySemverWithVersion: emptySemverWithVersion,
 	}, map[string]any{
 		keyVersion:           v,
 		"SemVer":             semver,
-		keySemver:            getCompareFunc(semver),
-		keySemverWithVersion: compare,
+		keySemver:            getCompareFunc(logger, semver),
+		keySemverWithVersion: compareFunc(logger),
 	})
 }

--- a/pkg/expr/version_constraint_test.go
+++ b/pkg/expr/version_constraint_test.go
@@ -1,6 +1,7 @@
 package expr_test
 
 import (
+	"log/slog"
 	"testing"
 
 	"github.com/aquaproj/aqua/v2/pkg/expr"
@@ -63,7 +64,7 @@ func TestVersionConstraints_Check(t *testing.T) { //nolint:funlen
 	for _, d := range data {
 		t.Run(d.title, func(t *testing.T) {
 			t.Parallel()
-			b, err := expr.EvaluateVersionConstraints(d.constraints, d.version, d.semver)
+			b, err := expr.EvaluateVersionConstraints(slog.Default(), d.constraints, d.version, d.semver)
 			if d.isErr {
 				if err == nil {
 					t.Fatal("err should be returned")

--- a/pkg/expr/version_filter.go
+++ b/pkg/expr/version_filter.go
@@ -1,6 +1,8 @@
 package expr
 
 import (
+	"log/slog"
+
 	"github.com/expr-lang/expr"
 	"github.com/expr-lang/expr/vm"
 )
@@ -9,7 +11,7 @@ func CompileVersionFilter(versionFilter string) (*vm.Program, error) {
 	return expr.Compile(versionFilter, expr.AsBool(), expr.Env(map[string]any{ //nolint:wrapcheck
 		keyVersion:           "",
 		keySemver:            emptySemver,
-		keySemverWithVersion: compare,
+		keySemverWithVersion: emptySemverWithVersion,
 	}))
 }
 
@@ -17,7 +19,7 @@ func CompileVersionFilterForTest(versionFilter string) *vm.Program {
 	p, err := expr.Compile(versionFilter, expr.AsBool(), expr.Env(map[string]any{
 		keyVersion:           "",
 		keySemver:            emptySemver,
-		keySemverWithVersion: compare,
+		keySemverWithVersion: emptySemverWithVersion,
 	}))
 	if err != nil {
 		panic(err)
@@ -25,10 +27,10 @@ func CompileVersionFilterForTest(versionFilter string) *vm.Program {
 	return p
 }
 
-func EvaluateVersionFilter(prog *vm.Program, v string) (bool, error) {
+func EvaluateVersionFilter(logger *slog.Logger, prog *vm.Program, v string) (bool, error) {
 	return evaluateBoolProg(prog, map[string]any{
 		keyVersion:           v,
-		keySemver:            getCompareFunc(v),
-		keySemverWithVersion: compare,
+		keySemver:            getCompareFunc(logger, v),
+		keySemverWithVersion: compareFunc(logger),
 	})
 }

--- a/pkg/policy/package.go
+++ b/pkg/policy/package.go
@@ -40,7 +40,7 @@ func validatePackage(logger *slog.Logger, param *paramValidatePackage) error {
 		return nil
 	}
 	for _, policyPkg := range param.PolicyConfig.Packages {
-		f, err := matchPkg(param.Pkg, policyPkg)
+		f, err := matchPkg(logger, param.Pkg, policyPkg)
 		if err != nil {
 			// If it fails to check if the policy matches with the package, output a debug log and treat as the policy doesn't match with the package.
 			slogerr.WithError(logger, err).Debug("check if the package matches with a policy")
@@ -53,7 +53,7 @@ func validatePackage(logger *slog.Logger, param *paramValidatePackage) error {
 	return errUnAllowedPackage
 }
 
-func matchPkg(pkg *config.Package, policyPkg *Package) (bool, error) {
+func matchPkg(logger *slog.Logger, pkg *config.Package, policyPkg *Package) (bool, error) {
 	if policyPkg.Name != "" && pkg.Package.Name != policyPkg.Name {
 		return false, nil
 	}
@@ -62,7 +62,7 @@ func matchPkg(pkg *config.Package, policyPkg *Package) (bool, error) {
 		if pkg.PackageInfo.VersionPrefix != "" {
 			sv = strings.TrimPrefix(pkg.Package.Version, pkg.PackageInfo.VersionPrefix)
 		}
-		matched, err := expr.EvaluateVersionConstraints(policyPkg.Version, pkg.Package.Version, sv)
+		matched, err := expr.EvaluateVersionConstraints(logger, policyPkg.Version, pkg.Package.Version, sv)
 		if err != nil {
 			return false, fmt.Errorf("evaluate the version constraint of package: %w", err)
 		}
@@ -70,10 +70,10 @@ func matchPkg(pkg *config.Package, policyPkg *Package) (bool, error) {
 			return false, nil
 		}
 	}
-	return matchRegistry(pkg.Registry, policyPkg.Registry)
+	return matchRegistry(logger, pkg.Registry, policyPkg.Registry)
 }
 
-func matchRegistry(rgst *aqua.Registry, rgstPolicy *Registry) (bool, error) {
+func matchRegistry(logger *slog.Logger, rgst *aqua.Registry, rgstPolicy *Registry) (bool, error) {
 	if rgst.Type != rgstPolicy.Type {
 		return false, nil
 	}
@@ -91,7 +91,7 @@ func matchRegistry(rgst *aqua.Registry, rgstPolicy *Registry) (bool, error) {
 	}
 
 	if rgstPolicy.Ref != "" {
-		matched, err := expr.EvaluateVersionConstraints(rgstPolicy.Ref, rgst.Ref, rgst.Ref)
+		matched, err := expr.EvaluateVersionConstraints(logger, rgstPolicy.Ref, rgst.Ref, rgst.Ref)
 		if err != nil {
 			return false, fmt.Errorf("evaluate the version constraint of registry: %w", err)
 		}

--- a/pkg/versiongetter/filter.go
+++ b/pkg/versiongetter/filter.go
@@ -1,6 +1,7 @@
 package versiongetter
 
 import (
+	"log/slog"
 	"strings"
 
 	"github.com/aquaproj/aqua/v2/pkg/config/registry"
@@ -59,7 +60,7 @@ func createFilters(pkgInfo *registry.PackageInfo) ([]*Filter, error) {
 	return filters, nil
 }
 
-func matchTagByFilter(tagName string, filter *Filter) bool {
+func matchTagByFilter(logger *slog.Logger, tagName string, filter *Filter) bool {
 	sv := tagName
 	if filter.Prefix != "" {
 		if !strings.HasPrefix(tagName, filter.Prefix) {
@@ -68,14 +69,14 @@ func matchTagByFilter(tagName string, filter *Filter) bool {
 		sv = strings.TrimPrefix(tagName, filter.Prefix)
 	}
 	if filter.Filter != nil {
-		if f, err := expr.EvaluateVersionFilter(filter.Filter, tagName); err != nil || !f {
+		if f, err := expr.EvaluateVersionFilter(logger, filter.Filter, tagName); err != nil || !f {
 			return false
 		}
 	}
 	if filter.Constraint == "" {
 		return true
 	}
-	if f, err := expr.EvaluateVersionConstraints(filter.Constraint, tagName, sv); err == nil && f {
+	if f, err := expr.EvaluateVersionConstraints(logger, filter.Constraint, tagName, sv); err == nil && f {
 		return true
 	}
 	return false

--- a/pkg/versiongetter/github_release.go
+++ b/pkg/versiongetter/github_release.go
@@ -103,7 +103,7 @@ func (g *GitHubReleaseVersionGetter) Get(ctx context.Context, logger *slog.Logge
 			return "", fmt.Errorf("list tags: %w", err)
 		}
 		for _, release := range releases {
-			if filterRelease(release, filters) {
+			if filterRelease(logger, release, filters) {
 				candidates = append(candidates, convRelease(release))
 			}
 		}
@@ -137,7 +137,7 @@ func (g *GitHubReleaseVersionGetter) List(ctx context.Context, logger *slog.Logg
 				continue
 			}
 			tags[tagName] = struct{}{}
-			if filterRelease(release, filters) {
+			if filterRelease(logger, release, filters) {
 				v := &fuzzyfinder.Version{
 					Name:        release.GetName(),
 					Version:     tagName,
@@ -160,7 +160,7 @@ func (g *GitHubReleaseVersionGetter) List(ctx context.Context, logger *slog.Logg
 	}
 }
 
-func filterRelease(release *github.RepositoryRelease, filters []*Filter) bool {
+func filterRelease(logger *slog.Logger, release *github.RepositoryRelease, filters []*Filter) bool {
 	if release.GetPrerelease() {
 		return false
 	}
@@ -168,7 +168,7 @@ func filterRelease(release *github.RepositoryRelease, filters []*Filter) bool {
 	tagName := release.GetTagName()
 
 	for _, filter := range filters {
-		if matchTagByFilter(tagName, filter) {
+		if matchTagByFilter(logger, tagName, filter) {
 			return !filter.NoAsset
 		}
 	}

--- a/pkg/versiongetter/github_release_internal_test.go
+++ b/pkg/versiongetter/github_release_internal_test.go
@@ -1,6 +1,7 @@
 package versiongetter
 
 import (
+	"log/slog"
 	"testing"
 
 	"github.com/aquaproj/aqua/v2/pkg/expr"
@@ -102,7 +103,7 @@ func Test_filterRelease(t *testing.T) { //nolint:funlen
 	for _, d := range data {
 		t.Run(d.name, func(t *testing.T) {
 			t.Parallel()
-			f := filterRelease(d.release, d.filters)
+			f := filterRelease(slog.Default(), d.release, d.filters)
 			if f != d.exp {
 				t.Fatalf("wanted %v, got %v", d.exp, f)
 			}

--- a/pkg/versiongetter/github_tag.go
+++ b/pkg/versiongetter/github_tag.go
@@ -55,7 +55,7 @@ func (g *GitHubTagVersionGetter) Get(ctx context.Context, logger *slog.Logger, p
 			return "", fmt.Errorf("list tags: %w", err)
 		}
 		for _, tag := range tags {
-			if filterTag(tag, filters) {
+			if filterTag(logger, tag, filters) {
 				candidates = append(candidates, convTag(tag))
 			}
 		}
@@ -89,7 +89,7 @@ func (g *GitHubTagVersionGetter) List(ctx context.Context, logger *slog.Logger, 
 				continue
 			}
 			tagNames[tagName] = struct{}{}
-			if filterTag(tag, filters) {
+			if filterTag(logger, tag, filters) {
 				versions = append(versions, tagName)
 			}
 		}
@@ -103,10 +103,10 @@ func (g *GitHubTagVersionGetter) List(ctx context.Context, logger *slog.Logger, 
 	}
 }
 
-func filterTag(tag *github.RepositoryTag, filters []*Filter) bool {
+func filterTag(logger *slog.Logger, tag *github.RepositoryTag, filters []*Filter) bool {
 	tagName := tag.GetName()
 	for _, filter := range filters {
-		if matchTagByFilter(tagName, filter) {
+		if matchTagByFilter(logger, tagName, filter) {
 			return !filter.NoAsset
 		}
 	}


### PR DESCRIPTION
- https://github.com/aquaproj/aqua-registry/pull/53474#discussion_r3213152277

## Summary

Threads a `*slog.Logger` through the `pkg/expr` version-comparison helpers so a malformed semver no longer panics — it now emits a debug log and is treated as non-matching.

Previously `compare()` called `panic(err)` if `version.NewVersion(...)` failed. Because expr expressions like `semverWithVersion(">= 4.2.0", trimPrefix(Version, "kustomize/"))` are evaluated against arbitrary tag names from upstream repositories, a release tag that wasn't a parseable semver would crash the process. Now it logs at debug level and the constraint evaluates to false.

## Changes

### pkg/expr — core change
- `compare(constr, ver)` → `compare(logger, constr, ver)`; replaced the two `panic(err)` paths with `slogerr.WithError(logger, err).Debug(...)` + `return false`.
- `getCompareFunc(v)` → `getCompareFunc(logger, v)`.
- `EvaluateVersionConstraints(constraint, v, semver)` → `EvaluateVersionConstraints(logger, constraint, v, semver)`.
- `EvaluateVersionFilter(prog, v)` → `EvaluateVersionFilter(logger, prog, v)`.
- Added two helpers in `version_compare.go`:
  - `emptySemverWithVersion(_, _ string) bool` — typed stub used in compile-time `expr.Env(...)` maps where no logger exists.
  - `compareFunc(logger) func(string, string) bool` — closure that captures the logger so the value assigned to `keySemverWithVersion` keeps the public 2-arg expr API intact.
- `CompileVersionFilter` / `CompileVersionFilterForTest` use `emptySemverWithVersion` instead of `compare` so the env's type signature matches the runtime input.

### Callers updated to forward the logger
- `pkg/versiongetter/filter.go` — `matchTagByFilter` gains a logger.
- `pkg/versiongetter/github_release.go` — `filterRelease` gains a logger; `Get` / `List` forward their existing `logger`.
- `pkg/versiongetter/github_tag.go` — `filterTag` gains a logger; `Get` / `List` forward their existing `logger`.
- `pkg/policy/package.go` — `matchPkg` and `matchRegistry` gain a logger; `validatePackage` forwards its existing `logger`.
- `pkg/config/registry/version_override.go` — both `EvaluateVersionConstraints` calls forward the existing `logger`.
- `pkg/controller/generate-registry/version_overrides.go` — `excludeVersion` forwards its existing `logger` to `EvaluateVersionFilter`.

### Tests
- `pkg/expr/version_compare_internal_test.go`, `pkg/expr/version_constraint_test.go`, `pkg/versiongetter/github_release_internal_test.go` — pass `slog.Default()` to the updated signatures.

## Behavior change

Previously: malformed semver in a version-constraint context = panic.
Now: malformed semver = debug log + constraint evaluates to false (matches the existing pattern around invalid commit-hash inputs).

The user-facing expr API (`semverWithVersion(constraint, version)` taking 2 strings) is preserved via the closure wrapper.

## Test plan

- [x] `go vet ./...` — passes
- [x] `go build ./...` — passes
- [x] `go test ./pkg/expr/... ./pkg/versiongetter/... ./pkg/policy/... ./pkg/config/registry/... ./pkg/controller/generate-registry/...` — passes
- [ ] Manual sanity check that `semverWithVersion(...)` expressions still work end-to-end via `aqua g` against a registry with version overrides

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for version constraints and filtering—malformed version strings no longer cause system failures and are now handled gracefully.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aquaproj/aqua/pull/4798)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->