### PR TITLE
ci: keep the pnpm test checksums up to date in autofix

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -29,6 +29,10 @@ jobs:
         working-directory: pkg/ghattestation
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}
+      - run: aqua upc -prune
+        working-directory: tests/pnpm
+        env:
+          AQUA_GITHUB_TOKEN: ${{github.token}}
 
       - run: git ls-files docs | xargs pinact run -u
         working-directory: website

--- a/tests/pnpm/aqua-checksums.json
+++ b/tests/pnpm/aqua-checksums.json
@@ -6,8 +6,18 @@
       "algorithm": "sha256"
     },
     {
+      "id": "github_release/github.com/pnpm/pnpm/v11.5.2/pnpm-linux-arm64-musl.tar.gz",
+      "checksum": "843BEED7BCA760276D29F8950CA219600995D345DBC93FAD8150B3E5F83B74D4",
+      "algorithm": "sha256"
+    },
+    {
       "id": "github_release/github.com/pnpm/pnpm/v11.5.2/pnpm-linux-arm64.tar.gz",
       "checksum": "7FEF0C74081135D777754FCCF25272F698E504B26BA0568504846C0CEA402F8F",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/pnpm/pnpm/v11.5.2/pnpm-linux-x64-musl.tar.gz",
+      "checksum": "0B794B23461C7475F7FFC29C4945692838B51DDADD857A2ACE8EDF0018798305",
       "algorithm": "sha256"
     },
     {
@@ -26,8 +36,8 @@
       "algorithm": "sha256"
     },
     {
-      "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.523.0/registry.yaml",
-      "checksum": "14BFA633212CF508D45DE47AD17CF666E009BCA351787E28F41D63FFD5B99D8B",
+      "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.557.0/registry.yaml",
+      "checksum": "43B82E8B025E6AD42D09C02B194593D0AC8EEDBD47B9982A88C1651CE76A51FA",
       "algorithm": "sha256"
     }
   ]


### PR DESCRIPTION
#5168 had to update `tests/pnpm/aqua-checksums.json` by hand after Renovate bumped pnpm. This stops that recurring.

`tests/pnpm/aqua.yaml` sets `require_checksum: true`, so when Renovate bumps the pnpm version and leaves the checksum file listing the old one, the install fails:

```
ERR install the package  package_name=pnpm/pnpm package_version=v11.24.0
    doc=https://aquaproj.github.io/docs/reference/codes/001
    error="checksum is required"
```

autofix already runs `aqua upc -prune` for the embedded tool configs under `pkg/` — cosign, slsa, minisign, ghattestation. `tests/pnpm` is the only other tracked `aqua-checksums.json` in the repository, so it gets the same step.

```sh
$ git ls-files | grep aqua-checksums.json
pkg/cosign/aqua-checksums.json
pkg/ghattestation/aqua-checksums.json
pkg/minisign/aqua-checksums.json
pkg/slsa/aqua-checksums.json
tests/pnpm/aqua-checksums.json
aqua/aqua-checksums.json
```

`tests/cosign` has no checksum file and sets `require_checksum: false`, so it needs nothing.

`actionlint` passes.

Note this only helps from the next bump onwards; #5168 is still needed for the pnpm PR that is already open.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated dependency cleanup for the test environment.
  * Eligible maintenance fixes can now be applied automatically using the repository’s authorization token.
  * Updated package verification metadata to support additional Linux architectures and newer package registry versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->