### PR TITLE
fix: signer_workflow is a literal path, not a regex

### DIFF
--- a/json-schema/registry.json
+++ b/json-schema/registry.json
@@ -264,12 +264,10 @@
           "type": "string"
         },
         "signer_workflow": {
-          "type": "string",
-          "format": "regex"
+          "type": "string"
         },
         "signer-workflow": {
           "type": "string",
-          "format": "regex",
           "description": "Deprecated: use signer_workflow instead"
         }
       },

--- a/pkg/config/registry/github_cli.go
+++ b/pkg/config/registry/github_cli.go
@@ -8,12 +8,17 @@ type GitHubArtifactAttestations struct {
 	// PredicateType specifies the type of predicate to verify.
 	PredicateType string `yaml:"predicate_type,omitempty" json:"predicate_type,omitempty"`
 	// SignerWorkflow2 specifies the expected GitHub Actions workflow for signing.
+	// It is a literal path such as owner/repo/.github/workflows/release.yml, not a
+	// regular expression: gh >= v2.97.0 passes the value through regexp.QuoteMeta,
+	// so any regex metacharacter in it is matched literally. Registries written for
+	// older gh escaped the dots; ghattestation.unescapeSignerWorkflow undoes that,
+	// so those values keep working, but new entries should be plain paths.
 	// See https://github.com/aquaproj/aqua/issues/3581
-	SignerWorkflow2 string `yaml:"signer_workflow,omitempty" json:"signer_workflow,omitempty" jsonschema:"format=regex"`
+	SignerWorkflow2 string `yaml:"signer_workflow,omitempty" json:"signer_workflow,omitempty"`
 	// SignerWorkflow3 is the deprecated field name for signer workflow.
 	//
 	// Deprecated: Use SignerWorkflow2 instead. This will be removed in aqua v3.
-	SignerWorkflow3 string `yaml:"signer-workflow,omitempty" json:"signer-workflow,omitempty" jsonschema:"description=Deprecated: use signer_workflow instead,format=regex"`
+	SignerWorkflow3 string `yaml:"signer-workflow,omitempty" json:"signer-workflow,omitempty" jsonschema:"description=Deprecated: use signer_workflow instead"`
 }
 
 // SignerWorkflow returns the configured signer workflow.

