### PR TITLE
fix(unarchive): block writes through a dangling escaping symlink

### DIFF
--- a/pkg/unarchive/archives.go
+++ b/pkg/unarchive/archives.go
@@ -122,34 +122,70 @@ func (h *handler) handleSymlink(dstPath, target string) {
 	}
 }
 
-// escapesDest reports whether path resolves outside h.dest once the symlinks in
-// its already-existing portion are followed. It resolves the deepest existing
-// ancestor of path (or path itself), so it detects both a symlink planted at
-// path and an escaping symlink in any of its parent directories. h.dest is
-// resolved too because it may itself contain symlinks (e.g. macOS /var ->
-// /private/var), which would otherwise make every entry look like an escape.
+// maxSymlinkHops bounds how many symlinks escapesDest follows before giving up,
+// guarding against symlink cycles. It matches the conventional MAXSYMLINKS.
+const maxSymlinkHops = 255
+
+// escapesDest reports whether writing to path would land outside h.dest once the
+// symlinks along path are followed. Unlike filepath.EvalSymlinks it does not
+// require path's final target to exist, so it also catches a dangling symlink
+// planted at path that a later O_CREATE write would follow out of h.dest. It
+// detects a symlink planted at path itself as well as an escaping symlink in any
+// parent directory. h.dest is resolved too because it may itself contain
+// symlinks (e.g. macOS /var -> /private/var), which would otherwise make every
+// entry look like an escape.
 func (h *handler) escapesDest(path string) bool {
 	dest, err := filepath.EvalSymlinks(h.dest)
 	if err != nil {
 		dest = filepath.Clean(h.dest)
 	}
-	p := path
-	for {
-		resolved, err := filepath.EvalSymlinks(p)
-		if err == nil {
-			resolved = filepath.Clean(resolved)
-			if resolved == dest {
-				return false
-			}
-			return !strings.HasPrefix(resolved, dest+string(filepath.Separator))
-		}
-		parent := filepath.Dir(p)
-		if parent == p {
-			// Reached the filesystem root without finding an existing path.
-			return false
-		}
-		p = parent
+	resolved, ok := h.resolveSymlinks(path, 0)
+	if !ok {
+		// A symlink cycle or an unreadable link: treat as unsafe.
+		return true
 	}
+	resolved = filepath.Clean(resolved)
+	if resolved == dest {
+		return false
+	}
+	return !strings.HasPrefix(resolved, dest+string(filepath.Separator))
+}
+
+// resolveSymlinks resolves the symlinks in path, following even a dangling
+// symlink whose final target does not exist yet (which filepath.EvalSymlinks
+// refuses to do). Components that do not exist and are not symlinks are kept
+// literally. It returns false if a symlink cycle or an unreadable link is hit.
+func (h *handler) resolveSymlinks(path string, hops int) (string, bool) {
+	if hops > maxSymlinkHops {
+		return "", false
+	}
+	// Fast path: a fully existing path resolves cleanly.
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return resolved, true
+	}
+	// path did not fully resolve. If path itself is a symlink (possibly
+	// dangling), follow its target manually.
+	if fi, err := os.Lstat(path); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+		target, err := os.Readlink(path)
+		if err != nil {
+			return "", false
+		}
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(filepath.Dir(path), target)
+		}
+		return h.resolveSymlinks(target, hops+1)
+	}
+	// path does not exist and is not a symlink. Resolve its parent so an escaping
+	// symlink in an ancestor is still followed, then re-attach the base name.
+	parent := filepath.Dir(path)
+	if parent == path {
+		return path, true
+	}
+	resolvedParent, ok := h.resolveSymlinks(parent, hops)
+	if !ok {
+		return "", false
+	}
+	return filepath.Join(resolvedParent, filepath.Base(path)), true
 }
 
 // withinDest reports whether the cleaned path is h.dest itself or located inside

--- a/pkg/unarchive/unarchive_test.go
+++ b/pkg/unarchive/unarchive_test.go
@@ -176,6 +176,43 @@ func TestUnarchiver_Unarchive_symlinkDirTraversal(t *testing.T) {
 	}
 }
 
