### PR TITLE
ci(security): use takumi guard

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -5,12 +5,14 @@ permissions: {}
 jobs:
   autofix:
     runs-on: ubuntu-24.04
-    permissions: {}
+    permissions:
+      id-token: write
     timeout-minutes: 15
     steps:
-      - uses: suzuki-shunsuke/go-autofix-action@ba716cebb7767055bdde0e62bb91d715bde39ab2 # v0.1.12
+      - uses: suzuki-shunsuke/go-autofix-action@9a8682f2dc2a935fe2a2ac96deb03de2dfcb872e # v0.1.13
         with:
           aqua_version: v2.59.1
+          takumi_guard_bot_id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
       - run: aqua upc -prune
         working-directory: pkg/cosign
         env:
@@ -43,6 +45,18 @@ jobs:
           node-version: ${{steps.package_json.outputs.prop}}
           cache: npm
           cache-dependency-path: website/package-lock.json
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+      - name: Move the npmrc to the user npmrc
+        # setup-takumi-guard-npm writes the registry and auth token to ./.npmrc,
+        # but npm ci runs in website/ and npm does not read parent directories'
+        # .npmrc. Move it to the user-level ~/.npmrc so npm ci picks it up.
+        run: |
+          if [ -f .npmrc ]; then
+            cat .npmrc >> "$HOME/.npmrc"
+            rm .npmrc
+          fi
       - run: npm ci
         working-directory: website
       - run: bash scripts/generate-usage.sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,9 @@ on:
 permissions: {}
 jobs:
   release:
-    uses: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml@b2ecf54e35aca9e9689e761f5bd6d1ad9542a8cf # v8.0.0
+    uses: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml@884a4badb955df4a4ddddd802e433096371f3157 # v8.1.0
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     with:
       go-version-file: go.mod
       aqua_policy_allow: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,10 @@ jobs:
       - run: exit 1
   test:
     uses: ./.github/workflows/workflow_call_test.yaml
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       issues: write
       pull-requests: write
+      id-token: write

--- a/.github/workflows/wc-integration-test.yaml
+++ b/.github/workflows/wc-integration-test.yaml
@@ -1,11 +1,17 @@
 ---
 name: integration-test
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 jobs:
   integration-test:
     timeout-minutes: 30
     runs-on: ubuntu-24.04
-    permissions: {}
+    permissions:
+      contents: read
+      id-token: write
     env:
       GITHUB_TOKEN: ${{github.token}}
       AQUA_LOG_COLOR: always
@@ -18,6 +24,10 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+
+      - uses: flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
 
       - run: |
           go install \
@@ -281,7 +291,9 @@ jobs:
   integration-test-cargo:
     timeout-minutes: 30
     runs-on: ubuntu-24.04
-    permissions: {}
+    permissions:
+      contents: read
+      id-token: write
     env:
       AQUA_LOG_COLOR: always
     steps:
@@ -292,6 +304,10 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+
+      - uses: flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
 
       - run: |
           go install \
@@ -327,7 +343,9 @@ jobs:
   integration-test-all-envs:
     timeout-minutes: 30
     runs-on: ${{ matrix.env.runs-on }}
-    permissions: {}
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       matrix:
         env:
@@ -347,6 +365,13 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+
+      # setup-takumi-guard-golang is bash/Unix-based; only run it on Linux.
+      - uses: flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1
+        if: runner.os == 'Linux'
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+
       - run: |
           go install -ldflags "-X main.version=v2.48.2-local -X main.commit=$sha -X main.date=$(date +"%Y-%m-%dT%H:%M:%SZ%:z" | tr -d '+')" ./cmd/aqua
 

--- a/.github/workflows/wc-test-docker.yaml
+++ b/.github/workflows/wc-test-docker.yaml
@@ -1,6 +1,10 @@
 ---
 name: test-docker-prebuilt
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 jobs:
   test-docker:
     # Test Dockerfile
@@ -16,7 +20,9 @@ jobs:
   test-docker-build:
     timeout-minutes: 30
     runs-on: ubuntu-24.04
-    permissions: {}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -26,6 +32,11 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+
+      - uses: flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+
       - run: |
           go install \
             -ldflags "-X main.version=v2.48.2-local -X main.commit=$sha -X main.date=$(date +"%Y-%m-%dT%H:%M:%SZ%:z" | tr -d '+')" \

--- a/.github/workflows/workflow_call_deploy_doc.yaml
+++ b/.github/workflows/workflow_call_deploy_doc.yaml
@@ -1,5 +1,9 @@
 name: Deploy document (workflow_call)
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 jobs:
   deploy_doc:
     timeout-minutes: 15
@@ -7,7 +11,21 @@ jobs:
     permissions:
       contents: write
       issues: write
