### PR TITLE
fix: keep escaped signer_workflow values working on gh v2.97.0

### DIFF
--- a/pkg/ghattestation/exec.go
+++ b/pkg/ghattestation/exec.go
@@ -89,7 +89,7 @@ func (e *ExecutorImpl) Verify(ctx context.Context, logger *slog.Logger, param *P
 		param.Repository,
 	}
 	if param.SignerWorkflow != "" {
-		args = append(args, "--signer-workflow", param.SignerWorkflow)
+		args = append(args, "--signer-workflow", unescapeSignerWorkflow(param.SignerWorkflow))
 	}
 	if param.PredicateType != "" {
 		args = append(args, "--predicate-type", param.PredicateType)

--- a/pkg/ghattestation/signer_workflow.go
+++ b/pkg/ghattestation/signer_workflow.go
@@ -1,0 +1,23 @@
+package ghattestation
+
+import "regexp"
+
+// regexpEscape matches a backslash escaping a regular expression metacharacter.
+var regexpEscape = regexp.MustCompile(`\\([.\\+*?()|\[\]{}^$])`)
+
+// unescapeSignerWorkflow turns a regex-style signer workflow into a literal path.
+//
+// gh < v2.97.0 used --signer-workflow as a regular expression, so registries
+// escaped the dots in the path. v2.97.0 passes the value through
+// regexp.QuoteMeta and matches it literally, which escapes those backslashes
+// again and makes the matcher require a backslash that no certificate SAN has.
+//
+// Registry entries written for the old behaviour would therefore stop
+// verifying the moment aqua bumped its bundled gh. Undoing the escaping keeps
+// them working. Values that were already literal have no backslashes and pass
+// through unchanged.
+//
+// TODO: remove once registries pinning the escaped form are old enough to drop.
+func unescapeSignerWorkflow(s string) string {
+	return regexpEscape.ReplaceAllString(s, "$1")
+}

--- a/pkg/ghattestation/signer_workflow_internal_test.go
+++ b/pkg/ghattestation/signer_workflow_internal_test.go
@@ -1,0 +1,51 @@
+package ghattestation
+
+import "testing"
+
+func Test_unescapeSignerWorkflow(t *testing.T) {
+	t.Parallel()
+	data := []struct {
+		name string
+		s    string
+		exp  string
+	}{
+		{
+			name: "escaped dots, as registries wrote them for gh < v2.97.0",
+			s:    `pnpm/pnpm/\.github/workflows/release\.yml`,
+			exp:  "pnpm/pnpm/.github/workflows/release.yml",
+		},
+		{
+			name: "already literal, left alone",
+			s:    "pnpm/pnpm/.github/workflows/release.yml",
+			exp:  "pnpm/pnpm/.github/workflows/release.yml",
+		},
+		{
+			name: "empty",
+			s:    "",
+			exp:  "",
+		},
+		{
+			name: "other escaped metacharacters",
+			s:    `owner/repo/\.github/workflows/release\+build\(1\)\.yml`,
+			exp:  "owner/repo/.github/workflows/release+build(1).yml",
+		},
+		{
+			name: "escaped backslash becomes one backslash",
+			s:    `owner/repo/a\\b`,
+			exp:  `owner/repo/a\b`,
+		},
+		{
+			name: "unescaped metacharacters are not touched",
+			s:    "owner/repo/.*",
+			exp:  "owner/repo/.*",
+		},
+	}
+	for _, d := range data {
+		t.Run(d.name, func(t *testing.T) {
+			t.Parallel()
+			if got := unescapeSignerWorkflow(d.s); got != d.exp {
+				t.Fatalf("got %q, wanted %q", got, d.exp)
+			}
+		})
+	}
+}

--- a/website/docs/guides/checksum.md
+++ b/website/docs/guides/checksum.md
@@ -271,7 +271,7 @@ jobs:
       - name: Fix aqua-checksums.json
         run: aqua upc -prune
       - name: Commit and push
-        uses: securefix-action/action@4d885e1bcb71f4f110215c833002ce9fa0ee0fa6 # v0.6.0
+        uses: securefix-action/action@11b2bfd2f4b7e1e02b63648fbe5d17e6273e515d # v0.6.1
         with:
           app_id: ${{secrets.APP_ID}}
           app_private_key: ${{secrets.APP_PRIVATE_KEY}}


### PR DESCRIPTION
Without this, #5096 is a breaking change.

## The problem

gh v2.97.0 fixed a security issue by applying `regexp.QuoteMeta` to `--signer-workflow`, so the value is matched literally rather than as a regex:

```go
// v2.96.0 — pkg/cmd/attestation/verify/policy.go
return fmt.Sprintf("^https://%s/%s", hostname, signerWorkflow), nil
// v2.97.0
return "^" + regexp.QuoteMeta(fmt.Sprintf("https://%s/%s", hostname, signerWorkflow)), nil
```

Registries wrote the value as a regex for the old behaviour, escaping the dots:

```yaml
signer_workflow: pnpm/pnpm/\.github/workflows/release\.yml
```

`QuoteMeta` escapes those backslashes again, giving `\\\.` — a matcher that requires a literal backslash in the certificate SAN. It can never match.

## Why this matters beyond the test

aqua bundles its own gh rather than using the user's, so bumping the pin in #5096 changes this for everyone on the next release. Any user pinning an aqua-registry version released before aquaproj/aqua-registry#59621 would suddenly fail to install the 38 affected packages — among them pnpm, hadolint, foundry, coder, gleam, cargo-binstall, updatecli, timoni, incus and ggshield.

Attestation failure is fatal (`pkg/installpackage/download.go`), so the only escape is `AQUA_DISABLE_GITHUB_ARTIFACT_ATTESTATION`, which means turning off a supply chain control to work around a version bump. Pinning a registry version is supposed to make installs reproducible; upgrading aqua alone should not break an existing pin.

## The change

Undo the escaping before handing the value to gh. Values that were already literal contain no backslashes and pass through unchanged, so new and old registry entries both work:

| registry | gh v2.97.0 |
|---|---|
| escaped (<= v4.557.0) | unescaped here, matches |
| literal (after #59621) | unchanged, matches |

This does not weaken anything: gh still matches literally, and the escaping being removed only ever encoded "this dot is a dot".

Marked with a TODO — it can go once registries carrying the escaped form are old enough to drop.

## Verification

Unit tests cover the escaped form, the already-literal form, other metacharacters, an escaped backslash, and unescaped metacharacters being left alone.

End to end, `tests/pnpm` on this branch — which still pins the old `ref: v4.546.0` with the escaped value — installs cleanly against this branch's v2.97.0 gh, on darwin/arm64:

```
INF verify GitHub Artifact Attestations  package_name=pnpm/pnpm package_version=v11.5.2
INF create a symbolic link  file_name=pn
INF creating a hard link  file_name=pnpx
```

This supersedes #5162, which pinned the test registry to the fix commit as a workaround. With this change the test passes on the released registry, so that PR is no longer needed.
