### PR TITLE
feat: create timestamp files as group writable and document read only $AQUA_ROOT_DIR

### DIFF
--- a/pkg/vacuum/client.go
+++ b/pkg/vacuum/client.go
@@ -15,7 +15,12 @@ import (
 )
 
 const (
-	filePermission = 0o644
+	// filePermission is group writable so that several users can update the same
+	// timestamp file if they share $AQUA_ROOT_DIR. A file created with 0o644
+	// can't be updated by other users, and umask can't add the permission.
+	// Note that umask still removes the permission, so this doesn't grant it to
+	// users whose umask is 0o022.
+	filePermission = 0o664
 	fileName       = "timestamp.txt"
 	baseDir        = "metadata"
 )

--- a/website/docs/guides/vacuum.md
+++ b/website/docs/guides/vacuum.md
@@ -47,20 +47,63 @@ aqua vacuum --init
 `aqua vacuum --init` can't record date times of install packages which are not found in aqua.yaml.
 If you want to record their date times, you need to remove them by `aqua rm` command and re-install them.
 
-## Disable tracking
+## Read only `$AQUA_ROOT_DIR`
+
+Sometimes `$AQUA_ROOT_DIR` is read only for users.
+For instance, an administrator installs packages in a shared directory such as `/opt/aqua` and other users only execute them.
+
+In that case aqua fails to record last used date times and outputs a warning log every time packages are executed.
+
+```
+WRN update the last used datetime ... error="update the last used datetime: create a package timestamp file: open /opt/aqua/metadata/pkgs/http/get.helm.sh/helm-v4.2.3-linux-amd64.tar.gz/timestamp.txt: permission denied"
+```
+
+There are two solutions.
+[Granting write permission](#grant-write-permission-to-the-metadata-directory) is better if it's acceptable, because [disabling tracking](#disable-tracking) makes `aqua vacuum` unavailable for everyone including the administrator.
+
+### Grant write permission to the metadata directory
 
 `aqua >= v2.63.0`
 
-If the environment variable `AQUA_DISABLE_TRACKING` is `true`, aqua doesn't record packages' last used date times.
+aqua records last used date times in `$AQUA_ROOT_DIR/metadata`, which is separated from installed packages in `$AQUA_ROOT_DIR/pkgs`.
+So you can allow users to record last used date times while keeping installed packages read only.
+
+```sh
+sudo chgrp -R aqua /opt/aqua/metadata
+sudo chmod -R g+w /opt/aqua/metadata
+sudo find /opt/aqua/metadata -type d -exec chmod g+s {} +
+```
+
+Users need to belong to the group and to set `umask` to `0002`, because aqua creates timestamp files and directories with `0664` and `0775` and `umask` removes the group write permission.
+
+```sh
+umask 0002
+```
+
+The administrator needs to set `umask` too when installing packages.
+aqua records the last used date time when it installs a package, so timestamp files of newly installed packages are created by the administrator.
+Users can't update them if they aren't group writable.
+
+Warning logs go away, and the administrator can run `aqua vacuum` based on the actual usage of all users.
+
+:::info
+aqua < v2.63.0 creates timestamp files with `0644`, so a timestamp file created by a user can't be updated by other users.
+:::
+
+### Disable tracking
+
+`aqua >= v2.63.0`
+
+If you can't grant write permission, for instance because `$AQUA_ROOT_DIR` is on a read only file system, you can disable the tracking of last used date times.
+If the environment variable `AQUA_DISABLE_TRACKING` is `true`, aqua doesn't record packages' last used date times, so the warning logs go away.
 
 ```sh
 export AQUA_DISABLE_TRACKING=true
 ```
 
-This is useful if `$AQUA_ROOT_DIR` is read only.
-For instance, an administrator installs packages in a shared directory and other users only execute them.
-In that case aqua fails to record last used date times and outputs warning logs every time packages are executed.
-`AQUA_DISABLE_TRACKING` suppresses those warning logs.
+:::caution
+Last used date times aren't recorded while `AQUA_DISABLE_TRACKING` is set, so the administrator can't remove unused packages based on the actual usage either.
+:::
 
 `aqua vacuum` and `aqua vacuum --init` fail while `AQUA_DISABLE_TRACKING` is set.
 

--- a/website/docs/reference/codes/007.md
+++ b/website/docs/reference/codes/007.md
@@ -39,3 +39,6 @@ Please run `aqua vacuum --init` to record the current date time as the last used
 ```console
 $ aqua vacuum --init
 ```
+
+If `AQUA_DISABLE_TRACKING` is set because `$AQUA_ROOT_DIR` isn't writable, [granting write permission to the metadata directory](/docs/guides/vacuum#grant-write-permission-to-the-metadata-directory) is a better solution.
+Then aqua records last used date times without making `$AQUA_ROOT_DIR/pkgs` writable, and `aqua vacuum` remains available.

--- a/website/docs/reference/config/index.md
+++ b/website/docs/reference/config/index.md
@@ -42,7 +42,7 @@ To install tools in global configuration files, you have to set `-a` to `aqua in
 * [`AQUA_DISABLE_GITHUB_ARTIFACT_ATTESTATION`: `aqua >= v2.35.0` If true, the verification using GitHub Artifact Attestations is disabled](/docs/reference/security/github-artifact-attestations#disable-the-verification-of-github-artifact-attestations)
 * `AQUA_DISABLE_POLICY`: If true, [Policy](/docs/reference/security/policy-as-code) is disabled (aqua >= v2.1.0)
 * `AQUA_DISABLE_LAZY_INSTALL`: If true, [Lazy Install](/docs/reference/lazy-install/) is disabled (aqua >= v2.9.0)
-* `AQUA_DISABLE_TRACKING`: If true, aqua doesn't record packages' last used date times and the [aqua vacuum](/docs/guides/vacuum#disable-tracking) command fails (aqua >= v2.63.0)
+* `AQUA_DISABLE_TRACKING`: If true, aqua doesn't record packages' last used date times and the [aqua vacuum](/docs/guides/vacuum#disable-tracking) command fails. This is a solution for [read only `$AQUA_ROOT_DIR`](/docs/guides/vacuum#read-only-aqua_root_dir) (aqua >= v2.63.0)
 * `AQUA_ROOT_DIR`: The directory path where aqua install tools
   * default (linux and macOS): `${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua`
   * default (windows): `${HOME/AppData/Local}/aquaproj-aqua`


### PR DESCRIPTION
A follow-up of #5115.

## Background

#5115 added `AQUA_DISABLE_TRACKING` for a read only `$AQUA_ROOT_DIR`, but it isn't the only solution and it isn't the best one when it can be avoided.

aqua records last used date times in `$AQUA_ROOT_DIR/metadata`, which is separated from installed packages in `$AQUA_ROOT_DIR/pkgs`. So an administrator can grant write permission to the metadata directory only. Then warning logs go away without making installed packages writable, and the administrator can still run `aqua vacuum` based on the actual usage.

`AQUA_DISABLE_TRACKING` gives up the usage records, so the administrator can't remove unused packages based on the actual usage either. It should be a fallback for the case where no write permission can be granted at all, such as a read only file system.

## Create timestamp files as group writable

Timestamp files were created with `0o644`, so a timestamp file created by a user couldn't be updated by other users sharing `$AQUA_ROOT_DIR`. The second user got exactly the same warning as #5110. `umask` can't add a permission, so it couldn't be worked around by the administrator.

They are created with `0o664` now. Directories have been created with `0o775` already (`pkg/osfile/const.go`).

This doesn't change anything for users whose `umask` is `0o022`, because `umask` still removes the group write permission. Verified with `umask 0`:

```
file mode: 664
dir mode: 775
```

The scope is limited to vacuum's timestamp files. `osfile.FilePermission` isn't changed because it's used for other files including executable files and configuration files.

## Docs

`website/docs/guides/vacuum.md` had a section which only described `AQUA_DISABLE_TRACKING`. It's restructured into a section about a read only `$AQUA_ROOT_DIR` with the two solutions, so that users don't give up the usage records unnecessarily.

The permission recipe documents two things which are easy to miss:

- Users need `umask 0002`, because aqua creates timestamp files and directories with `0664` and `0775`
- The administrator needs `umask 0002` too when installing packages, because aqua records the last used date time on installation, so timestamp files of newly installed packages are created by the administrator

`website/docs/reference/codes/007.md` also refers to the permission solution now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp tracking for shared-user environments by allowing group write access.

* **Documentation**
  * Added guidance for using aqua with read-only root directories.
  * Documented recommended metadata directory permissions and setup commands.
  * Clarified tracking warnings, disabling tracking, and vacuum availability.
  * Added guidance to avoid making package directories writable when enabling tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->