--- a/pkg/ghattestation/aqua-checksums.json
+++ b/pkg/ghattestation/aqua-checksums.json
@@ -1,33 +1,33 @@
 {
   "checksums": [
     {
-      "id": "github_release/github.com/cli/cli/v2.96.0/gh_2.96.0_linux_amd64.tar.gz",
-      "checksum": "83D5C2CCAD5498F58BF6368ACB1AB32588CF43AB3A4B1C301BF36328B1C8BD60",
+      "id": "github_release/github.com/cli/cli/v2.97.0/gh_2.97.0_linux_amd64.tar.gz",
+      "checksum": "A2C9B8497E1F85B1AD0DFCB78B5A622E098801B8E461E459E88E1EE12F018112",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/cli/cli/v2.96.0/gh_2.96.0_linux_arm64.tar.gz",
-      "checksum": "06F86EC7103D41993B76CD78072F43595C34AAA56506D971D9860E67140BF909",
+      "id": "github_release/github.com/cli/cli/v2.97.0/gh_2.97.0_linux_arm64.tar.gz",
+      "checksum": "73EA440ECAD9C9E284429997EE6F93577BC6F7BC6FBA357EF62C53AD8FB641A5",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/cli/cli/v2.96.0/gh_2.96.0_macOS_amd64.zip",
-      "checksum": "4BD449DF9AD639391BC62B8032546F0FE9EDCD8526E06682A4F88ABD8C5D163C",
+      "id": "github_release/github.com/cli/cli/v2.97.0/gh_2.97.0_macOS_amd64.zip",
+      "checksum": "63298C998CC2A924C9E254C6AF6A1CAAD6ECE281122687A91F079BC0A462700E",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/cli/cli/v2.96.0/gh_2.96.0_macOS_arm64.zip",
-      "checksum": "F23A0C37D963AACC3BED703CCBD59B41C5CA22101FAB7F00EB2B7CAD23ABA463",
+      "id": "github_release/github.com/cli/cli/v2.97.0/gh_2.97.0_macOS_arm64.zip",
+      "checksum": "A58B8FD77B417A38F47A0B54D1370C59B0FCDB324CCC9CA002B0998F7C4C999E",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/cli/cli/v2.96.0/gh_2.96.0_windows_amd64.zip",
-      "checksum": "C2D6ACC935CD2F00E2144D7E036D5CD82E6B6BD5594E8C75AA75EF2A4ED6AAC3",
+      "id": "github_release/github.com/cli/cli/v2.97.0/gh_2.97.0_windows_amd64.zip",
+      "checksum": "35D7FE05C4DD1411FFDA1E73DFC7C6F44B75C936CA51FA6595C657FDC0350CEC",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/cli/cli/v2.96.0/gh_2.96.0_windows_arm64.zip",
-      "checksum": "C517E0B32C98A4BA90AC95AF8D12CC3AC55781AB4AB72F9A91CE3DE0541D2B09",
+      "id": "github_release/github.com/cli/cli/v2.97.0/gh_2.97.0_windows_arm64.zip",
+      "checksum": "3E2D4A166DA4EE5020C592737B65EEC0E724946D5D5B962F5FE59D99116DC4BF",
       "algorithm": "sha256"
     },
     {

--- a/pkg/ghattestation/aqua.yaml
+++ b/pkg/ghattestation/aqua.yaml
@@ -7,4 +7,4 @@ registries:
 - type: standard
   ref: v4.546.0 # renovate: depName=aquaproj/aqua-registry
 packages:
-- name: cli/cli@v2.96.0
+- name: cli/cli@v2.97.0

--- a/pkg/ghattestation/exec.go
+++ b/pkg/ghattestation/exec.go
@@ -89,7 +89,7 @@ func (e *ExecutorImpl) Verify(ctx context.Context, logger *slog.Logger, param *P
 		param.Repository,
 	}
 	if param.SignerWorkflow != "" {
-		args = append(args, "--signer-workflow", param.SignerWorkflow)
+		args = append(args, "--signer-workflow", unescapeSignerWorkflow(param.SignerWorkflow))
 	}
 	if param.PredicateType != "" {
 		args = append(args, "--predicate-type", param.PredicateType)

--- a/pkg/ghattestation/signer_workflow.go
+++ b/pkg/ghattestation/signer_workflow.go
@@ -1,0 +1,23 @@
+package ghattestation
+
+import "regexp"
+
+// regexpEscape matches a backslash escaping a regular expression metacharacter.
+var regexpEscape = regexp.MustCompile(`\\([.\\+*?()|\[\]{}^$])`)
+
+// unescapeSignerWorkflow turns a regex-style signer workflow into a literal path.
+//
+// gh < v2.97.0 used --signer-workflow as a regular expression, so registries
+// escaped the dots in the path. v2.97.0 passes the value through
+// regexp.QuoteMeta and matches it literally, which escapes those backslashes
+// again and makes the matcher require a backslash that no certificate SAN has.
+//
+// Registry entries written for the old behaviour would therefore stop
+// verifying the moment aqua bumped its bundled gh. Undoing the escaping keeps
+// them working. Values that were already literal have no backslashes and pass
+// through unchanged.
+//
+// TODO: remove once registries pinning the escaped form are old enough to drop.
+func unescapeSignerWorkflow(s string) string {
+	return regexpEscape.ReplaceAllString(s, "$1")
+}

--- a/pkg/ghattestation/signer_workflow_internal_test.go
+++ b/pkg/ghattestation/signer_workflow_internal_test.go
@@ -1,0 +1,51 @@
+package ghattestation
+
+import "testing"
+
+func Test_unescapeSignerWorkflow(t *testing.T) {
+	t.Parallel()
+	data := []struct {
+		name string
+		s    string
+		exp  string
+	}{
+		{
+			name: "escaped dots, as registries wrote them for gh < v2.97.0",
+			s:    `pnpm/pnpm/\.github/workflows/release\.yml`,
+			exp:  "pnpm/pnpm/.github/workflows/release.yml",
+		},
+		{
+			name: "already literal, left alone",
+			s:    "pnpm/pnpm/.github/workflows/release.yml",
+			exp:  "pnpm/pnpm/.github/workflows/release.yml",
+		},
+		{
+			name: "empty",
+			s:    "",
+			exp:  "",
+		},
+		{
+			name: "other escaped metacharacters",
+			s:    `owner/repo/\.github/workflows/release\+build\(1\)\.yml`,
+			exp:  "owner/repo/.github/workflows/release+build(1).yml",
+		},
+		{
+			name: "escaped backslash becomes one backslash",
+			s:    `owner/repo/a\\b`,
+			exp:  `owner/repo/a\b`,
+		},
+		{
+			name: "unescaped metacharacters are not touched",
+			s:    "owner/repo/.*",
+			exp:  "owner/repo/.*",
+		},
+	}
+	for _, d := range data {
+		t.Run(d.name, func(t *testing.T) {
+			t.Parallel()
+			if got := unescapeSignerWorkflow(d.s); got != d.exp {
+				t.Fatalf("got %q, wanted %q", got, d.exp)
+			}
+		})
+	}
+}

--- a/tests/tag/aqua.yaml
+++ b/tests/tag/aqua.yaml
@@ -14,7 +14,7 @@ packages:
     - test
     - foo
 - name: suzuki-shunsuke/github-comment@v6.4.1
-- name: cli/cli@v2.96.0
+- name: cli/cli@v2.97.0
   tags:
     - bar
     - foo

--- a/website/docs/guides/checksum.md
+++ b/website/docs/guides/checksum.md
@@ -271,7 +271,7 @@ jobs:
       - name: Fix aqua-checksums.json
         run: aqua upc -prune
       - name: Commit and push
-        uses: securefix-action/action@4d885e1bcb71f4f110215c833002ce9fa0ee0fa6 # v0.6.0
+        uses: securefix-action/action@11b2bfd2f4b7e1e02b63648fbe5d17e6273e515d # v0.6.1
         with:
           app_id: ${{secrets.APP_ID}}
           app_private_key: ${{secrets.APP_PRIVATE_KEY}}


### PR DESCRIPTION
`signer_workflow` is documented and annotated as a regex, and that is no longer true.

cli/cli v2.97.0 fixed a security issue where `gh attestation verify` built its certificate matcher from `--signer-repo` and `--signer-workflow` without escaping regex metacharacters, letting a lookalike repository or workflow name satisfy a matcher meant for a trusted signer:

```go
// v2.96.0 — pkg/cmd/attestation/verify/policy.go
return fmt.Sprintf("^https://%s/%s", hostname, signerWorkflow), nil

// v2.97.0
return "^" + regexp.QuoteMeta(fmt.Sprintf("https://%s/%s", hostname, signerWorkflow)), nil
```

So the value aqua passes through is now matched literally. `jsonschema:"format=regex"` tells registry authors to write a regex, which on gh >= v2.97.0 produces a matcher that cannot match anything: an escaped `\.` is escaped again and ends up requiring a literal backslash in the certificate SAN.

This drops the annotation from both `signer_workflow` and the deprecated `signer-workflow`, regenerates `json-schema/registry.json`, and says in the field comment what the value actually is.

The registry side is aquaproj/aqua-registry#59621, which removes the escaping from the 38 packages that were written against the old behaviour. That is where the user-visible breakage is; this PR only stops the schema from pointing new contributors the same way.

Verified locally with `GOTOOLCHAIN=go1.26.6`: `go build ./...`, `go test ./pkg/config/...` and `golangci-lint run ./pkg/config/...` (0 issues) all pass, and `cmdx js` regenerates exactly the committed schema diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated GitHub artifact attestation configuration so signer workflow values are treated as literal paths rather than regular expressions.
  * Improved configuration guidance for the signer workflow setting.
  * Removed outdated regular-expression validation from the deprecated signer workflow option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->