### PR TITLE
docs: add a guide to use aqua with Claude Code's sandbox

### DIFF
--- a/website/docs/guides/claude-code-sandbox.md
+++ b/website/docs/guides/claude-code-sandbox.md
@@ -50,9 +50,9 @@ On macOS, add `env.GODEBUG` as well:
 
 `GODEBUG` works around a TLS verification failure that only happens on macOS, so it isn't needed on Linux or WSL2. Don't set it there: it would replace the system's certificate store with the roots embedded in aqua for no benefit.
 
-It requires aqua [v2.62.0](https://github.com/aquaproj/aqua/releases/tag/v2.62.0) or later [#5024](https://github.com/aquaproj/aqua/pull/5024). For older versions, see [Older versions of aqua](#older-versions-of-aqua).
+It requires aqua [v2.62.0](https://github.com/aquaproj/aqua/releases/tag/v2.62.0) or later [#5024](https://github.com/aquaproj/aqua/pull/5024). For older versions, see [Old versions of aqua](#old-versions-of-aqua).
 
-Don't set it either if you rely on a custom CA in the system trust store, such as behind a TLS-inspecting proxy. See [the caution below](#why-godebug-is-needed).
+Don't set it either if you rely on a custom CA in the system trust store, such as behind a TLS-inspecting proxy. See [TLS verification issue on macOS](#tls-verification-issue-on-macos).
 
 :::caution
 Sandbox settings are read when Claude Code starts.
@@ -98,10 +98,12 @@ Packages aren't limited to GitHub. If you install packages hosted elsewhere (`ht
 
 ### 3. A way to verify TLS certificates (macOS only)
 
-This is the one that isn't obvious. See below.
+This is the one that isn't obvious. See [TLS verification issue on macOS](#tls-verification-issue-on-macos).
 On Linux and WSL2, Go verifies certificates itself and the two requirements above are enough.
 
-## Why GODEBUG is needed
+## TLS verification issue on macOS
+
+Everything in this section applies to macOS only. On Linux and WSL2, the two requirements above are enough.
 
 Allowing the hosts above isn't enough. On macOS, aqua still fails:
 
@@ -116,6 +118,8 @@ This isn't a problem with `allowedDomains`. The host is reachable; other tools c
 
 This affects every Go-based CLI, not just aqua. Claude Code's documentation lists the same symptom for `gh`, `gcloud`, and `terraform` under [Troubleshooting](https://code.claude.com/docs/en/sandboxing#troubleshooting), and it's reported in [anthropics/claude-code#34876](https://github.com/anthropics/claude-code/issues/34876), which was closed as not planned.
 
+### aqua v2.62.0 or later
+
 Since [v2.62.0](https://github.com/aquaproj/aqua/releases/tag/v2.62.0), aqua embeds a copy of the Mozilla root certificates [#5024](https://github.com/aquaproj/aqua/pull/5024). Setting `GODEBUG=x509usefallbackroots=1` makes Go verify certificates with its own pure Go verifier and those embedded roots, so it never talks to the trust service and the sandbox doesn't need to be weakened:
 
 ```json
@@ -129,14 +133,14 @@ Since [v2.62.0](https://github.com/aquaproj/aqua/releases/tag/v2.62.0), aqua emb
 Setting it in `env` applies it to every Bash command in the session, which is what you want: aqua also downloads packages when you run an installed tool for the first time, and that runs under the tool's own name rather than `aqua`.
 
 :::caution
-`GODEBUG=x509usefallbackroots=1` makes Go ignore the system trust store, on every platform, and trust only the roots embedded in the binary. If you are behind a TLS-inspecting proxy, or otherwise rely on a CA added to the system trust store, aqua fails to verify certificates with this set. On macOS, use [`enableWeakerNetworkIsolation`](#older-versions-of-aqua) instead. This is also why you shouldn't set it on Linux or WSL2, where it buys you nothing.
+`GODEBUG=x509usefallbackroots=1` makes Go ignore the system trust store, on every platform, and trust only the roots embedded in the binary. If you are behind a TLS-inspecting proxy, or otherwise rely on a CA added to the system trust store, aqua fails to verify certificates with this set. On macOS, use [`enableWeakerNetworkIsolation`](#old-versions-of-aqua) instead. This is also why you shouldn't set it on Linux or WSL2, where it buys you nothing.
 
 Setting it session-wide is harmless for other Go tools. `x509usefallbackroots=1` has no effect unless the binary embeds fallback roots, which most tools don't.
 :::
 
 `SSL_CERT_FILE` is not an alternative: it's ignored on macOS. As [golang/go#77865](https://github.com/golang/go/issues/77865) puts it, "On darwin systems we use the platform certificate verifier, instead of the native Go one, by default". Supporting it on Darwin is an accepted proposal, so this may change in a future Go release.
 
-## Older versions of aqua
+### Old versions of aqua
 
 Before v2.62.0, aqua doesn't embed fallback roots, and `GODEBUG=x509usefallbackroots=1` does nothing: per [`x509.SetFallbackRoots`](https://pkg.go.dev/crypto/x509#SetFallbackRoots), "Setting x509usefallbackroots=1 without calling SetFallbackRoots has no effect".
 
@@ -160,7 +164,7 @@ It only matters on macOS. On Linux the sandbox uses bubblewrap, and this setting
 
 `network.allowMachLookup: ["com.apple.trustd.agent"]` is equivalent. Both grant the same Mach service lookup, and `allowMachLookup` isn't safer just because it names the service explicitly; the trade-off is the same.
 
-## Why excludedCommands isn't enough
+### Why excludedCommands isn't enough
 
 Claude Code's documentation recommends `excludedCommands` for Go-based CLIs, which runs them outside the sandbox:
 

--- a/website/docs/guides/claude-code-sandbox.md
+++ b/website/docs/guides/claude-code-sandbox.md
@@ -18,9 +18,11 @@ Add the following to `.claude/settings.json`:
 
 ```json
 {
+  "env": {
+    "GODEBUG": "x509usefallbackroots=1"
+  },
   "sandbox": {
     "enabled": true,
-    "enableWeakerNetworkIsolation": true,
     "network": {
       "allowedDomains": [
         "github.com",
@@ -36,7 +38,9 @@ Add the following to `.claude/settings.json`:
 }
 ```
 
-`enableWeakerNetworkIsolation` weakens the sandbox. Please read [Why enableWeakerNetworkIsolation is required](#why-enableweakernetworkisolation-is-required) before enabling it, and decide for yourself whether the trade-off is acceptable.
+`GODEBUG=x509usefallbackroots=1` requires aqua [v2.62.0](https://github.com/aquaproj/aqua/releases/tag/v2.62.0) or later [#5024](https://github.com/aquaproj/aqua/pull/5024). For older versions, see [Older versions of aqua](#older-versions-of-aqua).
+
+Don't set `GODEBUG` if you rely on a custom CA in the macOS system trust store, such as behind a TLS-inspecting proxy. See [the caution below](#why-godebug-is-needed).
 
 :::caution
 Sandbox settings are read when Claude Code starts.
@@ -80,11 +84,11 @@ Add the hosts aqua downloads from to `network.allowedDomains`:
 
 Packages aren't limited to GitHub. If you install packages hosted elsewhere (`http` type packages, Go modules, npm, and so on), add those hosts too.
 
-### 3. Access to the system TLS trust service
+### 3. A way to verify TLS certificates
 
 This is the one that isn't obvious. See below.
 
-## Why enableWeakerNetworkIsolation is required
+## Why GODEBUG is needed
 
 Allowing the hosts above isn't enough. On macOS, aqua still fails:
 
@@ -99,12 +103,31 @@ This isn't a problem with `allowedDomains`. The host is reachable; other tools c
 
 This affects every Go-based CLI, not just aqua. Claude Code's documentation lists the same symptom for `gh`, `gcloud`, and `terraform` under [Troubleshooting](https://code.claude.com/docs/en/sandboxing#troubleshooting), and it's reported in [anthropics/claude-code#34876](https://github.com/anthropics/claude-code/issues/34876), which was closed as not planned.
 
-Neither `SSL_CERT_FILE` nor `GODEBUG=x509usefallbackroots=1` helps:
+Since [v2.62.0](https://github.com/aquaproj/aqua/releases/tag/v2.62.0), aqua embeds a copy of the Mozilla root certificates [#5024](https://github.com/aquaproj/aqua/pull/5024). Setting `GODEBUG=x509usefallbackroots=1` makes Go verify certificates with its own pure Go verifier and those embedded roots, so it never talks to the trust service and the sandbox doesn't need to be weakened:
 
-- `SSL_CERT_FILE` is ignored on macOS. As [golang/go#77865](https://github.com/golang/go/issues/77865) puts it, "On darwin systems we use the platform certificate verifier, instead of the native Go one, by default". Supporting it on Darwin is an accepted proposal, so this may change in a future Go release.
-- `GODEBUG=x509usefallbackroots=1` only takes effect if the binary calls [`x509.SetFallbackRoots`](https://pkg.go.dev/crypto/x509#SetFallbackRoots): "Setting x509usefallbackroots=1 without calling SetFallbackRoots has no effect". aqua doesn't embed fallback roots, so it does nothing.
+```json
+{
+  "env": {
+    "GODEBUG": "x509usefallbackroots=1"
+  }
+}
+```
 
-The fix is to allow the sandbox to reach the trust service:
+Setting it in `env` applies it to every Bash command in the session, which is what you want: aqua also downloads packages when you run an installed tool for the first time, and that runs under the tool's own name rather than `aqua`.
+
+:::caution
+`GODEBUG=x509usefallbackroots=1` makes Go ignore the macOS system trust store and trust only the embedded roots. If you are behind a TLS-inspecting proxy, or otherwise rely on a CA added to the system trust store, aqua fails to verify certificates with this set. In that case, use [`enableWeakerNetworkIsolation`](#older-versions-of-aqua) instead.
+
+Setting it session-wide is harmless for other Go tools. `x509usefallbackroots=1` has no effect unless the binary embeds fallback roots, which most tools don't.
+:::
+
+`SSL_CERT_FILE` is not an alternative: it's ignored on macOS. As [golang/go#77865](https://github.com/golang/go/issues/77865) puts it, "On darwin systems we use the platform certificate verifier, instead of the native Go one, by default". Supporting it on Darwin is an accepted proposal, so this may change in a future Go release.
+
+## Older versions of aqua
+
+Before v2.62.0, aqua doesn't embed fallback roots, and `GODEBUG=x509usefallbackroots=1` does nothing: per [`x509.SetFallbackRoots`](https://pkg.go.dev/crypto/x509#SetFallbackRoots), "Setting x509usefallbackroots=1 without calling SetFallbackRoots has no effect".
+
+The only remaining option is to let the sandbox reach the trust service:
 
 ```json
 {
@@ -114,25 +137,15 @@ The fix is to allow the sandbox to reach the trust service:
 }
 ```
 
+This is also the option to use if you can't set `GODEBUG` because you rely on a custom CA.
+
 :::caution
 As the name says, this weakens the sandbox. Claude Code's documentation describes it as reducing security "by opening a potential data exfiltration path": the trust service fetches OCSP/CRL data over the network without going through the sandbox's proxy, so it isn't covered by `allowedDomains`.
 
-Decide whether this trade-off is acceptable for you. It only matters on macOS; on Linux the sandbox uses bubblewrap and this setting does nothing.
+It only matters on macOS. On Linux the sandbox uses bubblewrap, and this setting does nothing.
 :::
 
-`network.allowMachLookup` is equivalent:
-
-```json
-{
-  "sandbox": {
-    "network": {
-      "allowMachLookup": ["com.apple.trustd.agent"]
-    }
-  }
-}
-```
-
-Both grant the same Mach service lookup, and both were confirmed to work. `allowMachLookup` isn't safer just because it names the service explicitly; the trade-off is the same. Use `enableWeakerNetworkIsolation`, which is the documented setting for this purpose.
+`network.allowMachLookup: ["com.apple.trustd.agent"]` is equivalent. Both grant the same Mach service lookup, and `allowMachLookup` isn't safer just because it names the service explicitly; the trade-off is the same.
 
 ## Why excludedCommands isn't enough
 
@@ -158,7 +171,7 @@ ERR request failed error="Get \"https://github.com/mikefarah/yq/releases/downloa
 
 The pattern is matched against the command string, and the match is easy to miss. Prefixing environment variables defeats it: `AQUA_ROOT_DIR=/tmp/foo aqua i` doesn't match `aqua *`, so it runs sandboxed and fails, while `cd /tmp/foo && aqua i` does match.
 
-When it does match, it excludes more than you might expect. The exclusion applies to the whole command, so `aqua i && rm -rf ~/.config` runs entirely outside the sandbox, including the part that has nothing to do with aqua. That's a weaker outcome than `enableWeakerNetworkIsolation`, which keeps aqua inside the sandbox and subject to `allowedDomains` and `allowWrite`.
+When it does match, it excludes more than you might expect. The exclusion applies to the whole command, so `aqua i && rm -rf ~/.config` runs entirely outside the sandbox, including the part that has nothing to do with aqua.
 
 ## Notes
 

--- a/website/docs/guides/claude-code-sandbox.md
+++ b/website/docs/guides/claude-code-sandbox.md
@@ -14,13 +14,10 @@ This page is about the sandbox built into Claude Code, which is enabled by `sand
 
 ## TL;DR
 
-Add the following to `.claude/settings.json`:
+On Linux and WSL2, add the following to `.claude/settings.json`:
 
 ```json
 {
-  "env": {
-    "GODEBUG": "x509usefallbackroots=1"
-  },
   "sandbox": {
     "enabled": true,
     "network": {
@@ -38,9 +35,24 @@ Add the following to `.claude/settings.json`:
 }
 ```
 
-`GODEBUG=x509usefallbackroots=1` requires aqua [v2.62.0](https://github.com/aquaproj/aqua/releases/tag/v2.62.0) or later [#5024](https://github.com/aquaproj/aqua/pull/5024). For older versions, see [Older versions of aqua](#older-versions-of-aqua).
+On macOS, add `env.GODEBUG` as well:
 
-Don't set `GODEBUG` if you rely on a custom CA in the macOS system trust store, such as behind a TLS-inspecting proxy. See [the caution below](#why-godebug-is-needed).
+```json
+{
+  "env": {
+    "GODEBUG": "x509usefallbackroots=1"
+  },
+  "sandbox": {
+    "...": "same as above"
+  }
+}
+```
+
+`GODEBUG` works around a TLS verification failure that only happens on macOS, so it isn't needed on Linux or WSL2. Don't set it there: it would replace the system's certificate store with the roots embedded in aqua for no benefit.
+
+It requires aqua [v2.62.0](https://github.com/aquaproj/aqua/releases/tag/v2.62.0) or later [#5024](https://github.com/aquaproj/aqua/pull/5024). For older versions, see [Older versions of aqua](#older-versions-of-aqua).
+
+Don't set it either if you rely on a custom CA in the system trust store, such as behind a TLS-inspecting proxy. See [the caution below](#why-godebug-is-needed).
 
 :::caution
 Sandbox settings are read when Claude Code starts.
@@ -84,9 +96,10 @@ Add the hosts aqua downloads from to `network.allowedDomains`:
 
 Packages aren't limited to GitHub. If you install packages hosted elsewhere (`http` type packages, Go modules, npm, and so on), add those hosts too.
 
-### 3. A way to verify TLS certificates
+### 3. A way to verify TLS certificates (macOS only)
 
 This is the one that isn't obvious. See below.
+On Linux and WSL2, Go verifies certificates itself and the two requirements above are enough.
 
 ## Why GODEBUG is needed
 
@@ -116,7 +129,7 @@ Since [v2.62.0](https://github.com/aquaproj/aqua/releases/tag/v2.62.0), aqua emb
 Setting it in `env` applies it to every Bash command in the session, which is what you want: aqua also downloads packages when you run an installed tool for the first time, and that runs under the tool's own name rather than `aqua`.
 
 :::caution
-`GODEBUG=x509usefallbackroots=1` makes Go ignore the macOS system trust store and trust only the embedded roots. If you are behind a TLS-inspecting proxy, or otherwise rely on a CA added to the system trust store, aqua fails to verify certificates with this set. In that case, use [`enableWeakerNetworkIsolation`](#older-versions-of-aqua) instead.
+`GODEBUG=x509usefallbackroots=1` makes Go ignore the system trust store, on every platform, and trust only the roots embedded in the binary. If you are behind a TLS-inspecting proxy, or otherwise rely on a CA added to the system trust store, aqua fails to verify certificates with this set. On macOS, use [`enableWeakerNetworkIsolation`](#older-versions-of-aqua) instead. This is also why you shouldn't set it on Linux or WSL2, where it buys you nothing.
 
 Setting it session-wide is harmless for other Go tools. `x509usefallbackroots=1` has no effect unless the binary embeds fallback roots, which most tools don't.
 :::

--- a/website/docs/guides/claude-code-sandbox.md
+++ b/website/docs/guides/claude-code-sandbox.md
@@ -1,0 +1,165 @@
+---
+sidebar_position: 900
+---
+
+# Use aqua with Claude Code's sandbox
+
+[Claude Code](https://code.claude.com/docs/en/sandboxing) can run Bash commands inside an OS-level sandbox that restricts filesystem and network access.
+aqua doesn't work inside the sandbox with the default settings.
+This page describes the minimum settings aqua needs.
+
+:::info
+This page is about the sandbox built into Claude Code, which is enabled by `sandbox.enabled` in `settings.json`.
+:::
+
+## TL;DR
+
+Add the following to `.claude/settings.json`:
+
+```json
+{
+  "sandbox": {
+    "enabled": true,
+    "enableWeakerNetworkIsolation": true,
+    "network": {
+      "allowedDomains": [
+        "github.com",
+        "raw.githubusercontent.com",
+        "release-assets.githubusercontent.com",
+        "api.github.com"
+      ]
+    },
+    "filesystem": {
+      "allowWrite": ["~/.local/share/aquaproj-aqua"]
+    }
+  }
+}
+```
+
+`enableWeakerNetworkIsolation` weakens the sandbox. Please read [Why enableWeakerNetworkIsolation is required](#why-enableweakernetworkisolation-is-required) before enabling it, and decide for yourself whether the trade-off is acceptable.
+
+:::caution
+Sandbox settings are read when Claude Code starts.
+Editing `settings.json` in a running session has no effect. Restart Claude Code after changing them.
+:::
+
+## Requirements
+
+aqua needs three things from the sandbox.
+
+### 1. Write access to the root directory
+
+By default, sandboxed commands can write only to the current working directory and the session temp directory (`$TMPDIR`).
+aqua writes to its root directory (`aqua root-dir`), which is `${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua` by default, so it needs to be allowed explicitly:
+
+```json
+{
+  "sandbox": {
+    "filesystem": {
+      "allowWrite": ["~/.local/share/aquaproj-aqua"]
+    }
+  }
+}
+```
+
+Without this, writes fail with `Operation not permitted`.
+If you change the root directory with `AQUA_ROOT_DIR`, allow that path instead.
+
+### 2. Network access
+
+Add the hosts aqua downloads from to `network.allowedDomains`:
+
+| Host | Purpose |
+| --- | --- |
+| `github.com` | Downloads aqua-proxy and packages hosted on GitHub Releases |
+| `release-assets.githubusercontent.com` | GitHub Releases assets redirect here |
+| `raw.githubusercontent.com` | Standard Registry (`registry.yaml`) |
+| `api.github.com` | GitHub API. Needed to resolve versions (`aqua g`, `aqua up`, unpinned versions) |
+
+`api.github.com` isn't used when every package version is pinned and the download succeeds, but you generally want it.
+
+Packages aren't limited to GitHub. If you install packages hosted elsewhere (`http` type packages, Go modules, npm, and so on), add those hosts too.
+
+### 3. Access to the system TLS trust service
+
+This is the one that isn't obvious. See below.
+
+## Why enableWeakerNetworkIsolation is required
+
+Allowing the hosts above isn't enough. On macOS, aqua still fails:
+
+```
+Get "https://github.com/aquaproj/aqua-proxy/releases/download/v1.2.13/aqua-proxy_darwin_arm64.tar.gz":
+ tls: failed to verify certificate: x509: OSStatus -26276
+```
+
+This isn't a problem with `allowedDomains`. The host is reachable; other tools can download the same URL.
+
+`OSStatus -26276` is [`errSecInternalComponent`](https://developer.apple.com/documentation/security/errsecinternalcomponent). On macOS, Go doesn't verify certificates itself: it calls the platform verifier in Security.framework, which talks to the system trust service (`com.apple.trustd.agent`) over Mach IPC. macOS's sandbox (Seatbelt) blocks that lookup, so verification fails before the request goes out.
+
+This affects every Go-based CLI, not just aqua. Claude Code's documentation lists the same symptom for `gh`, `gcloud`, and `terraform` under [Troubleshooting](https://code.claude.com/docs/en/sandboxing#troubleshooting), and it's reported in [anthropics/claude-code#34876](https://github.com/anthropics/claude-code/issues/34876), which was closed as not planned.
+
+Neither `SSL_CERT_FILE` nor `GODEBUG=x509usefallbackroots=1` helps:
+
+- `SSL_CERT_FILE` is ignored on macOS. As [golang/go#77865](https://github.com/golang/go/issues/77865) puts it, "On darwin systems we use the platform certificate verifier, instead of the native Go one, by default". Supporting it on Darwin is an accepted proposal, so this may change in a future Go release.
+- `GODEBUG=x509usefallbackroots=1` only takes effect if the binary calls [`x509.SetFallbackRoots`](https://pkg.go.dev/crypto/x509#SetFallbackRoots): "Setting x509usefallbackroots=1 without calling SetFallbackRoots has no effect". aqua doesn't embed fallback roots, so it does nothing.
+
+The fix is to allow the sandbox to reach the trust service:
+
+```json
+{
+  "sandbox": {
+    "enableWeakerNetworkIsolation": true
+  }
+}
+```
+
+:::caution
+As the name says, this weakens the sandbox. Claude Code's documentation describes it as reducing security "by opening a potential data exfiltration path": the trust service fetches OCSP/CRL data over the network without going through the sandbox's proxy, so it isn't covered by `allowedDomains`.
+
+Decide whether this trade-off is acceptable for you. It only matters on macOS; on Linux the sandbox uses bubblewrap and this setting does nothing.
+:::
+
+`network.allowMachLookup` is equivalent:
+
+```json
+{
+  "sandbox": {
+    "network": {
+      "allowMachLookup": ["com.apple.trustd.agent"]
+    }
+  }
+}
+```
+
+Both grant the same Mach service lookup, and both were confirmed to work. `allowMachLookup` isn't safer just because it names the service explicitly; the trade-off is the same. Use `enableWeakerNetworkIsolation`, which is the documented setting for this purpose.
+
+## Why excludedCommands isn't enough
+
+Claude Code's documentation recommends `excludedCommands` for Go-based CLIs, which runs them outside the sandbox:
+
+```json
+{
+  "sandbox": {
+    "excludedCommands": ["aqua *"]
+  }
+}
+```
+
+This works for `aqua` itself, but it doesn't work well for aqua specifically, for three reasons.
+
+aqua installs packages lazily. The first time you run an installed tool, aqua-proxy downloads it. That download runs under the tool's own command name, not `aqua`, so `aqua *` doesn't cover it and it fails with the same TLS error:
+
+```console
+$ echo 'a: 1' | yq '.a'
+ERR request failed error="Get \"https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_darwin_arm64\":
+ tls: failed to verify certificate: x509: OSStatus -26276"
+```
+
+The pattern is matched against the command string, and the match is easy to miss. Prefixing environment variables defeats it: `AQUA_ROOT_DIR=/tmp/foo aqua i` doesn't match `aqua *`, so it runs sandboxed and fails, while `cd /tmp/foo && aqua i` does match.
+
+When it does match, it excludes more than you might expect. The exclusion applies to the whole command, so `aqua i && rm -rf ~/.config` runs entirely outside the sandbox, including the part that has nothing to do with aqua. That's a weaker outcome than `enableWeakerNetworkIsolation`, which keeps aqua inside the sandbox and subject to `allowedDomains` and `allowWrite`.
+
+## Notes
+
+`allowedDomains` isn't necessarily a hard boundary. By default, when a sandboxed command reaches a host that isn't allowed, Claude Code prompts you, and approving it allows that host for the rest of the session. If you use [auto mode](https://code.claude.com/docs/en/permission-modes), the classifier may approve hosts without prompting, so hosts outside `allowedDomains` can still be reached. To make it a hard allowlist, an administrator sets `network.allowManagedDomainsOnly` in managed settings.


### PR DESCRIPTION
## Summary

aqua doesn't work inside [Claude Code's sandbox](https://code.claude.com/docs/en/sandboxing) with the default settings. This adds a guide documenting the minimum settings aqua needs, and why each one is needed.

Depends on #5024, which is merged: the guide recommends `GODEBUG=x509usefallbackroots=1`, which only works from v2.62.0. The version and release link in the guide assume v2.62.0.

Everything in the guide was verified by hand on macOS (darwin/arm64, Claude Code 2.1.209), not derived from the documentation alone.

## What aqua needs

1. `sandbox.filesystem.allowWrite` for `aqua root-dir`. Sandboxed commands can write only to the working directory and `$TMPDIR` by default.
2. `sandbox.network.allowedDomains` for `github.com`, `raw.githubusercontent.com`, `release-assets.githubusercontent.com`, and `api.github.com`.
3. `GODEBUG=x509usefallbackroots=1`, which is the part that isn't obvious.

## The TLS problem

Allowing the hosts isn't enough. aqua fails with:

```
tls: failed to verify certificate: x509: OSStatus -26276
```

This isn't a network-permission problem: the host is reachable, and a non-Go client downloads the same URL fine. `OSStatus -26276` is `errSecInternalComponent`. On macOS, Go calls the platform verifier in Security.framework, which reaches the system trust service (`com.apple.trustd.agent`) over Mach IPC, and Seatbelt blocks that lookup. It affects every Go-based CLI; it's reported in anthropics/claude-code#34876 (closed as not planned).

With the fallback roots from #5024, `GODEBUG=x509usefallbackroots=1` makes Go use its own verifier and the embedded roots, so the sandbox doesn't need to be weakened at all. The guide sets it via `env` in the same `settings.json`, which also covers aqua's lazy installs, since those run under the installed tool's own command name and inherit the environment.

## Trade-offs the guide is explicit about

`GODEBUG=x509usefallbackroots=1` makes Go ignore the macOS system trust store, so users behind a TLS-inspecting proxy or relying on a custom CA must not set it. For them, and for aqua older than v2.62.0, the guide keeps `enableWeakerNetworkIsolation` as the fallback and states plainly that it weakens the sandbox by opening a path `allowedDomains` doesn't cover.

## Why not excludedCommands

Claude Code's docs recommend `excludedCommands` for Go-based CLIs, but it's a poor fit for aqua, and the guide explains why. aqua installs lazily, so the first run of an installed tool downloads it under that tool's own command name and isn't covered by `aqua *` — verified by watching `yq` fail with the same TLS error. It's also easy to miss the match (`AQUA_ROOT_DIR=... aqua i` doesn't match), and when it does match, the whole command runs outside the sandbox.

## Verification

Built from this branch and run on macOS inside the sandbox, confirming the process was sandboxed for each run, with no trustd allowance in the sandbox config:

| Binary | GODEBUG | Result |
| --- | --- | --- |
| Before #5024 | unset | `OSStatus -26276` |
| With #5024 | unset | `OSStatus -26276` |
| With #5024 | `x509usefallbackroots=1` via `env` | Succeeds |

In the last case `aqua i` installed aqua-proxy and a package, and the installed tool ran. The `allowWrite` requirement was verified separately: the root directory was writable while `~/.config` and `~/.cache` were denied.

## Notes for reviewers

- Placed under Guides with `sidebar_position: 900`.
- The guide notes that `allowedDomains` isn't a hard boundary outside managed settings: while sandboxed, hosts not on the list were still reachable because approval is automatic in auto mode.
- `network.allowMachLookup: ["com.apple.trustd.agent"]` was also verified to work and is mentioned, with the caveat that it's the same trade-off as `enableWeakerNetworkIsolation`, not a safer one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a guide for running `aqua` within Claude Code’s OS-level sandbox.
  * Documented required write permissions, download host allowlists, and macOS TLS configuration.
  * Added guidance for newer and older `aqua` versions, including custom certificate authorities.
  * Explained sandbox permission modes and why command exclusions may not cover lazy package downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->