### PR TITLE
fix(installpackage): extract packages into a temp dir and rename atomically

### DIFF
--- a/pkg/installpackage/download.go
+++ b/pkg/installpackage/download.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/aquaproj/aqua/v2/pkg/download"
+	"github.com/aquaproj/aqua/v2/pkg/osfile"
 	"github.com/aquaproj/aqua/v2/pkg/unarchive"
 	"github.com/schollz/progressbar/v3"
+	"github.com/spf13/afero"
 	"github.com/suzuki-shunsuke/slog-error/slogerr"
 )
 
@@ -149,9 +152,55 @@ func (is *Installer) download(ctx context.Context, logger *slog.Logger, param *D
 		return err
 	}
 
-	return is.unarchiver.Unarchive(ctx, logger, &unarchive.File{ //nolint:wrapcheck
+	return is.unarchive(ctx, logger, param, bodyFile, pkgInfo.GetFormat())
+}
+
+// unarchive extracts the asset into a temporary directory and moves it to
+// param.Dest only once the extraction has finished.
+//
+// aqua treats the mere existence of the destination directory as proof that the
+// package is installed (see downloadWithRetry), so extracting straight into it
+// would publish the directory before it is populated: a concurrent install of
+// the same package -- another goroutine of this process, or another aqua process
+// -- would skip the download and then fail to find the executable that has not
+// been written yet. Renaming a fully extracted directory into place keeps that
+// check honest, because the destination only ever appears complete.
+func (is *Installer) unarchive(ctx context.Context, logger *slog.Logger, param *DownloadParam, bodyFile *download.DownloadedFile, format string) error {
+	// The temporary directory must live under rootDir so that it is on the same
+	// filesystem as the destination; renaming across drives fails on Windows.
+	tempDir := filepath.Join(is.rootDir, "temp")
+	if err := osfile.MkdirAll(is.fs, tempDir); err != nil {
+		return fmt.Errorf("create a temporary directory: %w", err)
+	}
+	tempDir, err := afero.TempDir(is.fs, tempDir, "")
+	if err != nil {
+		return fmt.Errorf("create a temporary directory: %w", err)
+	}
+	defer func() {
+		if err := is.fs.RemoveAll(tempDir); err != nil {
+			slogerr.WithError(logger, err).Warn("remove a temporary directory")
+		}
+	}()
+
+	if err := is.unarchiver.Unarchive(ctx, logger, &unarchive.File{
 		Body:     bodyFile,
 		Filename: param.Asset,
-		Type:     pkgInfo.GetFormat(),
-	}, param.Dest)
+		Type:     format,
+	}, tempDir); err != nil {
+		return err //nolint:wrapcheck
+	}
+
+	if err := osfile.MkdirAll(is.fs, filepath.Dir(param.Dest)); err != nil {
+		return fmt.Errorf("create the parent directory of the package: %w", err)
+	}
+	if err := is.fs.Rename(tempDir, param.Dest); err != nil {
+		// The rename fails if something else already installed the package. Ask the
+		// destination rather than the error, whose text differs per platform.
+		if _, e := is.fs.Stat(param.Dest); e == nil {
+			logger.Debug("the package has been installed by another process")
+			return nil
+		}
+		return fmt.Errorf("move the unarchived package to the destination: %w", err)
+	}
+	return nil
 }

