### PR TITLE
fix: filter prerelease tags in github_tag version getter

### DIFF
--- a/pkg/versiongetter/github_tag.go
+++ b/pkg/versiongetter/github_tag.go
@@ -105,6 +105,10 @@ func (g *GitHubTagVersionGetter) List(ctx context.Context, logger *slog.Logger, 
 
 func filterTag(logger *slog.Logger, tag *github.RepositoryTag, filters []*Filter) bool {
 	tagName := tag.GetName()
+	v, _, _ := GetVersionAndPrefix(tagName)
+	if v != nil && v.Prerelease() != "" {
+		return false
+	}
 	for _, filter := range filters {
 		if matchTagByFilter(logger, tagName, filter) {
 			return !filter.NoAsset

--- a/pkg/versiongetter/github_tag_test.go
+++ b/pkg/versiongetter/github_tag_test.go
@@ -45,6 +45,114 @@ func TestGitHubTagVersionGetter_Get(t *testing.T) {
 			},
 			version: "v3.0.0",
 		},
+		{
+			name: "prereleases dominated page 1, stable on page 2",
+			filters: []*versiongetter.Filter{
+				{},
+			},
+			tags: map[string][]*github.RepositoryTag{
+				"testuser/testpkg": {
+					{
+						Name: new("v1.0.1-beta.30"),
+					},
+					{
+						Name: new("v1.0.1-beta.29"),
+					},
+					{
+						Name: new("v1.0.1-beta.28"),
+					},
+					{
+						Name: new("v1.0.1-beta.27"),
+					},
+					{
+						Name: new("v1.0.1-beta.26"),
+					},
+					{
+						Name: new("v1.0.1-beta.25"),
+					},
+					{
+						Name: new("v1.0.1-beta.24"),
+					},
+					{
+						Name: new("v1.0.1-beta.23"),
+					},
+					{
+						Name: new("v1.0.1-beta.22"),
+					},
+					{
+						Name: new("v1.0.1-beta.21"),
+					},
+					{
+						Name: new("v1.0.1-beta.20"),
+					},
+					{
+						Name: new("v1.0.1-beta.19"),
+					},
+					{
+						Name: new("v1.0.1-beta.18"),
+					},
+					{
+						Name: new("v1.0.1-beta.17"),
+					},
+					{
+						Name: new("v1.0.1-beta.16"),
+					},
+					{
+						Name: new("v1.0.1-beta.15"),
+					},
+					{
+						Name: new("v1.0.1-beta.14"),
+					},
+					{
+						Name: new("v1.0.1-beta.13"),
+					},
+					{
+						Name: new("v1.0.1-beta.12"),
+					},
+					{
+						Name: new("v1.0.1-beta.11"),
+					},
+					{
+						Name: new("v1.0.1-beta.10"),
+					},
+					{
+						Name: new("v1.0.1-beta.9"),
+					},
+					{
+						Name: new("v1.0.1-beta.8"),
+					},
+					{
+						Name: new("v1.0.1-beta.7"),
+					},
+					{
+						Name: new("v1.0.1-beta.6"),
+					},
+					{
+						Name: new("v1.0.1-beta.5"),
+					},
+					{
+						Name: new("v1.0.1-beta.4"),
+					},
+					{
+						Name: new("v1.0.1-beta.3"),
+					},
+					{
+						Name: new("v1.0.1-beta.2"),
+					},
+					{
+						Name: new("v1.0.1-beta.1"),
+					},
+					{
+						Name: new("v1.0.0"),
+					},
+				},
+			},
+			pkg: &registry.PackageInfo{
+				RepoOwner: "testuser",
+				RepoName:  "testpkg",
+			},
+			version: "v1.0.0",
+		},
 	}
 
 	for _, d := range data {

--- a/pkg/versiongetter/mock_github_tag.go
+++ b/pkg/versiongetter/mock_github_tag.go
@@ -23,7 +23,14 @@ func (g *MockGitHubTagClient) ListTags(ctx context.Context, owner string, repo s
 	if !ok {
 		return nil, nil, errors.New("repository is not found")
 	}
-	m := min((opts.Page+1)*opts.PerPage, len(tags))
+	start := opts.Page * opts.PerPage
+	end := min(start+opts.PerPage, len(tags))
+	if start >= len(tags) {
+		return nil, &github.Response{}, nil
+	}
 	resp := &github.Response{}
-	return tags[opts.Page*opts.PerPage : m], resp, nil
+	if end < len(tags) {
+		resp.NextPage = opts.Page + 1
+	}
+	return tags[start:end], resp, nil
 }


### PR DESCRIPTION
filterTag in github_tag.go did not auto-reject prerelease tags the way filterRelease does in github_release.go. When more than PerPage prerelease tags accumulate before a stable release, Get() short-circuits on page 1 and returns the highest prerelease instead of finding the stable version on page 2.

Adds a prerelease check to filterTag and a regression test for the pagination edge case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prerelease tags are now excluded when selecting stable versions, even when they appear before the stable release in tag listings.
  * Version lookup now handles paginated tag results correctly.
  * Requests beyond the available tag pages return an empty result instead of failing.

* **Tests**
  * Added coverage for stable version selection after multiple prerelease tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->