### PR TITLE
test: reproducer for github_tag pre-release pagination (issue #4808)

### DIFF
--- a/pkg/versiongetter/github_tag_test.go
+++ b/pkg/versiongetter/github_tag_test.go
@@ -1,10 +1,12 @@
 package versiongetter_test
 
 import (
+	"fmt"
 	"log/slog"
 	"testing"
 
 	"github.com/aquaproj/aqua/v2/pkg/config/registry"
+	"github.com/aquaproj/aqua/v2/pkg/expr"
 	"github.com/aquaproj/aqua/v2/pkg/fuzzyfinder"
 	"github.com/aquaproj/aqua/v2/pkg/github"
 	"github.com/aquaproj/aqua/v2/pkg/versiongetter"
@@ -44,6 +46,67 @@ func TestGitHubTagVersionGetter_Get(t *testing.T) { //nolint:dupl
 				RepoName:  "tfcmt",
 			},
 			version: "v3.0.0",
+		},
+		{
+			// Reproduces a behavioural asymmetry between github_release and
+			// github_tag version sources.
+			//
+			// github_release's filterRelease() hard-rejects any release whose
+			// `prerelease` flag is true (pkg/versiongetter/github_release.go),
+			// so pre-release tags never enter the candidate list. The Get()
+			// loop then pages on through ListReleases until a stable release
+			// is found.
+			//
+			// github_tag's filterTag() has no equivalent check. When the most
+			// recent page of tags contains only pre-releases (e.g. >PerPage
+			// pre-release tags accumulated since the last stable), candidates
+			// fills with pre-releases, len(candidates) > 0 short-circuits the
+			// Get() loop, and the latest stable on a later page is never
+			// reached. compareRelease()'s stable-vs-pre tiebreaker doesn't
+			// rescue this because both sides of the comparison are pre-release.
+			//
+			// Expected (matching github_release behaviour): "v1.0.0".
+			// Observed (current github_tag behaviour): "v1.0.1-beta.30".
+			name: "prereleases dominate page 1, stable on page 2 — should return stable",
+			filters: []*versiongetter.Filter{
+				{},
+			},
+			tags: map[string][]*github.RepositoryTag{
+				"kunobi-ninja/kunobi": tagListWithPrereleaseDominantFirstPage(),
+			},
+			pkg: &registry.PackageInfo{
+				RepoOwner: "kunobi-ninja",
+				RepoName:  "kunobi",
+			},
+			version: "v1.0.0",
+		},
+		{
+			// Same data as the previous case, but with a version_filter that
+			// excludes the rc/alpha/beta pre-release pattern. filterTag now
+			// rejects all of page 1's candidates, len(candidates) stays 0,
+			// the Get() loop pages on to page 2, and the stable is found.
+			//
+			// This documents the workaround that registry authors currently
+			// have to apply manually (e.g. apache/maven, the package whose
+			// version_filter expression matches this one), and that the
+			// asymmetry above means is mandatory for github_tag packages but
+			// unnecessary for github_release packages.
+			name: "version_filter excluding pre-releases recovers the stable",
+			filters: func() []*versiongetter.Filter {
+				f, err := expr.CompileVersionFilter(`not (Version matches "-(rc|alpha|beta)")`)
+				if err != nil {
+					panic(err)
+				}
+				return []*versiongetter.Filter{{Filter: f}}
+			}(),
+			tags: map[string][]*github.RepositoryTag{
+				"kunobi-ninja/kunobi": tagListWithPrereleaseDominantFirstPage(),
+			},
+			pkg: &registry.PackageInfo{
+				RepoOwner: "kunobi-ninja",
+				RepoName:  "kunobi",
+			},
+			version: "v1.0.0",
 		},
 	}
 
@@ -137,4 +200,24 @@ func TestGitHubTagVersionGetter_List(t *testing.T) { //nolint:funlen
 			}
 		})
 	}
+}
+
+// tagListWithPrereleaseDominantFirstPage returns a tag list that triggers
+// the github_tag prerelease-pagination edge documented above:
+// 30 pre-release tags (filling the entire first page given the hardcoded
+// PerPage = 30 in github_tag.go) followed by 1 stable tag on page 2.
+// Tags are ordered most-recent-first, matching real GitHub API output.
+func tagListWithPrereleaseDominantFirstPage() []*github.RepositoryTag {
+	tags := make([]*github.RepositoryTag, 0, 31)
+	// Page 1 — 30 pre-releases.
+	for i := 30; i >= 1; i-- {
+		tags = append(tags, &github.RepositoryTag{
+			Name: new(fmt.Sprintf("v1.0.1-beta.%d", i)),
+		})
+	}
+	// Page 2 — the stable release the user actually wants.
+	tags = append(tags, &github.RepositoryTag{
+		Name: new("v1.0.0"),
+	})
+	return tags
 }

--- a/pkg/versiongetter/mock_github_tag.go
+++ b/pkg/versiongetter/mock_github_tag.go
@@ -25,5 +25,8 @@ func (g *MockGitHubTagClient) ListTags(ctx context.Context, owner string, repo s
 	}
 	m := min((opts.Page+1)*opts.PerPage, len(tags))
 	resp := &github.Response{}
+	if m < len(tags) {
+		resp.NextPage = opts.Page + 1
+	}
 	return tags[opts.Page*opts.PerPage : m], resp, nil
 }


### PR DESCRIPTION
Reproducer for #4808. **Draft PR — failing test included intentionally to demonstrate the bug.**

## What this changes

- `pkg/versiongetter/mock_github_tag.go`: 3-line fix so `MockGitHubTagClient` sets `resp.NextPage` when more pages remain. Currently always returns `0`, which makes pagination-aware tests impossible. All existing tests still pass with this change.
- `pkg/versiongetter/github_tag_test.go`: two new test cases.

## Test output

```
--- PASS: TestGitHubTagVersionGetter_Get/normal
--- PASS: TestGitHubTagVersionGetter_Get/version_filter_excluding_pre-releases_recovers_the_stable
--- FAIL: TestGitHubTagVersionGetter_Get/prereleases_dominate_page_1,_stable_on_page_2_—_should_return_stable
        github_tag_test.go:130: wanted v1.0.0, got v1.0.1-beta.30
```

The failing case demonstrates the asymmetry described in #4808 — `filterTag` has no equivalent of `filterRelease`'s `if release.GetPrerelease() { return false }`, so when >30 pre-release tags accumulate between stables, the pagination loop in `Get()` short-circuits on page 1 and never reaches the stable on page 2.

The passing case demonstrates the workaround — `version_filter: not (Version matches "-(rc|alpha|beta)")` causes `filterTag` to reject page 1's pre-releases, `candidates` stays empty, and the loop pages on until the stable is found.

## What I'd like guidance on

#4808 lists three possible directions (auto-exclude in `filterTag`, document the asymmetry, or status quo). This PR doesn't pick one — it's just the reproducer. Happy to update with a fix once you've decided which direction you want.

🤖 Drafted with assistance from Claude (claude-opus-4-7).