### PR TITLE
fix(installpackage): create package directories with the usual permissions

### DIFF
--- a/pkg/installpackage/download.go
+++ b/pkg/installpackage/download.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aquaproj/aqua/v2/pkg/osfile"
 	"github.com/aquaproj/aqua/v2/pkg/unarchive"
 	"github.com/schollz/progressbar/v3"
-	"github.com/spf13/afero"
 	"github.com/suzuki-shunsuke/slog-error/slogerr"
 )
 
@@ -172,7 +171,10 @@ func (is *Installer) unarchive(ctx context.Context, logger *slog.Logger, param *
 	if err := osfile.MkdirAll(is.fs, tempDir); err != nil {
 		return fmt.Errorf("create a temporary directory: %w", err)
 	}
-	tempDir, err := afero.TempDir(is.fs, tempDir, "")
+	// The directory is renamed into place as is, so it must be created with the
+	// permissions a package directory needs. afero.TempDir would create it with
+	// 0700 and leave the package unreadable to every other user.
+	tempDir, err := osfile.MkdirTemp(is.fs, tempDir)
 	if err != nil {
 		return fmt.Errorf("create a temporary directory: %w", err)
 	}

--- a/pkg/installpackage/download_internal_test.go
+++ b/pkg/installpackage/download_internal_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aquaproj/aqua/v2/pkg/config/aqua"
 	"github.com/aquaproj/aqua/v2/pkg/config/registry"
 	"github.com/aquaproj/aqua/v2/pkg/download"
+	"github.com/aquaproj/aqua/v2/pkg/osfile"
 	"github.com/aquaproj/aqua/v2/pkg/runtime"
 	"github.com/aquaproj/aqua/v2/pkg/unarchive"
 	"github.com/spf13/afero"
@@ -95,6 +96,42 @@ func TestInstaller_unarchive(t *testing.T) {
 		t.Fatalf("the executable file is %q, want %q", b, "gh")
 	}
 	assertTempDirIsEmpty(t, inst.fs, rootDir)
+}
+
+// The destination is renamed into place from a temporary directory, so it must
+// end up with the permissions aqua grants its own directories. A temporary
+// directory defaults to 0700, which would leave the package unreadable to every
+// other user.
+// See https://github.com/aquaproj/aqua/issues/5049
+func TestInstaller_unarchive_destPermission(t *testing.T) {
+	t.Parallel()
+
+	inst, rootDir, dest := newUnarchiveTestInstaller(t, nil)
+
+	if err := inst.unarchive(t.Context(), slog.New(slog.DiscardHandler), &DownloadParam{
+		Dest:  dest,
+		Asset: "gh_2.96.0_linux_amd64.tar.gz",
+	}, nil, "tar.gz"); err != nil {
+		t.Fatal(err)
+	}
+
+	// The expectation is a directory created the way aqua creates its own, so
+	// that neither the umask nor the platform's handling of modes matters.
+	want := filepath.Join(rootDir, "reference")
+	if err := osfile.MkdirAll(inst.fs, want); err != nil {
+		t.Fatal(err)
+	}
+	wantInfo, err := inst.fs.Stat(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotInfo, err := inst.fs.Stat(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotInfo.Mode().Perm() != wantInfo.Mode().Perm() {
+		t.Fatalf("the permission of the package directory is %o, want %o", gotInfo.Mode().Perm(), wantInfo.Mode().Perm())
+	}
 }
 
 // A package another process finished extracting first must be left alone, and

--- a/pkg/osfile/mkdir.go
+++ b/pkg/osfile/mkdir.go
@@ -1,7 +1,35 @@
 package osfile
 
-import "github.com/spf13/afero"
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/afero"
+)
 
 func MkdirAll(fs afero.Fs, p string) error {
 	return fs.MkdirAll(p, dirPermission) //nolint:wrapcheck
+}
+
+// MkdirTemp creates a directory with a random name in dir and returns its path.
+// The parent directory dir must exist.
+//
+// It is afero.TempDir with the permissions aqua grants its own directories.
+// afero.TempDir hardcodes 0700 and ignores the umask, which is too strict for a
+// directory that is later renamed into place and read by other users.
+func MkdirTemp(fs afero.Fs, dir string) (string, error) {
+	b := make([]byte, 16) //nolint:mnd
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate a random directory name: %w", err)
+	}
+	// Mkdir rather than MkdirAll: a name that is already taken, by a leftover
+	// directory or by another user in a shared root directory, must be an error
+	// rather than a directory shared with whatever created it.
+	p := filepath.Join(dir, hex.EncodeToString(b))
+	if err := fs.Mkdir(p, dirPermission); err != nil {
+		return "", fmt.Errorf("create a directory: %w", err)
+	}
+	return p, nil
 }


### PR DESCRIPTION
## Overview

Fixes #5049.

Since v2.62.0, package directories under `$AQUA_ROOT_DIR/pkgs` are created with mode `0700` instead of `0775 & ~umask`. #5025 started extracting into a temporary directory created by `afero.TempDir`, which hardcodes `0700` and ignores the umask, and that mode survives the rename into the package directory. Before #5025 the destination was created by the unarchivers via `osfile.MkdirAll`.

This breaks setups where the root dir is shared between users, such as a Docker image whose packages are installed as `root` and which runs as a non-root user: packages installed by v2.62.0 are inaccessible, while packages installed by older versions keep working.

`pkg` and `dmg` packages were not affected, because `pkgutil` creates the directory itself and the dmg unarchiver copies the mode of the mounted image onto the destination. Every other format was.

## How to fix

Add `osfile.MkdirTemp`, which is `afero.TempDir` with the permissions aqua grants its own directories (`dirPermission`, subject to the umask), and use it in `Installer.unarchive`. It uses `Mkdir` rather than `MkdirAll`, so a name that is already taken is an error rather than a directory shared with whatever created it.

A `chmod` after the fact would not be equivalent, because chmod ignores the umask and would leave the directory group-writable under the usual umask 022.

## Tests

Added `TestInstaller_unarchive_destPermission`, which compares the mode of the package directory with a directory created by `osfile.MkdirAll` in the same test, so neither the umask nor the platform's handling of modes affects the result. It fails without this change (`700`, want `755`).

Verified end to end on macOS (darwin/arm64, umask 022) with a throwaway root dir, installing `cli/cli` (zip), `bep/s3deploy` (pkg) and `99designs/aws-vault` (dmg): every package directory, including `aqua-proxy` (tar.gz), is now `drwxr-xr-x`, the binaries run, and `$AQUA_ROOT_DIR/temp` is left empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package installation so temporary extraction directories use the expected directory permissions.
  * Ensured installed package destinations retain consistent permissions with other application-created directories.

* **Tests**
  * Added coverage to verify directory permissions remain consistent during package extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->