### PR TITLE
docs: fix the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Declarative CLI Version Manager written in Go.
 - Secure
 - Easy to use
 
-[![Star History Chart](https://api.star-history.com/svg?repos=aquaproj/aqua&type=Date)](https://star-history.com/#aquaproj/aqua&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=aquaproj/aqua&type=Date)](https://star-history.dera.page/#aquaproj/aqua&Date)
 
 ## Who uses aqua?
 


### PR DESCRIPTION
The star history chart in the README is currently broken and does not render. This change points the chart at a working server with the same data source, so the chart is displayed correctly again.

The badge is left unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Star History Chart badge and link to use the current Star History website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->