### PR TITLE
fix: pin the cosign test to a tfcmt registry with the new signature format

### DIFF
--- a/tests/cosign/aqua.yaml
+++ b/tests/cosign/aqua.yaml
@@ -13,7 +13,7 @@ registries:
     ref: 98524ca5b420af9115275d110b2cadeab60f49e2 # TODO update
     name: soulshack
   - type: standard
-    ref: 501377ba89acc447dce6b7ad69f51f705d00bff0 # TODO update
+    ref: v4.543.0 # renovate: depName=aquaproj/aqua-registry
     name: tfcmt
 packages:
   - name: suzuki-shunsuke/mkghtag@v0.1.11


### PR DESCRIPTION
Fixes the cosign test on #5046.

## What was wrong

The cosign test pinned the tfcmt registry to `501377ba…`, which predates aquaproj/aqua-registry#57356. That registry version still describes tfcmt's checksum signature as separate `.pem` and `.sig` assets:

```
cosign_opts="--certificate .../tfcmt_4.14.18_checksums.txt.pem ... --signature .../tfcmt_4.14.18_checksums.txt.sig"
error="verify with Cosign"
```

tfcmt stopped publishing those. The assets changed with the release workflow:

| version | checksum signature assets |
|---|---|
| ≤ v4.14.13 | `.sig` + `.pem` |
| v4.14.14 – v4.14.15 | `.sig` + `.pem` + `.bundle` |
| v4.14.16 onwards | `.sigstore.json` only |

aqua-registry already handles this — the `version_constraint: "true"` block for tfcmt uses `cosign.bundle` pointing at `.sigstore.json`. The test was simply pinned behind it.

## This change

```diff
-    ref: 501377ba89acc447dce6b7ad69f51f705d00bff0 # TODO update
+    ref: v4.543.0 # renovate: depName=aquaproj/aqua-registry
```

A version tag rather than a commit SHA, for two reasons:

- The policy in `aqua/aqua-policy.yaml` allows the standard registry on `semver(">= 3.0.0") or Version in [...]`. A tag satisfies the semver clause, so no allowlist entry is needed. A SHA would need one — that is what #5073 was missing, and why moving the pin there turned the Cosign failure into `this package isn't allowed` (code 002) rather than fixing anything.
- Renovate cannot update a SHA pin. With the annotation it tracks the registry from here on, so this stops being a `# TODO update` that quietly rots.

## Note on #5073

#5073 made this change on this same branch on 2026-07-26. Renovate rebased the branch afterwards, which force-pushes only its own commit, so it was dropped. Worth remembering for any fix based on a Renovate branch.

## Verification

Ran `tests/cosign` locally against this branch with the repository's policy file, after clearing the tfcmt package cache. All three checks pass for v4.14.18:

```
INF verify GitHub Artifact Attestations  package_name=suzuki-shunsuke/tfcmt package_version=v4.14.18
INF verify a package with slsa-verifier   package_name=suzuki-shunsuke/tfcmt package_version=v4.14.18
PASSED: SLSA verification passed
INF verifying a file with Cosign          package_name=suzuki-shunsuke/tfcmt package_version=v4.14.18
Verified OK
```
