### PR TITLE
docs: use go comment as the description of JSONSchema

### DIFF
--- a/cmd/gen-jsonschema/main.go
+++ b/cmd/gen-jsonschema/main.go
@@ -18,16 +18,19 @@ func main() {
 }
 
 func core() error {
-	if err := jsonschema.Write(&aqua.Config{}, "json-schema/aqua-yaml.json"); err != nil {
+	opts := &jsonschema.Options{
+		ModFile: "go.mod",
+	}
+	if err := jsonschema.Write(&aqua.Config{}, "json-schema/aqua-yaml.json", opts); err != nil {
 		return fmt.Errorf("create or update a JSON Schema: %w", err)
 	}
-	if err := jsonschema.Write(&registry.Config{}, "json-schema/registry.json"); err != nil {
+	if err := jsonschema.Write(&registry.Config{}, "json-schema/registry.json", opts); err != nil {
 		return fmt.Errorf("create or update a JSON Schema: %w", err)
 	}
-	if err := jsonschema.Write(&policy.ConfigYAML{}, "json-schema/policy.json"); err != nil {
+	if err := jsonschema.Write(&policy.ConfigYAML{}, "json-schema/policy.json", opts); err != nil {
 		return fmt.Errorf("create or update a JSON Schema: %w", err)
 	}
-	if err := jsonschema.Write(&genrgst.RawConfig{}, "json-schema/aqua-generate-registry.json"); err != nil {
+	if err := jsonschema.Write(&genrgst.RawConfig{}, "json-schema/aqua-generate-registry.json", opts); err != nil {
 		return fmt.Errorf("create or update a JSON Schema: %w", err)
 	}
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/schollz/progressbar/v3 v3.19.0
 	github.com/spf13/afero v1.15.0
 	github.com/suzuki-shunsuke/flute v1.0.1
-	github.com/suzuki-shunsuke/gen-go-jsonschema v0.1.0
+	github.com/suzuki-shunsuke/gen-go-jsonschema v0.1.1-0.20260628125018-584c7c85825a
 	github.com/suzuki-shunsuke/ghtkn-go-sdk v0.3.1
 	github.com/suzuki-shunsuke/go-error-with-exit-code v1.0.0
 	github.com/suzuki-shunsuke/go-findconfig v1.2.0
@@ -91,6 +91,7 @@ require (
 	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
 	go4.org v0.0.0-20230225012048-214862532bf5 // indirect
 	golang.org/x/crypto v0.45.0 // indirect
+	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect

--- a/go.sum
+++ b/go.sum
@@ -227,8 +227,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/suzuki-shunsuke/flute v1.0.1 h1:qzxSX2WQ8ih378zeCrjDMW5mVCsYyEmjicYuCy4aiLk=
 github.com/suzuki-shunsuke/flute v1.0.1/go.mod h1:lQKcCgbjiIzH4lar2V2UX1IdEwAB5KTfTckgWN1rtFg=
-github.com/suzuki-shunsuke/gen-go-jsonschema v0.1.0 h1:g7askc+nskCkKRWTVOdsAT8nMhwiaVT6Dmlnh6uvITM=
-github.com/suzuki-shunsuke/gen-go-jsonschema v0.1.0/go.mod h1:yFO7h5wwFejxi6jbtazqmk7b/JSBxHcit8DGwb1bhg0=
+github.com/suzuki-shunsuke/gen-go-jsonschema v0.1.1-0.20260628125018-584c7c85825a h1:zpRzXMaMcMLvxSxi0kY00rlGGQ8Ez9R76xAnwuljbjM=
+github.com/suzuki-shunsuke/gen-go-jsonschema v0.1.1-0.20260628125018-584c7c85825a/go.mod h1:4325Vcxt2yuGUgtI8Vq5fFK10FPs7DjKuzDFmTff3eo=
 github.com/suzuki-shunsuke/ghtkn-go-sdk v0.3.1 h1:2eTHYGwHs27R4GFk466ZrbiAleoFrQ6AT3e282dwtko=
 github.com/suzuki-shunsuke/ghtkn-go-sdk v0.3.1/go.mod h1:l3V+n7F4V8q6nqopI6RohWdRlh955HC+4PjCuU/waLE=
 github.com/suzuki-shunsuke/go-cliutil v0.0.0-20181211154308-176f852d9bca/go.mod h1:Vq3NkhgmA9DT/2UZ08x/3A34xxvzQ/vTMABnTWKoMbY=
@@ -309,6 +309,8 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
+golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/json-schema/aqua-yaml.json
+++ b/json-schema/aqua-yaml.json
@@ -6,28 +6,35 @@
     "Checksum": {
       "properties": {
         "enabled": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether checksum validation is enabled"
         },
         "require_checksum": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether checksums are required for all packages"
         },
         "supported_envs": {
-          "$ref": "#/$defs/SupportedEnvs"
+          "$ref": "#/$defs/SupportedEnvs",
+          "description": "Platforms where checksum validation applies"
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "Checksum contains global checksum validation configuration."
     },
     "CommandAlias": {
       "properties": {
         "command": {
-          "type": "string"
+          "type": "string",
+          "description": "Original command name"
         },
         "alias": {
-          "type": "string"
+          "type": "string",
+          "description": "Alias name"
         },
         "no_link": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether to skip creating symlinks"
         }
       },
       "additionalProperties": false,
@@ -35,7 +42,8 @@
       "required": [
         "command",
         "alias"
-      ]
+      ],
+      "description": "CommandAlias defines an alias for a package command."
     },
     "Config": {
       "properties": {
@@ -43,28 +51,34 @@
           "items": {
             "$ref": "#/$defs/Package"
           },
-          "type": "array"
+          "type": "array",
+          "description": "List of packages to manage"
         },
         "registries": {
-          "$ref": "#/$defs/Registries"
+          "$ref": "#/$defs/Registries",
+          "description": "Registry configurations"
         },
         "checksum": {
-          "$ref": "#/$defs/Checksum"
+          "$ref": "#/$defs/Checksum",
+          "description": "Checksum validation settings"
         },
         "import_dir": {
-          "type": "string"
+          "type": "string",
+          "description": "Directory for importing configurations"
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
         "registries"
-      ]
+      ],
+      "description": "Config represents the complete aqua.yaml configuration."
     },
     "Package": {
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "Package name"
         },
         "registry": {
           "type": "string",
@@ -76,47 +90,59 @@
           ]
         },
         "version": {
-          "type": "string"
+          "type": "string",
+          "description": "Package version"
         },
         "import": {
-          "type": "string"
+          "type": "string",
+          "description": "Import path for configuration inclusion"
         },
         "tags": {
           "items": {
             "type": "string"
           },
-          "type": "array"
+          "type": "array",
+          "description": "Package tags for filtering"
         },
         "description": {
-          "type": "string"
+          "type": "string",
+          "description": "Package description"
         },
         "link": {
-          "type": "string"
+          "type": "string",
+          "description": "Package homepage link"
         },
         "update": {
-          "$ref": "#/$defs/Update"
+          "$ref": "#/$defs/Update",
+          "description": "Update configuration"
         },
         "go_version_file": {
-          "type": "string"
+          "type": "string",
+          "description": "Go version file path"
         },
         "version_expr": {
-          "type": "string"
+          "type": "string",
+          "description": "Version expression for dynamic versions"
         },
         "version_expr_prefix": {
-          "type": "string"
+          "type": "string",
+          "description": "Prefix for version expressions"
         },
         "vars": {
-          "type": "object"
+          "type": "object",
+          "description": "Package-specific variables"
         },
         "command_aliases": {
           "items": {
             "$ref": "#/$defs/CommandAlias"
           },
-          "type": "array"
+          "type": "array",
+          "description": "Command aliases for the package"
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "Package represents a package definition in aqua.yaml configuration."
     },
     "Registries": {
       "items": {
@@ -176,20 +202,24 @@
     "Update": {
       "properties": {
         "enabled": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Enabled controls whether the package is included in update operations.\nIf false, aqua up command ignores the package unless explicitly specified.\nBy default, enabled is true."
         },
         "allowed_version": {
-          "type": "string"
+          "type": "string",
+          "description": "AllowedVersion is an expression that defines which versions are allowed.\nUses expr language (https://github.com/expr-lang/expr).\nBy default, all versions are allowed."
         },
         "types": {
           "items": {
             "type": "string"
           },
-          "type": "array"
+          "type": "array",
+          "description": "Types specifies which update types are allowed (major, minor, patch, other).\nBy default, all types are allowed."
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "Update contains configuration for package update behavior."
     }
   }
 }

--- a/json-schema/registry.json
+++ b/json-schema/registry.json
@@ -6,42 +6,50 @@
     "Alias": {
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "Name is the alternative name for the package."
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
         "name"
-      ]
+      ],
+      "description": "Alias represents an alternative name for a package."
     },
     "Build": {
       "properties": {
         "enabled": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Enabled controls whether building from source is allowed."
         },
         "type": {
           "type": "string",
           "enum": [
             "go_install",
             "go_build"
-          ]
+          ],
+          "description": "Type specifies the build method (go_install or go_build)."
         },
         "path": {
-          "type": "string"
+          "type": "string",
+          "description": "Path is the import path or directory for Go packages."
         },
         "files": {
           "items": {
             "$ref": "#/$defs/File"
           },
-          "type": "array"
+          "type": "array",
+          "description": "Files specifies which files to install after building."
         },
         "excluded_envs": {
-          "$ref": "#/$defs/SupportedEnvs"
+          "$ref": "#/$defs/SupportedEnvs",
+          "description": "ExcludedEnvs lists environments where building should be skipped."
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "Build defines configuration for building packages from source code."
     },
     "Cargo": {
       "properties": {
@@ -49,17 +57,21 @@
           "items": {
             "type": "string"
           },
-          "type": "array"
+          "type": "array",
+          "description": "Features is a list of specific features to enable when installing."
         },
         "all_features": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "AllFeatures enables all available features for the package."
         },
         "locked": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Locked uses the exact versions from Cargo.lock file."
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "Cargo defines configuration options for installing Rust packages via Cargo."
     },
     "Checksum": {
       "properties": {
@@ -68,16 +80,20 @@
           "enum": [
             "github_release",
             "http"
-          ]
+          ],
+          "description": "Type specifies where to download the checksum file from."
         },
         "asset": {
-          "type": "string"
+          "type": "string",
+          "description": "Asset is the name of the checksum file asset (for github_release type)."
         },
         "url": {
-          "type": "string"
+          "type": "string",
+          "description": "URL is the direct URL to the checksum file (for http type)."
         },
         "file_format": {
-          "type": "string"
+          "type": "string",
+          "description": "FileFormat specifies the format of the checksum file."
         },
         "algorithm": {
           "type": "string",
@@ -86,83 +102,103 @@
             "sha1",
             "sha256",
             "sha512"
-          ]
+          ],
+          "description": "Algorithm specifies the hash algorithm used for checksums."
         },
         "pattern": {
-          "$ref": "#/$defs/ChecksumPattern"
+          "$ref": "#/$defs/ChecksumPattern",
+          "description": "Pattern defines how to extract checksums from the checksum file."
         },
         "enabled": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Enabled controls whether checksum verification is active."
         },
         "replacements": {
-          "$ref": "#/$defs/Replacements"
+          "$ref": "#/$defs/Replacements",
+          "description": "Replacements provides template replacements for checksum URLs/assets."
         },
         "cosign": {
-          "$ref": "#/$defs/Cosign"
+          "$ref": "#/$defs/Cosign",
+          "description": "Cosign configuration for signature verification of checksums."
         },
         "minisign": {
-          "$ref": "#/$defs/Minisign"
+          "$ref": "#/$defs/Minisign",
+          "description": "Minisign configuration for signature verification of checksums."
         },
         "github_artifact_attestations": {
-          "$ref": "#/$defs/GitHubArtifactAttestations"
+          "$ref": "#/$defs/GitHubArtifactAttestations",
+          "description": "GitHubArtifactAttestations configuration for GitHub artifact attestation verification."
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "Checksum defines configuration for verifying package integrity using checksums."
     },
     "ChecksumPattern": {
       "properties": {
         "checksum": {
-          "type": "string"
+          "type": "string",
+          "description": "Checksum is a regex pattern to extract the checksum value."
         },
         "file": {
-          "type": "string"
+          "type": "string",
+          "description": "File is a regex pattern to extract the filename (optional)."
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
         "checksum"
-      ]
+      ],
+      "description": "ChecksumPattern defines regular expression patterns for extracting checksums from checksum files."
     },
     "Config": {
       "properties": {
         "packages": {
-          "$ref": "#/$defs/PackageInfos"
+          "$ref": "#/$defs/PackageInfos",
+          "description": "PackageInfos contains all package definitions in the registry."
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
         "packages"
-      ]
+      ],
+      "description": "Config represents a registry configuration containing package definitions."
     },
     "Cosign": {
       "properties": {
         "enabled": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Enabled controls whether Cosign verification is active."
         },
         "opts": {
           "items": {
             "type": "string"
           },
-          "type": "array"
+          "type": "array",
+          "description": "Opts contains additional command-line options to pass to cosign verify."
         },
         "signature": {
-          "$ref": "#/$defs/DownloadedFile"
+          "$ref": "#/$defs/DownloadedFile",
+          "description": "Signature specifies where to download the signature file."
         },
         "certificate": {
-          "$ref": "#/$defs/DownloadedFile"
+          "$ref": "#/$defs/DownloadedFile",
+          "description": "Certificate specifies where to download the certificate file."
         },
         "key": {
-          "$ref": "#/$defs/DownloadedFile"
+          "$ref": "#/$defs/DownloadedFile",
+          "description": "Key specifies where to download the public key file."
         },
         "bundle": {
-          "$ref": "#/$defs/DownloadedFile"
+          "$ref": "#/$defs/DownloadedFile",
+          "description": "Bundle specifies where to download the signature bundle."
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "Cosign defines configuration for verifying packages using Cosign signature verification."
     },
     "DownloadedFile": {
       "properties": {
@@ -171,47 +207,59 @@
           "enum": [
             "github_release",
             "http"
-          ]
+          ],
+          "description": "Type specifies the source type for downloading the file."
         },
         "repo_owner": {
-          "type": "string"
+          "type": "string",
+          "description": "RepoOwner is the GitHub repository owner (for github_release type)."
         },
         "repo_name": {
-          "type": "string"
+          "type": "string",
+          "description": "RepoName is the GitHub repository name (for github_release type)."
         },
         "asset": {
-          "type": "string"
+          "type": "string",
+          "description": "Asset is the name of the asset to download (for github_release type)."
         },
         "url": {
-          "type": "string"
+          "type": "string",
+          "description": "URL is the direct URL to download the file (for http type)."
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
         "type"
-      ]
+      ],
+      "description": "DownloadedFile represents a file that can be downloaded from various sources."
     },
     "File": {
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "Name is the name of the installed file."
         },
         "src": {
-          "type": "string"
+          "type": "string",
+          "description": "Src is the source path of the file within the package archive."
         },
         "dir": {
-          "type": "string"
+          "type": "string",
+          "description": "Dir is the directory where the file should be installed."
         },
         "link": {
-          "type": "string"
+          "type": "string",
+          "description": "Link is the relative path from Src to the link target."
         },
         "hard": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Hard indicates whether to create a hard link instead of a symbolic link."
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "File represents a file to be installed from a package."
     },
     "FormatOverride": {
       "properties": {
@@ -231,10 +279,12 @@
             "plan9",
             "solaris",
             "windows"
-          ]
+          ],
+          "description": "GOOS specifies the target operating system for this format override."
         },
         "format": {
           "type": "string",
+          "description": "Format specifies the archive format to use for this operating system.",
           "examples": [
             "tar.gz",
             "raw",
@@ -247,25 +297,30 @@
       "required": [
         "goos",
         "format"
-      ]
+      ],
+      "description": "FormatOverride allows specifying different archive formats for specific operating systems."
     },
     "FormatOverrides": {
       "items": {
         "$ref": "#/$defs/FormatOverride"
       },
-      "type": "array"
+      "type": "array",
+      "description": "FormatOverrides is a slice of platform-specific format overrides."
     },
     "GitHubArtifactAttestations": {
       "properties": {
         "enabled": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Enabled controls whether GitHub artifact attestation verification is active."
         },
         "predicate_type": {
-          "type": "string"
+          "type": "string",
+          "description": "PredicateType specifies the type of predicate to verify."
         },
         "signer_workflow": {
           "type": "string",
-          "format": "regex"
+          "format": "regex",
+          "description": "SignerWorkflow2 specifies the expected GitHub Actions workflow for signing.\nSee https://github.com/aquaproj/aqua/issues/3581"
         },
         "signer-workflow": {
           "type": "string",
@@ -274,38 +329,47 @@
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "GitHubArtifactAttestations defines configuration for GitHub artifact attestation verification."
     },
     "Minisign": {
       "properties": {
         "enabled": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Enabled controls whether Minisign verification is active."
         },
         "type": {
           "type": "string",
           "enum": [
             "github_release",
             "http"
-          ]
+          ],
+          "description": "Type specifies where to download the signature file from."
         },
         "repo_owner": {
-          "type": "string"
+          "type": "string",
+          "description": "RepoOwner is the GitHub repository owner (for github_release type)."
         },
         "repo_name": {
-          "type": "string"
+          "type": "string",
+          "description": "RepoName is the GitHub repository name (for github_release type)."
         },
         "asset": {
-          "type": "string"
+          "type": "string",
+          "description": "Asset is the name of the signature file asset (for github_release type)."
         },
         "url": {
-          "type": "string"
+          "type": "string",
+          "description": "URL is the direct URL to the signature file (for http type)."
         },
         "public_key": {
-          "type": "string"
+          "type": "string",
+          "description": "PublicKey is the base64-encoded public key for verification."
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "Minisign defines configuration for verifying packages using Minisign signature verification."
     },
     "Override": {
       "properties": {
@@ -410,13 +474,15 @@
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "Override provides platform-specific package configuration that overrides the default settings when the specified OS/architecture conditions are met."
     },
     "Overrides": {
       "items": {
         "$ref": "#/$defs/Override"
       },
-      "type": "array"
+      "type": "array",
+      "description": "Overrides is a slice of platform-specific configuration overrides."
     },
     "PackageInfo": {
       "properties": {
@@ -582,13 +648,15 @@
       "type": "object",
       "required": [
         "type"
-      ]
+      ],
+      "description": "PackageInfo represents a complete package definition including metadata, installation configuration, verification settings, and platform support."
     },
     "PackageInfos": {
       "items": {
         "$ref": "#/$defs/PackageInfo"
       },
-      "type": "array"
+      "type": "array",
+      "description": "PackageInfos represents a slice of package information."
     },
     "Replacements": {
       "properties": {
@@ -613,36 +681,45 @@
     "SLSAProvenance": {
       "properties": {
         "enabled": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Enabled controls whether SLSA provenance verification is active."
         },
         "type": {
           "type": "string",
           "enum": [
             "github_release",
             "http"
-          ]
+          ],
+          "description": "Type specifies where to download the provenance file from."
         },
         "repo_owner": {
-          "type": "string"
+          "type": "string",
+          "description": "RepoOwner is the GitHub repository owner (for github_release type)."
         },
         "repo_name": {
-          "type": "string"
+          "type": "string",
+          "description": "RepoName is the GitHub repository name (for github_release type)."
         },
         "asset": {
-          "type": "string"
+          "type": "string",
+          "description": "Asset is the name of the provenance file asset (for github_release type)."
         },
         "url": {
-          "type": "string"
+          "type": "string",
+          "description": "URL is the direct URL to the provenance file (for http type)."
         },
         "source_uri": {
-          "type": "string"
+          "type": "string",
+          "description": "SourceURI is the expected source repository URI for verification."
         },
         "source_tag": {
-          "type": "string"
+          "type": "string",
+          "description": "SourceTag is the expected source tag for verification."
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "SLSAProvenance defines configuration for SLSA (Supply-chain Levels for Software Artifacts) provenance verification."
     },
     "SupportedEnvs": {
       "items": {
@@ -667,18 +744,23 @@
     "Var": {
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "Name is the variable name used in templates."
         },
         "required": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Required indicates whether this variable must be provided."
         },
-        "default": true
+        "default": {
+          "description": "Default is the default value used when the variable is not provided."
+        }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
         "name"
-      ]
+      ],
+      "description": "Var represents a template variable that can be used in package configurations to customize installation behavior based on runtime values."
     },
     "Variant": {
       "properties": {
@@ -693,13 +775,15 @@
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "Variant represents an additional matching condition for an Override beyond the standard goos/goarch axis."
     },
     "Variants": {
       "items": {
         "$ref": "#/$defs/Variant"
       },
-      "type": "array"
+      "type": "array",
+      "description": "Variants is a list of Variant conditions that must all match for the containing Override to apply."
     },
     "VersionOverride": {
       "properties": {
@@ -825,7 +909,8 @@
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "VersionOverride allows different package configurations for specific version ranges."
     }
   }
 }


### PR DESCRIPTION
Close #4966

- https://github.com/suzuki-shunsuke/gen-go-jsonschema/pull/21
- https://github.com/invopop/jsonschema#using-go-comments
- https://pkg.go.dev/github.com/invopop/jsonschema#Reflector.AddGoComments
- https://pkg.go.dev/golang.org/x/mod/modfile#ModulePath

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved generated JSON Schemas with more human-readable field and section descriptions, making configuration details easier to understand.
  * Regenerated schema outputs to include updated metadata and clearer defaults where applicable.
* **Chores**
  * Updated the schema generation toolchain to use the latest compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->