### PR TITLE
feat: fall back to a system-installed minisign when aqua doesn't manage one

### DIFF
--- a/pkg/installpackage/verify_minisign.go
+++ b/pkg/installpackage/verify_minisign.go
@@ -27,19 +27,37 @@ func (s *minisignVerifier) Enabled(logger *slog.Logger) (bool, error) {
 	}
 
 	mPkg := minisign.Package()
-	if f, err := mPkg.PackageInfo.CheckSupported(s.runtime, s.runtime.Env()); err != nil {
+	f, err := mPkg.PackageInfo.CheckSupported(s.runtime, s.runtime.Env())
+	if err != nil {
 		return false, fmt.Errorf("check if minisign supports this environment: %w", err)
-	} else if !f {
-		logger.Warn("minisign doesn't support this environment")
-		return false, nil
 	}
+	if f {
+		return true, nil
+	}
+
+	// aqua doesn't manage a minisign binary for this environment, but
+	// verification is still possible with a minisign command installed on the system.
+	if _, err := minisign.LookSystemExe(); err != nil {
+		logger.Warn("minisign doesn't support this environment and minisign isn't found in PATH")
+		return false, nil //nolint:nilerr
+	}
+	logger.Debug("aqua doesn't manage minisign in this environment; using the minisign found in PATH")
 	return true, nil
 }
 
 func (s *minisignVerifier) Verify(ctx context.Context, logger *slog.Logger, file string) error {
 	logger.Info("verify a package with minisign")
-	if err := s.installer.install(ctx, logger); err != nil {
-		return fmt.Errorf("install minisign: %w", err)
+
+	// aqua's managed minisign is only installed for environments it supports.
+	// Otherwise verification relies on a minisign command installed on the system.
+	supported, err := minisign.Package().PackageInfo.CheckSupported(s.runtime, s.runtime.Env())
+	if err != nil {
+		return fmt.Errorf("check if minisign supports this environment: %w", err)
+	}
+	if supported {
+		if err := s.installer.install(ctx, logger); err != nil {
+			return fmt.Errorf("install minisign: %w", err)
+		}
 	}
 
 	pkg := s.pkg

--- a/pkg/installpackage/verify_minisign_internal_test.go
+++ b/pkg/installpackage/verify_minisign_internal_test.go
@@ -1,0 +1,89 @@
+package installpackage
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	goruntime "runtime"
+	"testing"
+
+	"github.com/aquaproj/aqua/v2/pkg/config/registry"
+	"github.com/aquaproj/aqua/v2/pkg/runtime"
+)
+
+func writeFakeMinisign(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "minisign"), []byte("#!/bin/sh\n"), 0o755); err != nil { //nolint:gosec
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func Test_minisignVerifier_Enabled(t *testing.T) { //nolint:funlen
+	enabled := true
+	disabled := false
+	// linux/amd64 is one of the environments aqua manages a minisign binary for,
+	// while linux/arm64 is not.
+	supportedRT := &runtime.Runtime{GOOS: "linux", GOARCH: "amd64"}
+	unsupportedRT := &runtime.Runtime{GOOS: "linux", GOARCH: "arm64"}
+
+	data := []struct {
+		name       string
+		rt         *runtime.Runtime
+		minisign   *registry.Minisign
+		pathHasExe bool
+		want       bool
+	}{
+		{
+			name:     "disabled",
+			rt:       supportedRT,
+			minisign: &registry.Minisign{Enabled: &disabled},
+			want:     false,
+		},
+		{
+			name:     "supported environment",
+			rt:       supportedRT,
+			minisign: &registry.Minisign{Enabled: &enabled},
+			want:     true,
+		},
+		{
+			name:       "unsupported environment falls back to a system minisign",
+			rt:         unsupportedRT,
+			minisign:   &registry.Minisign{Enabled: &enabled},
+			pathHasExe: true,
+			want:       true,
+		},
+		{
+			name:     "unsupported environment without a system minisign",
+			rt:       unsupportedRT,
+			minisign: &registry.Minisign{Enabled: &enabled},
+			want:     false,
+		},
+	}
+
+	logger := slog.New(slog.DiscardHandler)
+	for _, d := range data {
+		t.Run(d.name, func(t *testing.T) {
+			if d.pathHasExe && goruntime.GOOS == "windows" {
+				t.Skip("executable resolution on Windows depends on PATHEXT")
+			}
+			if d.pathHasExe {
+				t.Setenv("PATH", writeFakeMinisign(t))
+			} else {
+				t.Setenv("PATH", t.TempDir())
+			}
+			s := &minisignVerifier{
+				runtime:  d.rt,
+				minisign: d.minisign,
+			}
+			got, err := s.Enabled(logger)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != d.want {
+				t.Fatalf("Enabled() = %v, want %v", got, d.want)
+			}
+		})
+	}
+}

--- a/pkg/minisign/exec.go
+++ b/pkg/minisign/exec.go
@@ -42,8 +42,18 @@ func NewExecutor(logger *slog.Logger, executor CommandExecutor, param *config.Pa
 		return nil, fmt.Errorf("check if the package is supported in the environment: %w", err)
 	}
 	if !supported {
-		logger.Debug("the package isn't supported in the environment")
-		return nil, nil //nolint:nilnil
+		// aqua doesn't manage a minisign binary for this environment.
+		// Fall back to a minisign command installed on the system (e.g. via a package manager).
+		exePath, err := LookSystemExe()
+		if err != nil {
+			logger.Debug("aqua doesn't manage minisign in this environment and minisign isn't found in PATH")
+			return nil, nil //nolint:nilnil,nilerr
+		}
+		logger.Debug("aqua doesn't manage minisign in this environment; using the minisign found in PATH", "minisign_path", exePath)
+		return &ExecutorImpl{
+			executor:        executor,
+			minisignExePath: exePath,
+		}, nil
 	}
 	pkg.PackageInfo = pkgInfo
 	exePath, err := pkg.ExePath(param.RootDir, pkgInfo.GetFiles()[0], rt)

--- a/pkg/minisign/system.go
+++ b/pkg/minisign/system.go
@@ -1,0 +1,17 @@
+package minisign
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+// LookSystemExe searches for a minisign command installed on the system and
+// returns its path. It is used as a fallback for environments where aqua
+// doesn't manage a minisign binary of its own.
+func LookSystemExe() (string, error) {
+	p, err := exec.LookPath(pkgName)
+	if err != nil {
+		return "", fmt.Errorf("look for minisign in PATH: %w", err)
+	}
+	return p, nil
+}

--- a/pkg/minisign/system_test.go
+++ b/pkg/minisign/system_test.go
@@ -1,0 +1,37 @@
+package minisign_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/aquaproj/aqua/v2/pkg/minisign"
+)
+
+func TestLookSystemExe(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executable resolution on Windows depends on PATHEXT")
+	}
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "minisign")
+	if err := os.WriteFile(exe, []byte("#!/bin/sh\n"), 0o755); err != nil { //nolint:gosec
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+
+	got, err := minisign.LookSystemExe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != exe {
+		t.Fatalf("LookSystemExe() = %q, want %q", got, exe)
+	}
+}
+
+func TestLookSystemExe_notFound(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	if _, err := minisign.LookSystemExe(); err == nil {
+		t.Fatal("an error must be returned when minisign isn't installed on the system")
+	}
+}