--- a/pkg/installpackage/download_internal_test.go
+++ b/pkg/installpackage/download_internal_test.go
@@ -1,8 +1,11 @@
 package installpackage
 
 import (
+	"context"
+	"errors"
 	"io"
 	"log/slog"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -15,6 +18,137 @@ import (
 	"github.com/aquaproj/aqua/v2/pkg/unarchive"
 	"github.com/spf13/afero"
 )
+
+// writeUnarchiver stands in for a real unarchiver by writing exeName into the
+// destination it is handed, so that tests can tell which directory the
+// extraction went to.
+type writeUnarchiver struct {
+	fs      afero.Fs
+	exeName string
+	err     error
+}
+
+func (u *writeUnarchiver) Unarchive(_ context.Context, _ *slog.Logger, _ *unarchive.File, dest string) error {
+	if u.err != nil {
+		return u.err
+	}
+	p := filepath.Join(dest, u.exeName)
+	if err := u.fs.MkdirAll(filepath.Dir(p), dirPerm); err != nil {
+		return err //nolint:wrapcheck
+	}
+	return afero.WriteFile(u.fs, p, []byte("gh"), dirPerm) //nolint:wrapcheck
+}
+
+const dirPerm = 0o755
+
+// newUnarchiveTestInstaller returns an installer rooted at a fresh temporary
+// directory, along with that root and the package destination under it.
+func newUnarchiveTestInstaller(t *testing.T, unarchiveErr error) (*Installer, string, string) {
+	t.Helper()
+	fs := afero.NewOsFs()
+	rootDir := t.TempDir()
+	dest := filepath.Join(rootDir, "pkgs", "github_release", "github.com", "cli", "cli", "v2.96.0", "gh_2.96.0_linux_amd64.tar.gz")
+	return &Installer{
+		fs:      fs,
+		rootDir: rootDir,
+		unarchiver: &writeUnarchiver{
+			fs:      fs,
+			exeName: filepath.Join("bin", "gh"),
+			err:     unarchiveErr,
+		},
+	}, rootDir, dest
+}
+
+// assertTempDirIsEmpty checks that neither a discarded nor a failed extraction
+// left a temporary directory behind.
+func assertTempDirIsEmpty(t *testing.T, fs afero.Fs, rootDir string) {
+	t.Helper()
+	entries, err := afero.ReadDir(fs, filepath.Join(rootDir, "temp"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("%d temporary directories are left", len(entries))
+	}
+}
+
+// The OS filesystem is used rather than a memory-mapped one because these tests
+// turn on Rename's real behaviour: MemMapFs happily renames onto an existing
+// directory, which is exactly the case the lost-race test needs to exercise.
+func TestInstaller_unarchive(t *testing.T) {
+	t.Parallel()
+
+	inst, rootDir, dest := newUnarchiveTestInstaller(t, nil)
+
+	if err := inst.unarchive(t.Context(), slog.New(slog.DiscardHandler), &DownloadParam{
+		Dest:  dest,
+		Asset: "gh_2.96.0_linux_amd64.tar.gz",
+	}, nil, "tar.gz"); err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := afero.ReadFile(inst.fs, filepath.Join(dest, "bin", "gh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != "gh" {
+		t.Fatalf("the executable file is %q, want %q", b, "gh")
+	}
+	assertTempDirIsEmpty(t, inst.fs, rootDir)
+}
+
+// A package another process finished extracting first must be left alone, and
+// this installer's own copy discarded.
+func TestInstaller_unarchive_destExists(t *testing.T) {
+	t.Parallel()
+
+	inst, rootDir, dest := newUnarchiveTestInstaller(t, nil)
+	exePath := filepath.Join(dest, "bin", "gh")
+	if err := inst.fs.MkdirAll(filepath.Dir(exePath), dirPerm); err != nil {
+		t.Fatal(err)
+	}
+	if err := afero.WriteFile(inst.fs, exePath, []byte("installed by someone else"), dirPerm); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := inst.unarchive(t.Context(), slog.New(slog.DiscardHandler), &DownloadParam{
+		Dest:  dest,
+		Asset: "gh_2.96.0_linux_amd64.tar.gz",
+	}, nil, "tar.gz"); err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := afero.ReadFile(inst.fs, exePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != "installed by someone else" {
+		t.Fatalf("the executable file is %q, want %q", b, "installed by someone else")
+	}
+	assertTempDirIsEmpty(t, inst.fs, rootDir)
+}
+
+// The destination must not be created at all when the extraction fails,
+// otherwise downloadWithRetry would treat the package as installed.
+func TestInstaller_unarchive_failure(t *testing.T) {
+	t.Parallel()
+
+	inst, rootDir, dest := newUnarchiveTestInstaller(t, errors.New("unarchive failed"))
+
+	if err := inst.unarchive(t.Context(), slog.New(slog.DiscardHandler), &DownloadParam{
+		Dest:  dest,
+		Asset: "gh_2.96.0_linux_amd64.tar.gz",
+	}, nil, "tar.gz"); err == nil {
+		t.Fatal("error must be returned")
+	}
+
+	if f, err := afero.Exists(inst.fs, dest); err != nil {
+		t.Fatal(err)
+	} else if f {
+		t.Fatal("the destination must not be created when the extraction fails")
+	}
+	assertTempDirIsEmpty(t, inst.fs, rootDir)
+}
 
 func TestInstaller_download(t *testing.T) { //nolint:funlen
 	t.Parallel()


### PR DESCRIPTION
Fixes #5022

## Problem

aqua decides a package is already installed by a bare `Stat` of its destination directory (`downloadWithRetry`), but extraction wrote into that directory in place. The directory therefore became visible while still half-populated, so a concurrent install of the same package would skip the download and then fail to find the executable that had not been written yet.

This is not hypothetical. aqua installs `cli/cli` itself to verify GitHub Artifact Attestations, and `PkgPath` resolves that embedded package to exactly the same directory as a user-managed `cli/cli` of the same version — same asset template, same linux `tar.gz` override. The two installs really can overlap: `ghInstaller.install` runs from inside `download` during attestation verification, which itself runs in one of the errgroup goroutines that install user packages in parallel. The `DedicatedInstaller` mutex is per-instance and only serializes dedicated installs against each other, never against a user-level install of the same package.

Renovate keeps both the embedded pin and users' `aqua.yaml` at the latest version, so the two keep coinciding and the failure recurs.

## Fix

Extract into a temporary directory under `rootDir` and rename it into place once extraction has finished, so the destination only ever appears complete and the `Stat` check becomes honest. Unlike an in-process lock, this also holds between separate aqua processes (parallel `aqua exec` via the proxy).

The change is confined to one call site. `Unarchiver.Unarchive` is the single choke point that dispatches to every format handler (archives, raw, dmg, pkg), and each takes `dest` as a plain parameter, so redirecting `dest` covers all of them with no change inside `pkg/unarchive`.

Details worth noting for review:

- The temp directory lives under `rootDir` so it is on the same filesystem as the destination; renaming across drives fails on Windows. This reuses the existing `rootDir/temp` convention from `copyAquaOnWindows`.
- When the rename fails, the code asks the destination itself whether the package is now there rather than matching on the error text, which differs per platform (`ENOTEMPTY` on Linux/macOS, something else on Windows).
- A deferred `RemoveAll` means a failed or discarded extraction leaves nothing behind.

## Verification

I reproduced the reported bug and confirmed the fix against it, rather than relying on tests alone.

Installing `suzuki-shunsuke/ghtkn@v0.3.3` (whose attestation verification triggers the dedicated `cli/cli` install) together with `cli/cli@v2.96.0` into an empty aqua root, with delays inserted to make the interleaving deterministic, the pre-fix binary fails exactly as reported:

```
ERR check file_src is correct ... file_name=gh
  error="check file_src is correct: exe_path isn't found: stat .../cli/cli/v2.96.0/gh_2.96.0_macOS_arm64.zip/gh_2.96.0_macOS_arm64/bin/gh: no such file or directory"
ERR executable files aren't found
ERR aqua failed error="install packages: it failed to install some packages"
```

The log shows the mechanism: ghtkn's verification starts the dedicated `cli/cli` install (`registry=""`), and the user-managed `cli/cli` (`registry=standard`) then finds the half-extracted directory.

With this change and the same delays still in place, the install succeeds, `gh version 2.96.0` runs, and `rootDir/temp` is left empty. The delays were only scheduling nudges — no logic was altered — and were discarded afterwards.

Unit tests cover the successful install, the lost-race path (a destination another process finished first is left untouched and our copy discarded), and the failure path (the destination is not created at all, so `downloadWithRetry` will not treat the package as installed). These use the OS filesystem rather than `MemMapFs`, which happily renames onto an existing directory and so cannot exercise the lost-race case. Reverting the fix makes the lost-race test fail.

`cmdx v`, `cmdx l`, and `cmdx t` all pass, as does `go test -race` via the pre-commit hook.

## Out of scope

- `go_install` and `cargo` return earlier and build into the destination via external commands, so the same race remains there.
- `checkFileSrc` calls `createFileLink`, which writes a link inside the package directory after the rename. Two goroutines reaching this for the same package can still collide; `linker.go` checks existence first but is TOCTOU. Separate and lower severity.
- No retry in `checkFileSrc` (#553): with the rename in place the destination is never partial, so a retry would paper over a race that no longer exists.
- No singleflight. It only helps within one process, and the rename already gives correctness. The trade-off is that two concurrent installs of the same package both download and one discards its work — rare, and it keeps the change small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package installation reliability by unpacking assets safely before making them available.
  * Prevented partially extracted packages from appearing when an installation fails.
  * Preserved existing installations when another process completes the installation first.
  * Ensured temporary extraction files are cleaned up after installation attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->