### PR TITLE
fix(unarchive): allow benign symlinks that point outside the extraction directory

### DIFF
--- a/pkg/unarchive/archives.go
+++ b/pkg/unarchive/archives.go
@@ -16,10 +16,7 @@ import (
 	"github.com/suzuki-shunsuke/slog-error/slogerr"
 )
 
-var (
-	errEscapeDest        = errors.New("the file path escapes the extraction directory")
-	errSymlinkEscapeDest = errors.New("the symlink target escapes the extraction directory")
-)
+var errEscapeDest = errors.New("the file path escapes the extraction directory")
 
 type handler struct {
 	fs       afero.Fs
@@ -34,24 +31,60 @@ func (h *handler) HandleFile(_ context.Context, f archives.FileInfo) error {
 		return fmt.Errorf("%w: %s", errEscapeDest, f.NameInArchive)
 	}
 	parentDir := filepath.Dir(dstPath)
+	// Reject an entry whose parent directory resolves outside dest through a
+	// symlink planted by an earlier entry. Creating the parent directories or
+	// writing the entry would otherwise follow that symlink and escape dest.
+	if h.escapesDest(parentDir) {
+		return fmt.Errorf("%w: %s", errEscapeDest, f.NameInArchive)
+	}
 	if err := osfile.MkdirAll(h.fs, parentDir); err != nil {
 		slogerr.WithError(h.logger, err).Warn("create a directory")
 		return nil
 	}
 
 	if f.IsDir() {
-		if err := h.fs.MkdirAll(dstPath, f.Mode()|0o700); err != nil { //nolint:mnd
-			slogerr.WithError(h.logger, err).Warn("create a directory")
-			return nil
-		}
-		return nil
+		return h.handleDir(dstPath, f)
 	}
 
 	if f.LinkTarget != "" {
 		if f.Mode()&os.ModeSymlink != 0 {
-			return h.handleSymlink(dstPath, f.LinkTarget)
+			h.handleSymlink(dstPath, f.LinkTarget)
 		}
 		return nil
+	}
+
+	return h.handleRegularFile(dstPath, f)
+}
+
+func (h *handler) Unarchive(ctx context.Context, _ *slog.Logger, src *File) error {
+	tempFilePath, err := src.Body.Path()
+	if err != nil {
+		return fmt.Errorf("get a temporary file path: %w", err)
+	}
+	if err := h.unarchive(ctx, src.Filename, tempFilePath); err != nil {
+		return slogerr.With(err, "archived_file", tempFilePath, "archived_filename", src.Filename) //nolint:wrapcheck
+	}
+	return nil
+}
+
+func (h *handler) handleDir(dstPath string, f archives.FileInfo) error {
+	// Guard against a directory entry whose path was planted as an escaping
+	// symlink by an earlier entry; MkdirAll would otherwise follow it.
+	if h.escapesDest(dstPath) {
+		return fmt.Errorf("%w: %s", errEscapeDest, f.NameInArchive)
+	}
+	if err := h.fs.MkdirAll(dstPath, f.Mode()|0o700); err != nil { //nolint:mnd
+		slogerr.WithError(h.logger, err).Warn("create a directory")
+	}
+	return nil
+}
+
+func (h *handler) handleRegularFile(dstPath string, f archives.FileInfo) error {
+	// Refuse to write through an escaping symlink planted at dstPath itself. An
+	// archive can create "pwn -> /outside" and then a regular file entry "pwn";
+	// opening it with O_CREATE would follow the symlink and write outside dest.
+	if h.escapesDest(dstPath) {
+		return fmt.Errorf("%w: %s", errEscapeDest, f.NameInArchive)
 	}
 
 	reader, err := f.Open()
@@ -70,49 +103,51 @@ func (h *handler) HandleFile(_ context.Context, f archives.FileInfo) error {
 
 	if _, err := io.Copy(dstFile, reader); err != nil {
 		slogerr.WithError(h.logger, err).Warn("copy a file")
-		return nil
 	}
 	return nil
 }
 
-func (h *handler) Unarchive(ctx context.Context, _ *slog.Logger, src *File) error {
-	tempFilePath, err := src.Body.Path()
-	if err != nil {
-		return fmt.Errorf("get a temporary file path: %w", err)
-	}
-	if err := h.unarchive(ctx, src.Filename, tempFilePath); err != nil {
-		return slogerr.With(err, "archived_file", tempFilePath, "archived_filename", src.Filename) //nolint:wrapcheck
-	}
-	return nil
-}
-
-// handleSymlink creates a symlink at dstPath pointing to target. It returns an
-// error if the target resolves outside h.dest, because such a symlink could be
-// followed by a later file entry with the same path to write outside the
-// extraction directory. This indicates a malicious or broken archive, so
-// extraction is aborted rather than silently skipping the entry.
-func (h *handler) handleSymlink(dstPath, target string) error {
-	if !h.symlinkTargetWithinDest(dstPath, target) {
-		return fmt.Errorf("%w: %s -> %s", errSymlinkEscapeDest, dstPath, target)
-	}
+// handleSymlink creates a symlink at dstPath pointing to target. The symlink is
+// created even when target resolves outside h.dest: the symlink inode itself
+// writes nothing outside the extraction directory, and such symlinks are common
+// in legitimate archives (e.g. a root filesystem's "var/run -> /run"). Escaping
+// through the symlink is instead prevented at write time by escapesDest, which
+// rejects any later entry that would follow it out of h.dest. The caller has
+// already verified dstPath's parent directory stays within h.dest.
+func (h *handler) handleSymlink(dstPath, target string) {
 	if err := os.Symlink(target, dstPath); err != nil {
 		slogerr.WithError(h.logger, err).Warn("create a symlink", "link_target", target, "link_dest", dstPath)
 	}
-	return nil
 }
 
-// symlinkTargetWithinDest reports whether a symlink created at linkPath with the
-// given target resolves to a path inside h.dest. A relative target is resolved
-// against the directory containing the symlink, matching how the OS dereferences
-// it. This prevents an archive from planting a symlink that points outside the
-// extraction directory, which a later file entry with the same path could
-// otherwise follow to write outside h.dest.
-func (h *handler) symlinkTargetWithinDest(linkPath, target string) bool {
-	resolved := target
-	if !filepath.IsAbs(resolved) {
-		resolved = filepath.Join(filepath.Dir(linkPath), target)
+// escapesDest reports whether path resolves outside h.dest once the symlinks in
+// its already-existing portion are followed. It resolves the deepest existing
+// ancestor of path (or path itself), so it detects both a symlink planted at
+// path and an escaping symlink in any of its parent directories. h.dest is
+// resolved too because it may itself contain symlinks (e.g. macOS /var ->
+// /private/var), which would otherwise make every entry look like an escape.
+func (h *handler) escapesDest(path string) bool {
+	dest, err := filepath.EvalSymlinks(h.dest)
+	if err != nil {
+		dest = filepath.Clean(h.dest)
 	}
-	return h.withinDest(resolved)
+	p := path
+	for {
+		resolved, err := filepath.EvalSymlinks(p)
+		if err == nil {
+			resolved = filepath.Clean(resolved)
+			if resolved == dest {
+				return false
+			}
+			return !strings.HasPrefix(resolved, dest+string(filepath.Separator))
+		}
+		parent := filepath.Dir(p)
+		if parent == p {
+			// Reached the filesystem root without finding an existing path.
+			return false
+		}
+		p = parent
+	}
 }
 
 // withinDest reports whether the cleaned path is h.dest itself or located inside

--- a/pkg/unarchive/archives.go
+++ b/pkg/unarchive/archives.go
@@ -34,7 +34,9 @@ func (h *handler) HandleFile(_ context.Context, f archives.FileInfo) error {
 	// Reject an entry whose parent directory resolves outside dest through a
 	// symlink planted by an earlier entry. Creating the parent directories or
 	// writing the entry would otherwise follow that symlink and escape dest.
-	if h.escapesDest(parentDir) {
+	// The root entry ("./") is exempt: its dstPath equals dest, so its parent is
+	// legitimately outside dest. dest itself is validated in the handlers below.
+	if dstPath != filepath.Clean(h.dest) && h.escapesDest(parentDir) {
 		return fmt.Errorf("%w: %s", errEscapeDest, f.NameInArchive)
 	}
 	if err := osfile.MkdirAll(h.fs, parentDir); err != nil {

--- a/pkg/unarchive/unarchive_test.go
+++ b/pkg/unarchive/unarchive_test.go
@@ -70,6 +70,36 @@ func TestIsUnarchived(t *testing.T) {
 	}
 }
 
+type tarEntry struct {
+	hdr     *tar.Header
+	payload []byte
+}
+
+// buildTarGz builds a gzip-compressed tar archive from the given entries. When
+// an entry has a payload, its header Size is set from the payload length.
+func buildTarGz(t *testing.T, entries ...tarEntry) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	for _, e := range entries {
+		e.hdr.Size = int64(len(e.payload))
+		if err := tw.WriteHeader(e.hdr); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write(e.payload); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
 // TestUnarchiver_Unarchive_symlinkTraversal verifies that an archive cannot use
 // a symlink pointing outside the extraction directory followed by a regular file
 // entry at the same path to write outside the destination.
@@ -133,6 +163,107 @@ func TestUnarchiver_Unarchive_symlinkTraversal(t *testing.T) {
 	}
 	if string(got) != "original" {
 		t.Fatalf("the outside file was modified through a symlink: %q", got)
+	}
+}
+
+// TestUnarchiver_Unarchive_symlinkDirTraversal verifies that a regular file
+// whose path descends through a symlink pointing outside the extraction
+// directory cannot be written outside it. This is the multi-entry variant of
+// the traversal: "pwn" -> outside dir, then "pwn/file".
+// See https://github.com/aquaproj/aqua/security/advisories/GHSA-mf5c-hw34-4hpp
+func TestUnarchiver_Unarchive_symlinkDirTraversal(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	logger := slog.New(slog.DiscardHandler)
+
+	dest := t.TempDir()
+	outsideDir := t.TempDir()
+
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     "pwn",
+		Typeflag: tar.TypeSymlink,
+		Linkname: outsideDir,
+		Mode:     0o777,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	payload := []byte("PWNED_BY_AQUA_SYMLINK_DIR_TRAVERSAL")
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     "pwn/file",
+		Typeflag: tar.TypeReg,
+		Mode:     0o644,
+		Size:     int64(len(payload)),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	fs := afero.NewOsFs()
+	src := &unarchive.File{
+		Filename: "malicious.tar.gz",
+		Body:     download.NewDownloadedFile(fs, io.NopCloser(bytes.NewReader(buf.Bytes())), nil),
+	}
+	if err := unarchive.New(nil, fs).Unarchive(ctx, logger, src, dest); err == nil {
+		t.Fatal("an error must be returned for a file escaping via a symlinked directory")
+	}
+	if _, err := os.Stat(filepath.Join(outsideDir, "file")); !os.IsNotExist(err) {
+		t.Fatalf("a file was written outside dest through a symlinked directory: %v", err)
+	}
+}
+
+// TestUnarchiver_Unarchive_symlinkOutsideAllowed verifies that a symlink whose
+// target points outside the extraction directory is created successfully when
+// no later entry follows it to write outside. Such symlinks are common in
+// legitimate archives such as root filesystem images (e.g. "var/run -> /run"),
+// so extraction must not fail on their mere presence.
+func TestUnarchiver_Unarchive_symlinkOutsideAllowed(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	logger := slog.New(slog.DiscardHandler)
+
+	dest := t.TempDir()
+
+	// An absolute symlink escaping dest (mirroring a rootfs "var/run -> /run")
+	// followed by a normal file that must still be extracted.
+	archive := buildTarGz(
+		t,
+		tarEntry{hdr: &tar.Header{Name: "var/run", Typeflag: tar.TypeSymlink, Linkname: "/run", Mode: 0o777}},
+		tarEntry{hdr: &tar.Header{Name: "bin/tool", Typeflag: tar.TypeReg, Mode: 0o755}, payload: []byte("hello")},
+	)
+
+	fs := afero.NewOsFs()
+	src := &unarchive.File{
+		Filename: "rootfs.tar.gz",
+		Body:     download.NewDownloadedFile(fs, io.NopCloser(bytes.NewReader(archive)), nil),
+	}
+	if err := unarchive.New(nil, fs).Unarchive(ctx, logger, src, dest); err != nil {
+		t.Fatalf("extraction must succeed for a benign escaping symlink: %v", err)
+	}
+
+	target, err := os.Readlink(filepath.Join(dest, "var/run"))
+	if err != nil {
+		t.Fatalf("the escaping symlink must be created: %v", err)
+	}
+	if target != "/run" {
+		t.Fatalf("unexpected symlink target: %q", target)
+	}
+	got, err := os.ReadFile(filepath.Join(dest, "bin/tool"))
+	if err != nil {
+		t.Fatalf("the regular file must be extracted: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Fatalf("unexpected file content: %q", got)
 	}
 }
 

--- a/pkg/unarchive/unarchive_test.go
+++ b/pkg/unarchive/unarchive_test.go
@@ -130,7 +130,7 @@ func TestUnarchiver_Unarchive_symlinkTraversal(t *testing.T) {
 		Body:     download.NewDownloadedFile(fs, io.NopCloser(bytes.NewReader(archive)), nil),
 	}
 	if err := unarchive.New(nil, fs).Unarchive(ctx, logger, src, dest); err == nil {
-		t.Fatal("an error must be returned for a symlink escaping the extraction directory")
+		t.Fatal("an error must be returned for a regular file that follows a symlink escaping the extraction directory")
 	}
 
 	got, err := os.ReadFile(outside)

--- a/pkg/unarchive/unarchive_test.go
+++ b/pkg/unarchive/unarchive_test.go
@@ -267,6 +267,41 @@ func TestUnarchiver_Unarchive_symlinkOutsideAllowed(t *testing.T) {
 	}
 }
 
+// TestUnarchiver_Unarchive_rootEntry verifies that an archive whose first entry
+// is the root directory "./" (as produced by e.g. crate-ci/typos releases)
+// extracts successfully. Its dstPath equals dest, so its parent is legitimately
+// outside dest and must not be treated as an escape.
+func TestUnarchiver_Unarchive_rootEntry(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	logger := slog.New(slog.DiscardHandler)
+
+	dest := t.TempDir()
+
+	archive := buildTarGz(
+		t,
+		tarEntry{hdr: &tar.Header{Name: "./", Typeflag: tar.TypeDir, Mode: 0o755}},
+		tarEntry{hdr: &tar.Header{Name: "./tool", Typeflag: tar.TypeReg, Mode: 0o755}, payload: []byte("hello")},
+	)
+
+	fs := afero.NewOsFs()
+	src := &unarchive.File{
+		Filename: "tool.tar.gz",
+		Body:     download.NewDownloadedFile(fs, io.NopCloser(bytes.NewReader(archive)), nil),
+	}
+	if err := unarchive.New(nil, fs).Unarchive(ctx, logger, src, dest); err != nil {
+		t.Fatalf("extraction must succeed for an archive with a \"./\" root entry: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dest, "tool"))
+	if err != nil {
+		t.Fatalf("the regular file must be extracted: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Fatalf("unexpected file content: %q", got)
+	}
+}
+
 // TestUnarchiver_Unarchive_pathTraversal verifies that an archive entry whose
 // path contains ".." cannot write outside the extraction directory.
 // See https://github.com/aquaproj/aqua/security/advisories/GHSA-mf5c-hw34-4hpp

--- a/pkg/unarchive/unarchive_test.go
+++ b/pkg/unarchive/unarchive_test.go
@@ -116,42 +116,18 @@ func TestUnarchiver_Unarchive_symlinkTraversal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Build a tar.gz: a symlink "pwn" -> outside target, then a regular file
-	// "pwn" whose write would follow the planted symlink.
-	var buf bytes.Buffer
-	gw := gzip.NewWriter(&buf)
-	tw := tar.NewWriter(gw)
-	if err := tw.WriteHeader(&tar.Header{
-		Name:     "pwn",
-		Typeflag: tar.TypeSymlink,
-		Linkname: outside,
-		Mode:     0o777,
-	}); err != nil {
-		t.Fatal(err)
-	}
-	payload := []byte("PWNED_BY_AQUA_SYMLINK_TRAVERSAL")
-	if err := tw.WriteHeader(&tar.Header{
-		Name:     "pwn",
-		Typeflag: tar.TypeReg,
-		Mode:     0o644,
-		Size:     int64(len(payload)),
-	}); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := tw.Write(payload); err != nil {
-		t.Fatal(err)
-	}
-	if err := tw.Close(); err != nil {
-		t.Fatal(err)
-	}
-	if err := gw.Close(); err != nil {
-		t.Fatal(err)
-	}
+	// A symlink "pwn" -> outside target, then a regular file "pwn" whose write
+	// would follow the planted symlink.
+	archive := buildTarGz(
+		t,
+		tarEntry{hdr: &tar.Header{Name: "pwn", Typeflag: tar.TypeSymlink, Linkname: outside, Mode: 0o777}},
+		tarEntry{hdr: &tar.Header{Name: "pwn", Typeflag: tar.TypeReg, Mode: 0o644}, payload: []byte("PWNED_BY_AQUA_SYMLINK_TRAVERSAL")},
+	)
 
 	fs := afero.NewOsFs()
 	src := &unarchive.File{
 		Filename: "malicious.tar.gz",
-		Body:     download.NewDownloadedFile(fs, io.NopCloser(bytes.NewReader(buf.Bytes())), nil),
+		Body:     download.NewDownloadedFile(fs, io.NopCloser(bytes.NewReader(archive)), nil),
 	}
 	if err := unarchive.New(nil, fs).Unarchive(ctx, logger, src, dest); err == nil {
 		t.Fatal("an error must be returned for a symlink escaping the extraction directory")
@@ -179,40 +155,18 @@ func TestUnarchiver_Unarchive_symlinkDirTraversal(t *testing.T) {
 	dest := t.TempDir()
 	outsideDir := t.TempDir()
 
-	var buf bytes.Buffer
-	gw := gzip.NewWriter(&buf)
-	tw := tar.NewWriter(gw)
-	if err := tw.WriteHeader(&tar.Header{
-		Name:     "pwn",
-		Typeflag: tar.TypeSymlink,
-		Linkname: outsideDir,
-		Mode:     0o777,
-	}); err != nil {
-		t.Fatal(err)
-	}
-	payload := []byte("PWNED_BY_AQUA_SYMLINK_DIR_TRAVERSAL")
-	if err := tw.WriteHeader(&tar.Header{
-		Name:     "pwn/file",
-		Typeflag: tar.TypeReg,
-		Mode:     0o644,
-		Size:     int64(len(payload)),
-	}); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := tw.Write(payload); err != nil {
-		t.Fatal(err)
-	}
-	if err := tw.Close(); err != nil {
-		t.Fatal(err)
-	}
-	if err := gw.Close(); err != nil {
-		t.Fatal(err)
-	}
+	// A symlink "pwn" -> outside dir, then a regular file "pwn/file" whose write
+	// would descend through the planted symlink.
+	archive := buildTarGz(
+		t,
+		tarEntry{hdr: &tar.Header{Name: "pwn", Typeflag: tar.TypeSymlink, Linkname: outsideDir, Mode: 0o777}},
+		tarEntry{hdr: &tar.Header{Name: "pwn/file", Typeflag: tar.TypeReg, Mode: 0o644}, payload: []byte("PWNED_BY_AQUA_SYMLINK_DIR_TRAVERSAL")},
+	)
 
 	fs := afero.NewOsFs()
 	src := &unarchive.File{
 		Filename: "malicious.tar.gz",
-		Body:     download.NewDownloadedFile(fs, io.NopCloser(bytes.NewReader(buf.Bytes())), nil),
+		Body:     download.NewDownloadedFile(fs, io.NopCloser(bytes.NewReader(archive)), nil),
 	}
 	if err := unarchive.New(nil, fs).Unarchive(ctx, logger, src, dest); err == nil {
 		t.Fatal("an error must be returned for a file escaping via a symlinked directory")
@@ -317,33 +271,16 @@ func TestUnarchiver_Unarchive_pathTraversal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Build a tar.gz with a single regular file whose name escapes dest via "..".
-	var buf bytes.Buffer
-	gw := gzip.NewWriter(&buf)
-	tw := tar.NewWriter(gw)
-	payload := []byte("PWNED_BY_AQUA_PATH_TRAVERSAL")
-	if err := tw.WriteHeader(&tar.Header{
-		Name:     "../outside-target",
-		Typeflag: tar.TypeReg,
-		Mode:     0o644,
-		Size:     int64(len(payload)),
-	}); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := tw.Write(payload); err != nil {
-		t.Fatal(err)
-	}
-	if err := tw.Close(); err != nil {
-		t.Fatal(err)
-	}
-	if err := gw.Close(); err != nil {
-		t.Fatal(err)
-	}
+	// A single regular file whose name escapes dest via "..".
+	archive := buildTarGz(
+		t,
+		tarEntry{hdr: &tar.Header{Name: "../outside-target", Typeflag: tar.TypeReg, Mode: 0o644}, payload: []byte("PWNED_BY_AQUA_PATH_TRAVERSAL")},
+	)
 
 	fs := afero.NewOsFs()
 	src := &unarchive.File{
 		Filename: "malicious.tar.gz",
-		Body:     download.NewDownloadedFile(fs, io.NopCloser(bytes.NewReader(buf.Bytes())), nil),
+		Body:     download.NewDownloadedFile(fs, io.NopCloser(bytes.NewReader(archive)), nil),
 	}
 	if err := unarchive.New(nil, fs).Unarchive(ctx, logger, src, dest); err == nil {
 		t.Fatal("an error must be returned for an entry escaping the extraction directory")


### PR DESCRIPTION
## Background

The fix for [GHSA-mf5c-hw34-4hpp](https://github.com/aquaproj/aqua/security/advisories/GHSA-mf5c-hw34-4hpp) (commit d5b02b2) rejected any symlink whose target resolves outside the extraction directory and aborted the whole extraction.

This turned out to be too strict and broke the installation of legitimate archives that ship root filesystem images. Concretely, `smol-machines/smolvm` v1.0.3 ships a full Alpine/musl rootfs containing 276 absolute symlinks such as `agent-rootfs/var/run -> /run` and `agent-rootfs/bin/cat -> /bin/busybox`. Installation failed at the very first such symlink:

```
extract files: handling file:
smolvm-1.0.3-darwin-arm64/agent-rootfs/var/run:
the symlink target escapes the extraction directory:
.../smolvm-1.0.3-darwin-arm64/agent-rootfs/var/run -> /run
```

See aquaproj/aqua-registry#55426.

## Why the old check was too strict

Creating a symlink whose target points outside the extraction directory writes nothing outside it — the symlink inode lives inside the directory. The actual threat behind the advisory is a *later* archive entry that follows such a symlink to write outside the directory (e.g. a symlink `pwn -> /outside` followed by a regular file `pwn`, or a file `pwn/x` under a symlinked directory).

I verified against the real smolvm tarball that none of its 276 escaping symlinks are followed by any entry that writes through them, so the archive never writes outside the destination. Rejecting it was a false positive.

## Change

Instead of rejecting the symlink itself, allow it and block the escape at write time:

- `handleSymlink` no longer checks the symlink target; the symlink is created even when its target points outside the extraction directory.
- New `escapesDest` resolves the deepest existing ancestor of a write path (or the path itself) with `filepath.EvalSymlinks` and rejects it when it lands outside the destination. This catches both an escaping symlink planted at the write path and one in a parent directory. The destination is resolved too, so a symlinked temp dir (e.g. macOS `/var -> /private/var`) is not a false positive.
- `escapesDest` is checked before creating parent directories, before `MkdirAll` of a directory entry, and before opening a regular file for writing.
- `HandleFile` is split into `handleDir` / `handleRegularFile` to keep complexity within lint limits.

Net effect: benign escaping symlinks (as in a rootfs image) are preserved and extraction succeeds, while any write that would follow a symlink out of the extraction directory is still rejected.

## Tests

- Keep the existing symlink-traversal and path-traversal tests.
- Add `TestUnarchiver_Unarchive_symlinkDirTraversal`: a regular file whose path descends through a symlinked directory pointing outside is rejected and nothing is written outside.
- Add `TestUnarchiver_Unarchive_symlinkOutsideAllowed`: an archive with a benign escaping symlink (`var/run -> /run`) extracts successfully, the symlink is created, and normal files are still extracted.
- Add a small `buildTarGz` test helper.

Manually verified that the real smolvm-1.0.3 tarball extracts fully with the new code (rootfs symlinks created, `bin/busybox` present), and that the macOS `/var -> /private/var` case does not trigger a false positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened archive extraction protections to block path-escape scenarios even when symlinks exist in the destination path.
  * Directories and regular files are now validated at write-time to ensure resolved paths never leave the selected destination.
  * Symlink handling is more permissive at creation time, while still preventing later traversal that could write outside the target.

* **Tests**
  * Improved tar/gzip generation for malicious and valid archives.
  * Added/updated regression coverage for symlink directory traversal, allowed escaping symlinks, and root entry handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->