### PR TITLE
feat: support Go build tags in go_build packages

### DIFF
--- a/json-schema/registry.json
+++ b/json-schema/registry.json
@@ -208,6 +208,12 @@
         },
         "hard": {
           "type": "boolean"
+        },
+        "build_tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": false,

--- a/pkg/config/registry/config.go
+++ b/pkg/config/registry/config.go
@@ -30,6 +30,9 @@ type File struct {
 	Link string `yaml:",omitempty" json:"link,omitempty"`
 	// Hard indicates whether to create a hard link instead of a symbolic link.
 	Hard bool `yaml:",omitempty" json:"hard,omitempty"`
+	// BuildTags is a list of Go build tags passed to "go build -tags".
+	// Only the go_build package type uses this field.
+	BuildTags []string `yaml:"build_tags,omitempty" json:"build_tags,omitempty"`
 }
 
 // ToMap converts the PackageInfos slice to a map indexed by package name.

--- a/pkg/installpackage/check_file.go
+++ b/pkg/installpackage/check_file.go
@@ -104,8 +104,9 @@ func (is *Installer) checkFileSrcGo(ctx context.Context, logger *slog.Logger, pk
 	logger.Info("building Go tool",
 		"exe_path", exePath,
 		"go_src", src,
-		"go_build_dir", exeDir)
-	if err := is.goBuildInstaller.Install(ctx, exePath, exeDir, src); err != nil {
+		"go_build_dir", exeDir,
+		"go_build_tags", file.BuildTags)
+	if err := is.goBuildInstaller.Install(ctx, exePath, exeDir, src, file.BuildTags); err != nil {
 		return "", fmt.Errorf("build Go tool: %w", err)
 	}
 	return exePath, nil

--- a/pkg/installpackage/go_build.go
+++ b/pkg/installpackage/go_build.go
@@ -3,12 +3,13 @@ package installpackage
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/aquaproj/aqua/v2/pkg/osexec"
 )
 
 type GoBuildInstaller interface {
-	Install(ctx context.Context, exePath, exeDir, src string) error
+	Install(ctx context.Context, exePath, exeDir, src string, buildTags []string) error
 }
 
 type GoBuildInstallerImpl struct {
@@ -21,8 +22,13 @@ func NewGoBuildInstallerImpl(exec Executor) *GoBuildInstallerImpl {
 	}
 }
 