--- a/website/docs/reference/security/minisign.md
+++ b/website/docs/reference/security/minisign.md
@@ -10,6 +10,10 @@ sidebar_position: 1250
 aqua supports verifying packages with [minisign](https://github.com/jedisct1/minisign) to install some packages securely.
 For example, [zig](https://ziglang.org/download/) is signed by minisign.
 
+To verify signatures aqua installs and runs minisign itself.
+In environments where aqua doesn't provide a minisign binary (for example `linux/arm64`), aqua looks for a `minisign` command in `PATH` and uses it instead, so you can still verify packages by installing minisign yourself (e.g. with a package manager).
+If minisign isn't managed by aqua and isn't found in `PATH`, the verification is skipped.
+
 ## Example
 
 ```yaml


### PR DESCRIPTION
Closes #4924.

aqua installs and runs minisign to verify signatures, but it only ships a managed minisign for a few environments (`darwin/arm64`, `linux/amd64`, `windows`). On anything else, such as `linux/arm64`, `minisignVerifier.Enabled` returned false and minisign verification was silently skipped even when a package configured it.

Following your suggestion on the issue to fall back to `exec.LookPath`, this looks for a `minisign` command in `PATH` in exactly those cases and uses it, so people on those platforms can still verify by installing minisign themselves (e.g. with a package manager). Environments where aqua already manages minisign are untouched: they keep downloading and using the managed binary, and `PATH` is never consulted there. If minisign is neither managed by aqua nor found in `PATH`, verification is skipped just like before.

I added unit tests for the PATH lookup and for the enable/fallback decision across supported and unsupported environments, plus a short note on the minisign docs page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Minisign verification now falls back to a system-installed executable when the managed binary is unavailable.
  * Verification is automatically skipped with a warning when no usable Minisign executable is found.

* **Documentation**
  * Added documentation describing Minisign verification and fallback behavior.

* **Tests**
  * Added coverage for managed, system-installed, and unavailable Minisign scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->