### PR TITLE
feat: embed fallback X.509 roots to support sandboxed environments

### DIFF
--- a/cmd/aqua/main.go
+++ b/cmd/aqua/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aquaproj/aqua/v2/pkg/cli"
 	"github.com/aquaproj/aqua/v2/pkg/runtime"
 	"github.com/suzuki-shunsuke/urfave-cli-v3-util/urfave"
+	_ "golang.org/x/crypto/x509roots/fallback"
 )
 
 var version = ""

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/urfave/cli/v3 v3.10.1
 	go.yaml.in/yaml/v2 v2.4.4
 	go.yaml.in/yaml/v3 v3.0.4
+	golang.org/x/crypto/x509roots/fallback v0.0.0-20260714033321-10b54ffa51b1
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0

--- a/go.sum
+++ b/go.sum
@@ -282,6 +282,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=
 golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX4=
+golang.org/x/crypto/x509roots/fallback v0.0.0-20260714033321-10b54ffa51b1 h1:b3ueIDxtAMnuzpNiR+JKwubD5Zs3WZ7+k82sx9Nrzec=
+golang.org/x/crypto/x509roots/fallback v0.0.0-20260714033321-10b54ffa51b1/go.mod h1:+UoQFNBq2p2wO+Q6ddVtYc25GZ6VNdOMyyrd4nrqrKs=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=


### PR DESCRIPTION
## Summary

Import `golang.org/x/crypto/x509roots/fallback` so that aqua can verify TLS certificates without the macOS system trust service. This lets aqua run inside sandboxes that block it, such as Claude Code's, by setting `GODEBUG=x509usefallbackroots=1`.

Follow-up to #5023, which documents the sandbox settings aqua needs today. This PR removes the need for the most problematic of those settings.

## Problem

On macOS, Go doesn't verify certificates itself: it calls the platform verifier in Security.framework, which reaches the system trust service (`com.apple.trustd.agent`) over Mach IPC. Sandboxes block that lookup, so aqua fails before any request goes out:

```
tls: failed to verify certificate: x509: OSStatus -26276
```

`OSStatus -26276` is `errSecInternalComponent`. This affects every Go-based CLI; see anthropics/claude-code#34876, closed as not planned.

Today the only workarounds are on the sandbox side, and both weaken it. Claude Code's `enableWeakerNetworkIsolation` re-allows the trustd lookup, which its own documentation describes as reducing security "by opening a potential data exfiltration path", because trustd fetches OCSP/CRL data outside the sandbox's proxy. `excludedCommands` is worse: it runs aqua entirely outside the sandbox, and it doesn't even work for aqua, since lazy installs run under the installed tool's own command name.

## Approach

`GODEBUG=x509usefallbackroots=1` makes Go use the pure Go verifier with embedded roots instead of trustd, but per [`x509.SetFallbackRoots`](https://pkg.go.dev/crypto/x509#SetFallbackRoots), "Setting x509usefallbackroots=1 without calling SetFallbackRoots has no effect". Importing the `fallback` package registers those roots, so the GODEBUG becomes effective.

Alternatives considered and rejected:

- `SSL_CERT_FILE` is ignored on macOS (golang/go#77865, an accepted proposal, so this may change in a future Go release).
- A `//go:debug x509usefallbackroots=1` directive would make this the default and remove the need for the env var, but it would ignore the macOS system trust store for everyone, breaking users who rely on custom CAs. Keeping it opt-in via the env var leaves the default behavior untouched.

## Behavior

Nothing changes by default. The embedded roots are only used when `GODEBUG=x509usefallbackroots=1` is set.

When it is set, the macOS system trust store is bypassed in favor of the embedded Mozilla roots. Users behind a TLS-inspecting proxy with a custom CA should not set it.

`golang.org/x/crypto` was already an indirect dependency. Binary size grows by about 147KB (34,160,754 to 34,311,346 bytes on darwin/arm64).

## Verification

Built from this branch and run on macOS (darwin/arm64) inside Claude Code's sandbox, with no trustd allowance in the sandbox config, confirming the process was sandboxed for each run:

| Binary | GODEBUG | Result |
| --- | --- | --- |
| Current aqua | unset | `OSStatus -26276` |
| This branch | unset | `OSStatus -26276` |
| This branch | `x509usefallbackroots=1` | Succeeds |

With the GODEBUG set, `aqua i` installed aqua-proxy and a package, and the installed tool ran. The lazy-install path was also verified: after deleting the package, invoking the tool directly re-downloaded it through aqua-proxy and succeeded, since GODEBUG is inherited by child processes. That's the path `excludedCommands` cannot cover.

`cmdx v` and `cmdx t` pass. Note that aqua's own tests can't run inside the sandbox for exactly this reason: `pkg/unarchive` fetches over HTTPS and fails with the same error.

## Note for reviewers

If this is merged, the guide in #5023 needs updating: it currently states that `GODEBUG=x509usefallbackroots=1` does nothing because aqua doesn't embed fallback roots, and it recommends `enableWeakerNetworkIsolation`. I'm happy to rework that guide around this approach in whichever order you prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved certificate validation reliability by enabling fallback root certificates at application startup.
  * Helps establish secure connections in environments where system root certificates are unavailable or incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->