-func (is *GoBuildInstallerImpl) Install(ctx context.Context, exePath, exeDir, src string) error {
-	cmd := osexec.Command(ctx, "go", "build", "-o", exePath, src)
+func (is *GoBuildInstallerImpl) Install(ctx context.Context, exePath, exeDir, src string, buildTags []string) error {
+	args := []string{"build"}
+	if len(buildTags) > 0 {
+		args = append(args, "-tags", strings.Join(buildTags, ","))
+	}
+	args = append(args, "-o", exePath, src)
+	cmd := osexec.Command(ctx, "go", args...)
 	cmd.Dir = exeDir
 	if _, err := is.exec.ExecStderr(cmd); err != nil {
 		return fmt.Errorf("build a go package: %w", err)

--- a/pkg/installpackage/go_build_internal_test.go
+++ b/pkg/installpackage/go_build_internal_test.go
@@ -1,0 +1,62 @@
+package installpackage
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aquaproj/aqua/v2/pkg/osexec"
+)
+
+type spyExecutor struct {
+	args []string
+}
+
+func (e *spyExecutor) ExecStderr(cmd *osexec.Cmd) (int, error) {
+	e.args = cmd.Args
+	return 0, nil
+}
+
+func (e *spyExecutor) ExecAndOutputWhenFailure(cmd *osexec.Cmd) (int, error) {
+	e.args = cmd.Args
+	return 0, nil
+}
+
+func TestGoBuildInstallerImpl_Install(t *testing.T) {
+	t.Parallel()
+	data := []struct {
+		name      string
+		buildTags []string
+		exp       string
+	}{
+		{
+			name: "no build tags",
+			exp:  "go build -o /root/bin/foo ./cmd/foo",
+		},
+		{
+			name:      "single build tag",
+			buildTags: []string{"containers_image_openpgp"},
+			exp:       "go build -tags containers_image_openpgp -o /root/bin/foo ./cmd/foo",
+		},
+		{
+			name:      "multiple build tags are comma separated",
+			buildTags: []string{"containers_image_openpgp", "exclude_graphdriver_btrfs"},
+			exp:       "go build -tags containers_image_openpgp,exclude_graphdriver_btrfs -o /root/bin/foo ./cmd/foo",
+		},
+	}
+	for _, d := range data {
+		t.Run(d.name, func(t *testing.T) {
+			t.Parallel()
+			exec := &spyExecutor{}
+			is := NewGoBuildInstallerImpl(exec)
+			if err := is.Install(context.Background(), "/root/bin/foo", "/root/src", "./cmd/foo", d.buildTags); err != nil {
+				t.Fatal(err)
+			}
+			// cmd.Args[0] is the resolved path of the go binary, so compare the rest.
+			got := "go " + strings.Join(exec.args[1:], " ")
+			if got != d.exp {
+				t.Fatalf("got %q, wanted %q", got, d.exp)
+			}
+		})
+	}
+}

--- a/pkg/installpackage/mock_go_build.go
+++ b/pkg/installpackage/mock_go_build.go
@@ -8,6 +8,6 @@ type MockGoBuildInstaller struct {
 	Err error
 }
 
-func (m *MockGoBuildInstaller) Install(ctx context.Context, exePath, exeDir, src string) error {
+func (m *MockGoBuildInstaller) Install(ctx context.Context, exePath, exeDir, src string, buildTags []string) error {
 	return m.Err
 }

--- a/website/docs/reference/registry-config/go-build-package.md
+++ b/website/docs/reference/registry-config/go-build-package.md
@@ -53,6 +53,7 @@ packages:
 * name: command name
 * dir: Directory path where `go build` is run
 * src: go build's target path
+* build_tags: Go build tags passed to `go build -tags`
 
 ```
 ${AQUA_ROOT_DIR}/pkgs/go_build/github.com/google/wire/v0.5.0/
@@ -61,3 +62,37 @@ ${AQUA_ROOT_DIR}/pkgs/go_build/github.com/google/wire/v0.5.0/
     wire-0.5.0/ # `go build` is run on this directory
       cmd/wire # build target
 ```
+
+## `build_tags`
+
+Some Go programs need build tags to compile without external C libraries.
+`build_tags` passes the tags to `go build -tags`.
+
+e.g. https://github.com/podman-container-tools/skopeo
+
+```yaml
+packages:
+  - type: go_build
+    repo_owner: podman-container-tools
+    repo_name: skopeo
+    description: Work with remote image registries
+    files:
+      - name: skopeo
+        src: ./cmd/skopeo
+        dir: skopeo-{{trimV .Version}}
+        build_tags:
+          - containers_image_openpgp
+          - exclude_graphdriver_btrfs
+```
+
+aqua joins the tags with a comma and runs:
+
+```sh
+go build -tags containers_image_openpgp,exclude_graphdriver_btrfs -o <exe_path> ./cmd/skopeo
+```
+
+Without these tags, skopeo imports `github.com/proglottis/gpgme`, which
+requires the system library `libgpgme` and `pkg-config`. The tags remove the
+dependency from the import graph, so the build needs no external library.
+
+If `build_tags` is empty, aqua does not pass `-tags`.


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: #5134
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->

Closes #5134

## What this changes

Add a `build_tags` field to the `files` of `go_build` packages. aqua joins the
tags with a comma and passes them to `go build -tags`.

```yaml
files:
  - name: skopeo
    src: ./cmd/skopeo
    dir: skopeo-{{trimV .Version}}
    build_tags:
      - containers_image_openpgp
      - exclude_graphdriver_btrfs
```

**If `build_tags` is empty, the command is byte for byte what it is today.**
A test case covers that case so the default path cannot regress.

## Why

Some Go programs need build tags to compile without external C libraries, so
`go_build` cannot install them at all today. See #5134 for the full analysis.

Short version, using [skopeo](https://github.com/podman-container-tools/skopeo):
it publishes no release assets on any tag, so only `go_build` applies. Without
tags it imports `github.com/proglottis/gpgme`, which declares
`// #cgo pkg-config: gpgme`, so the build needs `pkg-config` and `libgpgme` on
every user's machine. skopeo's own Makefile uses
`exclude_graphdriver_btrfs containers_image_openpgp` for the portable build.

Build tags alone are enough. With the tags applied gpgme leaves the import
graph, so pkg-config never runs and no `CGO_ENABLED` handling is needed. That
keeps this change to passing one flag.

## Verification

End to end with the patched aqua, on a machine with gpgme hidden
(`PKG_CONFIG_LIBDIR=/nonexistent`, no `gpgme-config` on `PATH`, fresh
`GOCACHE`). Same binary and same machine for both runs; only the new field
differs.

With `build_tags`:

```console
$ aqua install
INF download and unarchive the package package_name=podman-container-tools/skopeo package_version=v1.24.0
INF building Go tool ... go_src=./cmd/skopeo go_build_tags="[containers_image_openpgp exclude_graphdriver_btrfs]"
$ echo $?
0

$ .../pkgs/go_build/github.com/podman-container-tools/skopeo/v1.24.0/bin/skopeo --version
skopeo version 1.24.0

$ skopeo --override-os linux inspect --no-creds docker://busybox
{
    "Name": "docker.io/library/busybox",
    "Digest": "sha256:dc2d74b28e4cf8984fa52af1f39bc7c3d9c73760b41a74d629f5d11b1ab28616",
...
```

`otool -L` on the built binary shows only OS libraries, so it is
self-contained.

Without `build_tags` (negative control, identical otherwise):

```console
$ aqua install
# github.com/proglottis/gpgme
# [pkg-config --cflags  -- gpgme]
Package gpgme was not found in the pkg-config search path.
Package 'gpgme' not found
ERR check file_src is correct ... error="build Go tool: build a go package: exit status 1"
$ echo $?
1
```

The `build:` fallback path also passes the tags through. Same hidden-gpgme
environment, running on darwin with `supported_envs: [linux]` so the fallback
triggers:

```yaml
  - type: github_release
    repo_owner: podman-container-tools
    repo_name: skopeo
    asset: skopeo-{{.OS}}-{{.Arch}}
    format: raw
    supported_envs:
      - linux
    build:
      type: go_build
      files:
        - name: skopeo
          src: ./cmd/skopeo
          dir: skopeo-{{trimV .Version}}
          build_tags:
            - containers_image_openpgp
            - exclude_graphdriver_btrfs
```

```console
INF building Go tool ... go_build_tags="[containers_image_openpgp exclude_graphdriver_btrfs]"
$ echo $?
0
$ skopeo --version
skopeo version 1.24.0
```

Project checks:

```console
$ go test ./... -race -covermode=atomic   # pass
$ go vet ./...                            # clean
$ golangci-lint run                       # 0 issues.
$ gofumpt -l pkg/                          # no output
```

`json-schema/registry.json` is regenerated with `go run ./cmd/gen-jsonschema`.

## A question on the design

I put the field on `File` because each file is its own `go build` invocation,
and it then works for both a top-level `type: go_build` and the `build:`
fallback with no extra plumbing. The trade-off is that `build_tags` appears in
the schema for package types that ignore it.

The alternatives are a package-level `go_build_tags` on `PackageInfo`, or a
field on `Build`. I am happy to move it — please tell me which shape you
prefer before you spend time on a detailed review.

I left `go_install` alone to keep this to one thing.
