### PR TITLE
docs: add Cybozu to who-uses-aqua

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Declarative CLI Version Manager written in Go.
 - [Studist](https://studist.jp/) ([ref](https://studist.tech/entrance-book-4a57bc50aace))
 - [Connehito Inc.](https://connehito.com/) ([ref](https://tech.connehito.com/entry/2024/10/01/184156#%E3%83%87%E3%83%97%E3%83%AD%E3%82%A4%E3%81%A7%E6%89%B1%E3%81%86CLI%E3%83%84%E3%83%BC%E3%83%AB%E3%81%AF-aqua-%E3%81%A7%E7%AE%A1%E7%90%86))
 - [LayerX Inc.](https://layerx.co.jp/) ([ref](https://tech.layerx.co.jp/entry/aqua-local-setup))
+- [Cybozu, Inc.](https://cybozu.co.jp/) ([ref](https://blog.cybozu.io/entry/2025/04/14/100000#%E3%83%93%E3%83%AB%E3%83%89%E3%82%84%E3%83%AA%E3%83%B3%E3%83%88%E3%83%84%E3%83%BC%E3%83%AB))
 
 ## License
 


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - I think this change doesn't need an issue
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->
Cybozu started sponsoring to aquaproj yesterday. We use aqua directly for our products and OSS such as [cybozu-go/accurate](https://github.com/cybozu-go/accurate), and indirectly through mise. Thank you for developing this!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the list of aqua users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aquaproj/aqua/pull/4875?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->