### PR TITLE
fix: replace emoji shortcode `:thumbsup:`/`:thumbsdown:` with valid `:+1:`/`:-1:`

### DIFF
--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -261,23 +261,23 @@ Your contribution is welcome.
 
 ### Compared with Homebrew
 
-- :thumbsup: [Strict Version Control](#strict-version-control)
-- :thumbsup: [Windows Support](/docs/reference/windows-support/)
+- :+1: [Strict Version Control](#strict-version-control)
+- :+1: [Windows Support](/docs/reference/windows-support/)
 
 You can use Homebrew to install tools aqua can't install.
 
 ### Compared with asdf
 
-- :thumbsup: [Easy to use](#easy-to-use)
-- :thumbsup: [Lazy Install](https://aquaproj.github.io/docs/tutorial/lazy-install/)
-- :thumbsup: You don't have to install plugins in advance
-- :thumbsup: [Continuous update by Renovate](#continuous-update-by-renovate)
-- :thumbsup: [Security](reference/security/index.md) ([Checksum Verification](/docs/guides/checksum/))
-- :thumbsup: [aqua doesn't force to manage a tool by aqua in a project even if aqua is used to manage the tool in the other project](#aqua-doesnt-force-to-manage-a-tool-by-aqua-in-a-project-even-if-aqua-is-used-to-manage-the-tool-in-the-other-project)
-- :thumbsup: [aqua Registry is much easier to maintain than asdf plugins](#easy-to-support-new-tools)
-- :thumbsup: Small things
-  - :thumbsup: [Share aqua configuration for teams and organizations with AQUA_GLOBAL_CONFIG](/docs/guides/team-config)
-  * :thumbsup: [Split the list of packages](/docs/guides/split-config)
+- :+1: [Easy to use](#easy-to-use)
+- :+1: [Lazy Install](https://aquaproj.github.io/docs/tutorial/lazy-install/)
+- :+1: You don't have to install plugins in advance
+- :+1: [Continuous update by Renovate](#continuous-update-by-renovate)
+- :+1: [Security](reference/security/index.md) ([Checksum Verification](/docs/guides/checksum/))
+- :+1: [aqua doesn't force to manage a tool by aqua in a project even if aqua is used to manage the tool in the other project](#aqua-doesnt-force-to-manage-a-tool-by-aqua-in-a-project-even-if-aqua-is-used-to-manage-the-tool-in-the-other-project)
+- :+1: [aqua Registry is much easier to maintain than asdf plugins](#easy-to-support-new-tools)
+- :+1: Small things
+  - :+1: [Share aqua configuration for teams and organizations with AQUA_GLOBAL_CONFIG](/docs/guides/team-config)
+  * :+1: [Split the list of packages](/docs/guides/split-config)
 
 #### aqua doesn't force to manage a tool by aqua in a project even if aqua is used to manage the tool in the other project
 
@@ -299,10 +299,10 @@ You can use asdf for them and can use aqua for other tools.
 
 ### Compared with GitHub Actions
 
-- :thumbsup: [Strict Version Control](#strict-version-control)
-- :thumbsup: Unify how to install tools in both local development and CI
-- :thumbsup: [Continuous update by Renovate](#continuous-update-by-renovate)
-- :thumbsup: [Security](reference/security/index.md) ([Checksum Verification](/docs/guides/checksum/))
+- :+1: [Strict Version Control](#strict-version-control)
+- :+1: Unify how to install tools in both local development and CI
+- :+1: [Continuous update by Renovate](#continuous-update-by-renovate)
+- :+1: [Security](reference/security/index.md) ([Checksum Verification](/docs/guides/checksum/))
 
 ## Restriction
 

--- a/website/docs/reference/use-aqua-with-other-tools.md
+++ b/website/docs/reference/use-aqua-with-other-tools.md
@@ -9,7 +9,7 @@ you should add `${AQUA_ROOT_DIR}/bin` to the environment variable `PATH` after o
 
 e.g.
 
-:thumbsup:
+:+1:
 
 ```bash
 . $HOME/.asdf/asdf.sh
@@ -17,7 +17,7 @@ e.g.
 export PATH=${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin:$PATH
 ```
 
-:thumbsdown:
+:-1:
 
 ```bash
 export PATH=${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin:$PATH


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: fix #4886 
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->
The root cause of the issue was `node-emoji@2`. The major upgrade of Docusaurus upgraded `remark-emoji@2` to `remark-emoji@4`, and it upgraded its dependency `node-emoji@1` to `node-emoji@2`. The `node-emoji@2` no longer treats `:thumbsup:` as a valid shortcode for `👍` and now only recognizes `:+1:`. That's why other emoji shortcodes like `:tada:` were properly rendered without any issue. This PR replaces them with valid ones.