### PR TITLE
feat: allow arm as goarch in registry overrides

### DIFF
--- a/json-schema/registry.json
+++ b/json-schema/registry.json
@@ -321,7 +321,8 @@
           "type": "string",
           "enum": [
             "amd64",
-            "arm64"
+            "arm64",
+            "arm"
           ]
         },
         "type": {

--- a/pkg/config/registry/const_test.go
+++ b/pkg/config/registry/const_test.go
@@ -9,6 +9,7 @@ const (
 	osDarwin           = "darwin"
 	archAmd64          = "amd64"
 	archArm64          = "arm64"
+	archArm            = "arm"
 
 	pkgTypeGitHubRelease = "github_release"
 	pkgTypeHTTP          = "http"

--- a/pkg/config/registry/override_test.go
+++ b/pkg/config/registry/override_test.go
@@ -169,6 +169,29 @@ func TestOverride_Match(t *testing.T) { //nolint:funlen
 			},
 		},
 		{
+			title: "goarch arm matches a 32-bit ARM runtime",
+			exp:   true,
+			override: &registry.Override{
+				GOOS:   "linux",
+				GOArch: archArm,
+			},
+			rt: &runtime.Runtime{
+				GOOS:   "linux",
+				GOARCH: archArm,
+			},
+		},
+		{
+			title: "goarch arm doesn't match arm64",
+			override: &registry.Override{
+				GOOS:   "linux",
+				GOArch: archArm,
+			},
+			rt: &runtime.Runtime{
+				GOOS:   "linux",
+				GOARCH: archArm64,
+			},
+		},
+		{
 			title: "variant libc musl matches",
 			exp:   true,
 			override: &registry.Override{

--- a/pkg/config/registry/package_info.go
+++ b/pkg/config/registry/package_info.go
@@ -201,7 +201,7 @@ func (v Variants) IsZero() bool {
 // the default settings when the specified OS/architecture conditions are met.
 type Override struct {
 	GOOS                       string                      `yaml:",omitempty" json:"goos,omitempty" jsonschema:"enum=darwin,enum=linux,enum=windows"`
-	GOArch                     string                      `yaml:",omitempty" json:"goarch,omitempty" jsonschema:"enum=amd64,enum=arm64"`
+	GOArch                     string                      `yaml:",omitempty" json:"goarch,omitempty" jsonschema:"enum=amd64,enum=arm64,enum=arm"`
 	Type                       string                      `yaml:",omitempty" json:"type,omitempty" jsonschema:"enum=github_release,enum=github_content,enum=github_archive,enum=http,enum=go,enum=go_install,enum=cargo,enum=go_build"`
 	Format                     string                      `yaml:",omitempty" json:"format,omitempty" jsonschema:"example=tar.gz,example=raw,example=zip"`
 	Asset                      string                      `yaml:",omitempty" json:"asset,omitempty"`

--- a/website/docs/reference/registry-config/overrides.md
+++ b/website/docs/reference/registry-config/overrides.md
@@ -59,6 +59,39 @@ For example, Darwin AMD64 matches with second element but the second element isn
     asset: 'arkade-darwin-{{.Arch}}'
 ```
 
+## goos and goarch
+
+`goos` is Go's `GOOS` and `goarch` is Go's `GOARCH`.
+
+- `goos`: `darwin`, `linux`, `windows`
+- `goarch`: `amd64`, `arm64`, `arm`
+
+`arm` means 32 bit ARM.
+aqua compares `goos` and `goarch` with the runtime values as strings, so `goarch: arm` works on any aqua version.
+
+Note that aqua doesn't release binaries for 32 bit ARM, and `aqua gr` doesn't generate 32 bit ARM assets either.
+So 32 bit ARM support is best effort.
+You have to write `overrides` by hand and confirm the asset names by yourself.
+
+e.g. Many Rust tools publish 32 bit ARM assets with the `eabihf` suffix.
+
+```yaml
+  replacements:
+    amd64: x86_64
+    arm64: aarch64
+    linux: unknown-linux-musl
+  overrides:
+  - goos: linux
+    goarch: arm
+    replacements:
+      linux: unknown-linux-musleabihf
+  - goos: linux
+    replacements:
+      arm64: aarch64
+```
+
+The `goarch: arm` element must come before the element without `goarch`, because only the first matched element is applied.
+
 ## envs
 
 [#2318](https://github.com/aquaproj/aqua/issues/2318) [#2320](https://github.com/aquaproj/aqua/pull/2320) aqua >= [v2.13.0](https://github.com/aquaproj/aqua/releases/tag/v2.13.0)


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: #5146
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

---

Close #5146

Allow `arm` (32 bit ARM) in `overrides[].goarch` of the registry JSON Schema.

## Problem

[aqua-registry#59421](https://github.com/aquaproj/aqua-registry/pull/59421) fixes `sharkdp/fd` on `linux/arm`. fd publishes its 32 bit ARM archives with the `eabihf` suffix (`fd-v10.4.2-arm-unknown-linux-musleabihf.tar.gz`), so the package needs an override keyed on `goarch: arm`.

Its `json-schema` job fails:

```
registry.yaml invalid
[
  {
    instancePath: '/packages/1863/version_overrides/3/overrides/0/goarch',
    schemaPath: '#/properties/goarch/enum',
    keyword: 'enum',
    params: { allowedValues: [Array] },
    message: 'must be equal to one of the allowed values'
  }
]
```

That job validates `registry.yaml` against this repository's `main`:

```
curl --fail -O -L "https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json"
ajv --spec=draft2020 -c ajv-formats -s registry.json -d registry.yaml
```

`Override.GOArch` is `jsonschema:"enum=amd64,enum=arm64"`, and Go's `GOARCH` for 32 bit ARM is `arm`.

## This is a schema-only gap — aqua already resolves `arm`

There is no GOARCH allowlist on the install path. Every step compares strings:

| code | behavior |
|---|---|
| `pkg/runtime/runtime.go` `goarch()` | returns `AQUA_GOARCH` or `runtime.GOARCH` as is, no validation |
| `pkg/config/registry/override.go` `MatchPlatform` | `ov.GOArch != rt.GOARCH` |
| `pkg/config/registry/supported_envs.go` `matchEnvs` | `switch elem { case goos, goarch, env, "all" }` |
| `pkg/config/package.go` `getArch` | `replace(rt.GOARCH, replacements)` |

So the enum was narrower than the implementation. This PR widens the enum and adds a regression test; no runtime code changes.

## What is deliberately not changed

- **`runtime.allRuntimes()` / `GOARCHList()`** — `allRuntimes()` is the default enumeration for packages without `supported_envs`, used by `update-checksum`. Adding `linux/arm` there would make aqua resolve 32 bit ARM assets for every package that doesn't publish them. It stays at the current six combinations, so no existing package changes behavior.
- **`supported_envs`** — excluding 32 bit ARM is already expressible today (`linux/amd64`, `linux/arm64`, ...), and aqua-registry#59421 doesn't need it.
- **`Replacements`** — its schema has no `additionalProperties: false`, so `replacements: { arm: ... }` already validates.
- **`aqua gr`** — `pkg/asset/exclude.go` intentionally drops `armv6` / `armv7` / `eabihf` / `386` assets. The generator keeps targeting amd64/arm64 only; 32 bit ARM overrides stay hand-written. The docs say so explicitly.

## Verification

Reproduced the CI failure and the fix locally with the same `ajv` invocation, against the full `registry.yaml` of aqua-registry#59421:

```console
$ ajv --spec=draft2020 -c ajv-formats -s registry-before.json -d registry-pr.yaml
registry-pr.yaml invalid
[ { instancePath: '/packages/1863/version_overrides/3/overrides/0/goarch', ... } ]

$ ajv --spec=draft2020 -c ajv-formats -s json-schema/registry.json -d registry-pr.yaml
registry-pr.yaml valid
```

Current `aqua-registry` `main` still validates against the new schema (`registry.yaml valid`), so this is additive.

Asset resolution with that registry, using an aqua built from this branch — unchanged except for `linux/arm`, and every resolved archive exists in fd's releases (`HTTP 200`):

| env | resolved asset |
|---|---|
| `linux/arm` | `fd-v10.4.2-arm-unknown-linux-musleabihf.tar.gz` |
| `linux/arm64` | `fd-v10.4.2-aarch64-unknown-linux-musl.tar.gz` |
| `linux/amd64` | `fd-v10.4.2-x86_64-unknown-linux-musl.tar.gz` |
| `darwin/arm64` | `fd-v10.4.2-aarch64-apple-darwin.tar.gz` |
| `windows/amd64` | `fd-v10.4.2-x86_64-pc-windows-msvc.zip` |

`go vet ./...`, `go test ./... -race -covermode=atomic` and `golangci-lint run` (v2.12.2) all pass.

`json-schema/registry.json` was regenerated with `cmdx js`; its diff is the single added enum value.

## Note on other aqua-registry consumers

aqua-registry is also consumed by mise, which reports 32 bit ARM as `armv6l` (`armv7l` after [jdx/mise#12113](https://github.com/jdx/mise/pull/12113)) rather than Go's `arm`, so a `goarch: arm` override won't match there. That's out of scope here and I'll raise it with mise separately — this PR only makes aqua's own `GOARCH` expressible.

## Follow-ups (not in this PR)

- aqua-registry's `argd t` only exercises amd64/arm64, which is why the fd breakage went unnoticed.
- `pkg/asset/arch.go` maps a bare `arm` token in an asset name to `arm64` (with `Score -= 1`). `Exclude` drops `eabihf` assets before that, so it's not reachable today, but it looks worth a second look.

---

*AI-assisted: investigated and authored with Claude Code (claude-opus-5). I have reviewed the change and the verification output and take responsibility for it.*