+// TestUnarchiver_Unarchive_danglingSymlinkTraversal verifies that a symlink
+// whose target does not exist yet, followed by a regular file at the same path,
+// cannot create a file outside the extraction directory. filepath.EvalSymlinks
+// fails on such a dangling link, so the escape guard must not rely on the final
+// target already existing.
+// See https://github.com/aquaproj/aqua/security/advisories/GHSA-mf5c-hw34-4hpp
+func TestUnarchiver_Unarchive_danglingSymlinkTraversal(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	logger := slog.New(slog.DiscardHandler)
+
+	dest := t.TempDir()
+	outsideDir := t.TempDir()
+	// The target intentionally does not exist yet.
+	outside := filepath.Join(outsideDir, "created-outside-target")
+
+	// A symlink "pwn" -> not-yet-existing outside target, then a regular file
+	// "pwn" whose O_CREATE write would follow the dangling symlink.
+	archive := buildTarGz(
+		t,
+		tarEntry{hdr: &tar.Header{Name: "pwn", Typeflag: tar.TypeSymlink, Linkname: outside, Mode: 0o777}},
+		tarEntry{hdr: &tar.Header{Name: "pwn", Typeflag: tar.TypeReg, Mode: 0o644}, payload: []byte("PWNED_BY_AQUA_DANGLING_SYMLINK")},
+	)
+
+	fs := afero.NewOsFs()
+	src := &unarchive.File{
+		Filename: "malicious.tar.gz",
+		Body:     download.NewDownloadedFile(fs, io.NopCloser(bytes.NewReader(archive)), nil),
+	}
+	if err := unarchive.New(nil, fs).Unarchive(ctx, logger, src, dest); err == nil {
+		t.Fatal("an error must be returned for a regular file that follows a dangling symlink escaping the extraction directory")
+	}
+	if _, err := os.Stat(outside); !os.IsNotExist(err) {
+		t.Fatalf("a file was created outside dest through a dangling symlink: %v", err)
+	}
+}
+
 // TestUnarchiver_Unarchive_symlinkOutsideAllowed verifies that a symlink whose
 // target points outside the extraction directory is created successfully when
 // no later entry follows it to write outside. Such symlinks are common in


### PR DESCRIPTION
## Summary

Follow-up to #4990. KSHITIZ6341 reported (https://github.com/aquaproj/aqua/pull/4990#issuecomment-4927707857) that the write-time escape guard still lets an archive create a file outside the extraction directory when the escaping symlink's target does not exist yet.

I reproduced it against `main`: an archive with

```
pwn -> <outsideDir>/created-outside-target   (symlink, target does NOT exist)
pwn                                           (regular file)
```

extracts successfully and creates `<outsideDir>/created-outside-target` with the archive payload — a write outside `$(aqua root-dir)`.

## Root cause

`escapesDest` resolved paths with `filepath.EvalSymlinks`, which returns an error when a symlink's final target does not exist. For a dangling symlink planted at `dstPath`, `EvalSymlinks(dstPath)` failed, so the guard walked back to the parent directory (inside `dest`), concluded there was no escape, and let the write proceed. `OpenFile(dstPath, O_CREATE|O_WRONLY)` then followed the dangling symlink and created the target file outside `dest`.

The already-covered variants stayed safe by accident: when the target exists, `EvalSymlinks` resolves it and the escape is caught; and a dangling symlink used as a parent directory (`pwn/file`) makes `MkdirAll` fail so the entry is skipped. Only a dangling symlink at the write leaf slipped through.

## Fix

Replace the `EvalSymlinks`-only walk in `escapesDest` with `resolveSymlinks`, which follows symlink components manually via `os.Lstat` / `os.Readlink` and does not require the final target to exist. A dangling symlink's target is resolved (relative targets against the link's directory) and checked against `dest`, so an escaping target is detected whether or not it already exists. A symlink-hop counter (`maxSymlinkHops = 255`) guards against cycles.

Behavior for the existing cases is unchanged:
- Benign escaping symlinks (rootfs images like `var/run -> /run`) are still created and extraction still succeeds — symlink entries never go through `escapesDest`.
- Path traversal (`..`), the `./` root entry, and traversal through an existing escaping symlink are all still handled as before.

## Affected versions

No released version is affected by this bug; it exists only on `main`.

- This is a regression introduced by #4990, which is not part of any release tag yet (`git tag --contains` of the merge commit returns nothing; it is not an ancestor of the latest tag `v2.60.2-1`).
- Before #4990, `handleSymlink` rejected any symlink whose target resolves outside `dest` at creation time (`symlinkTargetWithinDest`), aborting extraction. A dangling escaping symlink like `pwn -> <outside>/missing` was therefore blocked regardless of whether its target existed, so this attack path did not exist.
- The original GHSA-mf5c-hw34-4hpp fix (d5b02b2) ships in `v2.60.1` and later, which retain that strict "reject the escaping symlink at creation" behavior and are not vulnerable to this variant.

Because #4990 is unreleased, #4990 and this fix will land in the same release, so end users are never exposed. No emergency release or advisory update is required.

## Tests

Add `TestUnarchiver_Unarchive_danglingSymlinkTraversal` covering the missing-target variant. It fails before this change (the outside file is created) and passes after. All existing unarchive tests continue to pass, and `golangci-lint` is clean.

Reported by @KSHITIZ6341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection against archive extraction paths escaping the destination directory.
  * Better handling of symlinks, including dangling links, parent-directory links, and symlink loops.
  * Extraction now fails safely when a path would resolve outside the intended location, helping prevent unwanted file creation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->