+      id-token: write
     steps:
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+      - name: Move the npmrc to the user npmrc
+        # setup-takumi-guard-npm writes the registry and auth token to ./.npmrc,
+        # but release-doc-action runs its own actions/checkout (clean) and npm ci
+        # in website/, which would not read this .npmrc. Move it to the
+        # user-level ~/.npmrc so it survives the checkout and npm ci picks it up.
+        run: |
+          if [ -f .npmrc ]; then
+            cat .npmrc >> "$HOME/.npmrc"
+            rm .npmrc
+          fi
       - uses: suzuki-shunsuke/release-doc-action@a9e1ea0c4ca8c62906ca2a7fd3fa33325ee43ec9 # v0.1.0
         with:
           source_dir: website

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -1,6 +1,10 @@
 ---
 name: test (workflow_call)
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 permissions: {}
 jobs:
   path-filter:
@@ -20,13 +24,16 @@ jobs:
               - .github/workflows/wc-test-docker.yaml
 
   test:
-    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@e442a17816baa8a940edc1544cc6e739d870e165 # v5.0.2
+    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb # v6.0.0
     with:
       aqua_version: v2.59.1
       golangci-lint-timeout: 120s
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write
 
   test-goreleaser:
     uses: ./.github/workflows/test-goreleaser.yaml
@@ -37,17 +44,28 @@ jobs:
     uses: ./.github/workflows/wc-test-docker.yaml
     needs: path-filter
     if: needs.path-filter.outputs.test-docker == 'true'
-    permissions: {}
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+    permissions:
+      contents: read
+      id-token: write
 
   integration-test:
     uses: ./.github/workflows/wc-integration-test.yaml
-    permissions: {}
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+    permissions:
+      contents: read
+      id-token: write
 
   test_doc:
     uses: ./.github/workflows/workflow_call_deploy_doc.yaml
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       issues: write
+      id-token: write
 
   typos:
     uses: ./.github/workflows/workflow_call_typos.yaml


### PR DESCRIPTION
## Overview

Introduce [Takumi Guard](https://github.com/suzuki-shunsuke/ghalint) into the CI workflows for both **Go** module downloads and **npm** (website) installs, following the pattern rolled out across the other repositories.

## Changes

### Go

#### `release.yaml`
- Bump `go-release-workflow` v8.0.0 → v8.1.0; pass `secrets.TAKUMI_GUARD_BOT_ID`.

#### `workflow_call_test.yaml`
- Declare `on.workflow_call.secrets.TAKUMI_GUARD_BOT_ID` (`required: true`).
- `test` job: bump `go-test-full-workflow` v5.0.2 → v6.0.0, pass the secret, add `id-token: write`.
- Pass the secret and add `id-token: write` (+`contents: read`) to the jobs that call `wc-test-docker.yaml`, `wc-integration-test.yaml`, and `workflow_call_deploy_doc.yaml`.

#### `test.yaml`
- `test` job: pass the secret and add `id-token: write`.

#### `wc-integration-test.yaml`
- Declare the secret. Add `contents: read` / `id-token: write` and a `setup-takumi-guard-golang@v1` step (after `setup-go`, before `go install`) to all three Go jobs.
- `integration-test-all-envs` runs a Windows/macOS/Linux matrix; the golang action is bash/Unix-based, so its step is guarded with `if: runner.os == 'Linux'`.

#### `wc-test-docker.yaml`
- Declare the secret. Add `contents: read` / `id-token: write` and the `setup-takumi-guard-golang@v1` step to the `test-docker-build` job (which runs `go install`).

#### `autofix.yaml`
- Bump `go-autofix-action` v0.1.12 → v0.1.13; add `takumi_guard_bot_id` and `id-token: write`.

### npm (website)

#### `autofix.yaml`
- Add `setup-takumi-guard-npm@v1.1.1` after `setup-node`, and move the generated `.npmrc` to `$HOME/.npmrc` before `npm ci` (npm does not read parent dirs' `.npmrc`, and `npm ci` runs in `website/`).

#### `workflow_call_deploy_doc.yaml`
- Declare the secret; add `id-token: write`; add `setup-takumi-guard-npm@v1.1.1` + the `$HOME/.npmrc` move before `release-doc-action` (which runs its own `npm ci`).

## Out of scope

- `test-goreleaser.yaml` (`goreleaser check` does not download Go modules), the docker-only job in `wc-test-docker.yaml`, and `workflow_call_typos.yaml`.
- The Windows/macOS legs of `integration-test-all-envs` (golang action is Unix-only) and the manual `workflow_dispatch` `macos-test.yaml` / `windows-test.yaml`.

## Note

- `go-test-full-workflow` crosses a **major** version (v5 → v6); please review CI for breaking changes.
- The `TAKUMI_GUARD_BOT_ID` secret must be configured in the repository/organization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow infrastructure with enhanced security measures and modernized tooling across build, test, and deployment pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->