### PR TITLE
fix(checksum): more signature related filename extension exclusions

### DIFF
--- a/pkg/checksum/checksum.go
+++ b/pkg/checksum/checksum.go
@@ -86,7 +86,7 @@ func convertChecksumFileName(filename, version string) string {
 // Returns a checksum configuration for github_release type or nil if no pattern matches.
 func GetChecksumConfigFromFilename(filename, version string) *registry.Checksum {
 	s := strings.ToLower(filename)
-	for _, suffix := range []string{"sig", "asc", "pem", "bundle", "sigstore", "sigstore.json", "minisig"} {
+	for _, suffix := range []string{"sig", "asc", "pem", "cert", "bundle", "sigstore", "sigstore.json", "minisig", "gpg", "gpgsig"} {
 		if strings.HasSuffix(s, "."+suffix) {
 			return nil
 		}


### PR DESCRIPTION
.cert, .gpg and .gpgsign are found in the wild.

Will conflict with https://github.com/aquaproj/aqua/pull/5015

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
  - [ ] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [ ] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue:
- [ ] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [ ] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved checksum configuration detection by excluding additional signature and certificate-related filename artifacts.
  - Prevents these files from being incorrectly interpreted as checksum configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->