### PR TITLE
fix(unarchive): expand a pkg file into a non-existent destination

### DIFF
--- a/pkg/unarchive/pkg.go
+++ b/pkg/unarchive/pkg.go
@@ -2,7 +2,9 @@ package unarchive
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"path/filepath"
 
@@ -27,6 +29,14 @@ func (u *pkgUnarchiver) Unarchive(ctx context.Context, _ *slog.Logger, src *File
 	tempFilePath, err := src.Body.Path()
 	if err != nil {
 		return fmt.Errorf("get a temporary file path: %w", err)
+	}
+
+	// pkgutil --expand-full fails with "File exists" unless the destination is
+	// absent, but the caller hands over a directory it has already created.
+	// Remove only succeeds on an empty directory, so a populated destination is
+	// never destroyed here.
+	if err := u.fs.Remove(u.dest); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("remove the destination directory before expanding a pkg file: %w", err)
 	}
 
 	if _, err := u.executor.ExecAndOutputWhenFailure(osexec.Command(ctx, "pkgutil", "--expand-full", tempFilePath, u.dest)); err != nil {

--- a/pkg/unarchive/unarchive_test.go
+++ b/pkg/unarchive/unarchive_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -331,6 +332,101 @@ func TestUnarchiver_Unarchive_pathTraversal(t *testing.T) {
 	}
 	if string(got) != "original" {
 		t.Fatalf("the outside file was modified via path traversal: %q", got)
+	}
+}
+
+// pkgutilStub stands in for the pkgutil command. It records whether the
+// destination existed when the command was invoked, then creates it as
+// "pkgutil --expand-full" does.
+type pkgutilStub struct {
+	fs          afero.Fs
+	args        []string
+	destExisted bool
+}
+
+func (e *pkgutilStub) ExecAndOutputWhenFailure(cmd *osexec.Cmd) (int, error) {
+	e.args = cmd.Args
+	dest := cmd.Args[len(cmd.Args)-1]
+	if _, err := e.fs.Stat(dest); err == nil {
+		e.destExisted = true
+	}
+	if err := e.fs.MkdirAll(dest, 0o755); err != nil {
+		return 1, fmt.Errorf("create the destination: %w", err)
+	}
+	return 0, nil
+}
+
+// newPkgFile returns a pkg format source file along with a destination
+// directory that the caller has already created, as Installer.unarchive does.
+func newPkgFile(t *testing.T, fs afero.Fs) (*unarchive.File, string) {
+	t.Helper()
+	dest := filepath.Join(t.TempDir(), "dest")
+	if err := fs.MkdirAll(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return &unarchive.File{
+		Filename: "s3deploy_2.16.0_darwin-universal.pkg",
+		Type:     unarchive.FormatPKG,
+		Body:     download.NewDownloadedFile(fs, io.NopCloser(strings.NewReader("pkg")), nil),
+	}, dest
+}
+
+// TestUnarchiver_Unarchive_pkg verifies that the destination handed to
+// "pkgutil --expand-full" does not exist when the command runs. pkgutil refuses
+// to expand into an existing path and fails with "File exists", so every pkg
+// format package failed to install once the caller started creating the
+// extraction directory itself.
+// See https://github.com/aquaproj/aqua/issues/5040
+func TestUnarchiver_Unarchive_pkg(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	logger := slog.New(slog.DiscardHandler)
+
+	fs := afero.NewOsFs()
+	src, dest := newPkgFile(t, fs)
+	executor := &pkgutilStub{fs: fs}
+
+	if err := unarchive.New(executor, fs).Unarchive(ctx, logger, src, dest); err != nil {
+		t.Fatal(err)
+	}
+
+	if executor.destExisted {
+		t.Fatal("the destination must not exist when pkgutil --expand-full is executed")
+	}
+	if len(executor.args) != 4 || executor.args[1] != "--expand-full" || executor.args[3] != dest {
+		t.Fatalf("unexpected command: %v", executor.args)
+	}
+	if f, err := afero.DirExists(fs, dest); err != nil {
+		t.Fatal(err)
+	} else if !f {
+		t.Fatal("the destination must be created by pkgutil")
+	}
+}
+
+// A destination that already holds files belongs to something else, so it must
+// not be removed to make room for pkgutil.
+func TestUnarchiver_Unarchive_pkg_destNotEmpty(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	logger := slog.New(slog.DiscardHandler)
+
+	fs := afero.NewOsFs()
+	src, dest := newPkgFile(t, fs)
+	payload := filepath.Join(dest, "Payload")
+	if err := afero.WriteFile(fs, payload, []byte("installed by someone else"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := unarchive.New(&pkgutilStub{fs: fs}, fs).Unarchive(ctx, logger, src, dest); err == nil {
+		t.Fatal("an error must be returned for a destination that is not empty")
+	}
+
+	b, err := afero.ReadFile(fs, payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != "installed by someone else" {
+		t.Fatalf("the existing file is %q, want %q", b, "installed by someone else")
 	}
 }
 


### PR DESCRIPTION
## Overview

Fixes #5040.

Since v2.62.0, installing any package with `format: pkg` on macOS fails with `Could not unarchive ... (File exists)` / `unarchive a pkg format file: exit status 1`.

#5025 changed `Installer.unarchive` to extract into a temporary directory and rename it into place. `afero.TempDir` creates that directory, and `pkgUnarchiver` passes it straight to `pkgutil --expand-full`, which requires the destination to not exist. Before #5025 the destination was the final install path, which never existed at that point, so pkgutil created it itself.

## How to fix

`pkgUnarchiver` removes the destination before running pkgutil. `Remove` only succeeds on an empty directory, so a destination that holds files is reported as an error rather than being discarded.

Expanding into a child path such as `filepath.Join(dest, "pkg")` was rejected: the destination is the package root that registry `files[].src` values are resolved against (e.g. `bep/s3deploy` declares `src: Payload/s3deploy`), so nesting one level deeper would break every pkg format package.

`dmg` is unaffected: `dmgUnarchiver` creates the destination itself and `osfile.Copy` merges into an existing directory.

## Tests

Added `TestUnarchiver_Unarchive_pkg`, which asserts the destination does not exist when the command is invoked, and `TestUnarchiver_Unarchive_pkg_destNotEmpty`, which asserts a non-empty destination is not removed. They use a stub `Executor`, so they run on Linux CI too. Both fail without this change.

Verified end to end on macOS (darwin/arm64) with a throwaway root directory:

- `bep/s3deploy@v2.16.0` (pkg): fails with the reported error on `main`, installs successfully with this change, and lands at `pkgs/.../s3deploy_2.16.0_darwin-universal.pkg/Payload/s3deploy` as before.
- `99designs/aws-vault@v7.2.0` (dmg): still installs and runs.
- The `temp` directory is left empty in both cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package archive extraction by ensuring the destination is clear before expansion.
  * Prevented existing destination contents from being overwritten when extraction cannot safely proceed.
  * Added clearer error handling for failures while preparing the destination directory.

* **Tests**
  * Added coverage for extraction into new destinations and protection of non-empty destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->