### PR TITLE
test: pin the pnpm test registry to the signer_workflow fix

### DIFF
--- a/aqua/aqua-policy.yaml
+++ b/aqua/aqua-policy.yaml
@@ -3,7 +3,7 @@
 # aqua Policy
 registries:
   - type: standard
-    ref: semver(">= 3.0.0") or Version in ["f9cce37273a70e2f5664fb4c3708169ffe7e320c", "1f20d0c2211df45694e762fcb20830d5c3cedf95", "98524ca5b420af9115275d110b2cadeab60f49e2", "501377ba89acc447dce6b7ad69f51f705d00bff0"]
+    ref: semver(">= 3.0.0") or Version in ["f9cce37273a70e2f5664fb4c3708169ffe7e320c", "1f20d0c2211df45694e762fcb20830d5c3cedf95", "98524ca5b420af9115275d110b2cadeab60f49e2", "501377ba89acc447dce6b7ad69f51f705d00bff0", "19070e42149f21efadd310d28c20caa9496fb105"]
   - name: main
     type: local
     path: ../tests/main/registry.yaml

--- a/tests/pnpm/aqua-checksums.json
+++ b/tests/pnpm/aqua-checksums.json
@@ -6,8 +6,18 @@
       "algorithm": "sha256"
     },
     {
+      "id": "github_release/github.com/pnpm/pnpm/v11.5.2/pnpm-linux-arm64-musl.tar.gz",
+      "checksum": "843BEED7BCA760276D29F8950CA219600995D345DBC93FAD8150B3E5F83B74D4",
+      "algorithm": "sha256"
+    },
+    {
       "id": "github_release/github.com/pnpm/pnpm/v11.5.2/pnpm-linux-arm64.tar.gz",
       "checksum": "7FEF0C74081135D777754FCCF25272F698E504B26BA0568504846C0CEA402F8F",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/pnpm/pnpm/v11.5.2/pnpm-linux-x64-musl.tar.gz",
+      "checksum": "0B794B23461C7475F7FFC29C4945692838B51DDADD857A2ACE8EDF0018798305",
       "algorithm": "sha256"
     },
     {
@@ -23,6 +33,11 @@
     {
       "id": "github_release/github.com/pnpm/pnpm/v11.5.2/pnpm-win32-x64.zip",
       "checksum": "B3DDFF2C2BF87D3996FADF074BAC58CD2259F718A17912A04AE930E3775B30E9",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "registries/github_content/github.com/aquaproj/aqua-registry/19070e42149f21efadd310d28c20caa9496fb105/registry.yaml",
+      "checksum": "F4DF47DF148AEEB3E669DD740B5EEAF3238C26AD95FF2B4C84DE5E90077E5794",
       "algorithm": "sha256"
     },
     {

--- a/tests/pnpm/aqua.yaml
+++ b/tests/pnpm/aqua.yaml
@@ -7,6 +7,8 @@ checksum:
   require_checksum: true
 registries:
   - type: standard
-    ref: v4.546.0 # renovate: depName=aquaproj/aqua-registry
+    # TODO restore "ref: <version> # renovate: depName=aquaproj/aqua-registry"
+    # once the signer_workflow fix is in an aqua-registry release.
+    ref: 19070e42149f21efadd310d28c20caa9496fb105
 packages:
   - name: pnpm/pnpm@v11.5.2

--- a/website/docs/guides/checksum.md
+++ b/website/docs/guides/checksum.md
@@ -271,7 +271,7 @@ jobs:
       - name: Fix aqua-checksums.json
         run: aqua upc -prune
       - name: Commit and push
-        uses: securefix-action/action@4d885e1bcb71f4f110215c833002ce9fa0ee0fa6 # v0.6.0
+        uses: securefix-action/action@11b2bfd2f4b7e1e02b63648fbe5d17e6273e515d # v0.6.1
         with:
           app_id: ${{secrets.APP_ID}}
           app_private_key: ${{secrets.APP_PRIVATE_KEY}}


### PR DESCRIPTION
Fixes the `integration-test-all-envs` failure on #5096.

## Why it fails

This PR's branch bumps the embedded `cli/cli` from v2.96.0 to v2.97.0. v2.97.0 fixed a security issue by applying `regexp.QuoteMeta` to `--signer-workflow`, so the value is now matched literally instead of as a regex:

```go
// v2.96.0 — pkg/cmd/attestation/verify/policy.go
return fmt.Sprintf("^https://%s/%s", hostname, signerWorkflow), nil
// v2.97.0
return "^" + regexp.QuoteMeta(fmt.Sprintf("https://%s/%s", hostname, signerWorkflow)), nil
```

Released aqua-registry versions store the value pre-escaped for the old behaviour:

```yaml
signer_workflow: pnpm/pnpm/\.github/workflows/release\.yml
```

`QuoteMeta` escapes that `\.` again, producing a matcher that requires a literal backslash in the certificate SAN. It can never match, so pnpm fails verification:

```
Error: verifying with issuer "sigstore.dev"
ERR install the package  package_name=pnpm/pnpm package_version=v11.5.2
    error="verify the asset: verify a package with gh attestation: verify GitHub Artifact Attestations"
```

## This change

aquaproj/aqua-registry#59621 removed the escaping from all 38 affected packages, but it is not in a release yet — v4.557.0 was cut just before it landed.

So `tests/pnpm/aqua.yaml` pins the registry `ref` to that commit (`19070e42149f21efadd310d28c20caa9496fb105`) until a release contains it, and the SHA is added to the standard-registry allowlist in `aqua/aqua-policy.yaml`. `tests/cosign/aqua.yaml` already pins SHAs the same way, with the same policy allowlist, so this follows the existing pattern rather than introducing one.

`tests/pnpm/aqua-checksums.json` is regenerated with `aqua update-checksum`. Besides the new registry checksum it picks up the `linux-arm64-musl` and `linux-x64-musl` entries the newer registry added for pnpm.

The `# renovate:` annotation is replaced with a TODO to restore it, since Renovate cannot track a SHA.

## Verification

Ran the test locally on darwin/arm64 against this branch's build, so with the v2.97.0 gh this PR pins:

```
INF verify GitHub Artifact Attestations  package_name=pnpm/pnpm package_version=v11.5.2
INF create a symbolic link  file_name=pn
INF creating a hard link  file_name=pnpx
```

Verification passes and the install completes.
