### PR TITLE
fix: disable exhaustruct_v5

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
     - err113
     - exhaustive
     - exhaustruct
+    - exhaustruct_v5
     - godot
     - godox
     - ireturn

--- a/pkg/config/aqua/config.go
+++ b/pkg/config/aqua/config.go
@@ -121,7 +121,7 @@ func (c *Config) Validate() error {
 
 // Registries maps registry names to their configurations.
 // It provides custom JSON schema generation for better documentation.
-type Registries map[string]*Registry //nolint:recvcheck
+type Registries map[string]*Registry
 
 // JSONSchema generates a JSON schema for registries configuration.
 // It creates an array schema with Registry items for validation purposes.

--- a/pkg/installpackage/check_file.go
+++ b/pkg/installpackage/check_file.go
@@ -25,9 +25,8 @@ func (is *Installer) checkFilesWrap(ctx context.Context, logger *slog.Logger, pa
 	notFound := false
 	for _, file := range pkgInfo.GetFiles() {
 		logger := logger.With("file_name", file.Name)
-		var errFileNotFound *config.FileNotFoundError
 		if err := is.checkAndCopyFile(ctx, logger, pkg, file); err != nil {
-			if errors.As(err, &errFileNotFound) {
+			if _, ok := errors.AsType[*config.FileNotFoundError](err); ok {
 				notFound = true
 			}
 			failed = true


### PR DESCRIPTION
Fixes the CI failure on the Renovate PR that this branches from, so that golangci-lint v2.13.0 can be merged.

golangci-lint v2.13.0 replaced `exhaustruct` with `exhaustruct_v5` (it bumped `dev.gaijin.team/go/exhaustruct` from v4 to v5). This config uses `default: all`, so the new name is enabled automatically while only the old `exhaustruct` sits in `disable`. That is why lint suddenly fails on struct literals that were fine before.

Adding `exhaustruct_v5` to `disable` keeps the linter off, the same way `wsl` and `wsl_v5` are both listed today.

Verified locally with golangci-lint v2.13.0 on three repositories. Every reported issue was `exhaustruct_v5`, and the change takes them to zero:

| repo | before | after |
|---|---|---|
| suzuki-shunsuke/ci-info | 18 issues | 0 issues |
| suzuki-shunsuke/tfcmt | 50 issues | 0 issues |
| aquaproj/aqua-registry-updater | 28 issues | 0 issues |

Base is the Renovate branch, so merging this puts the fix on it and leaves that PR to merge into the default branch as usual.

## Second commit — the remaining v2.13.0 findings

Four repositories had findings beyond `exhaustruct_v5`, so this PR carries a second commit for them. Both are v2.13.0 linter upgrades rather than anything wrong with the code:

- `modernize` gained an `errorsastype` check, which rewrites `errors.As` to the Go 1.26 `errors.AsType` generic form. `var e *T; if errors.As(err, &e) {` becomes `if e, ok := errors.AsType[*T](err); ok {`.
- `recvcheck` was bumped to v0.3.0 and no longer flags the receiver mix it used to, so the existing `//nolint:recvcheck` directives are now reported as unused by `nolintlint`.

Verified locally with golangci-lint v2.13.0: this repository reports 0 issues, and `go build ./...` and `go test ./...` pass.
