### PR TITLE
fix: support files[].src in go_install packages

### DIFF
--- a/pkg/config/package.go
+++ b/pkg/config/package.go
@@ -293,6 +293,13 @@ func (p *Package) fileSrcWithoutWindowsExt(file *registry.File, rt *runtime.Runt
 	if pkgInfo.Type == "cargo" {
 		return filepath.Join("bin", file.Name), nil
 	}
+	if pkgInfo.Type == PkgInfoTypeGoInstall && file.Src != "" {
+		src, err := p.RenderTemplateString(file.Src, rt)
+		if err != nil {
+			return "", fmt.Errorf("render the template file.src: %w", err)
+		}
+		return src, nil
+	}
 	assetName, err := p.RenderAsset(rt)
 	if err != nil {
 		return "", fmt.Errorf("render the asset name: %w", err)

--- a/pkg/config/package_internal_test.go
+++ b/pkg/config/package_internal_test.go
@@ -141,6 +141,77 @@ func TestPackage_fileSrc(t *testing.T) { //nolint:funlen
 			},
 		},
 		{
+			title: "go_install",
+			exp:   "in-toto",
+			pkg: &Package{
+				PackageInfo: &registry.PackageInfo{
+					Type: PkgInfoTypeGoInstall,
+					Path: "github.com/in-toto/in-toto-golang",
+					Files: []*registry.File{
+						{
+							Name: "in-toto",
+						},
+					},
+				},
+				Package: &aqua.Package{
+					Version: versionV077,
+				},
+			},
+			file: &registry.File{
+				Name: "in-toto",
+			},
+		},
+		{
+			title: "go_install (with src)",
+			exp:   "in-toto-golang",
+			pkg: &Package{
+				PackageInfo: &registry.PackageInfo{
+					Type: PkgInfoTypeGoInstall,
+					Path: "github.com/in-toto/in-toto-golang",
+					Files: []*registry.File{
+						{
+							Name: "in-toto",
+							Src:  "in-toto-golang",
+						},
+					},
+				},
+				Package: &aqua.Package{
+					Version: versionV077,
+				},
+			},
+			file: &registry.File{
+				Name: "in-toto",
+				Src:  "in-toto-golang",
+			},
+		},
+		{
+			title: "go_install (with src, windows)",
+			exp:   "in-toto-golang.exe",
+			pkg: &Package{
+				PackageInfo: &registry.PackageInfo{
+					Type: PkgInfoTypeGoInstall,
+					Path: "github.com/in-toto/in-toto-golang",
+					Files: []*registry.File{
+						{
+							Name: "in-toto",
+							Src:  "in-toto-golang",
+						},
+					},
+				},
+				Package: &aqua.Package{
+					Version: versionV077,
+				},
+			},
+			file: &registry.File{
+				Name: "in-toto",
+				Src:  "in-toto-golang",
+			},
+			rt: &runtime.Runtime{
+				GOOS:   osWindows,
+				GOARCH: archAmd64,
+			},
+		},
+		{
 			title: "add .sh in case of github_content",
 			exp:   "dcgoss.sh",
 			pkg: &Package{

--- a/website/docs/reference/registry-config/go-install-package.md
+++ b/website/docs/reference/registry-config/go-install-package.md
@@ -61,3 +61,20 @@ packages:
     description: Generate a Go ORM tailored to your database schema
     path: github.com/volatiletech/sqlboiler/v{{(semver .Version).Major}}
 ```
+
+## `files[].src`
+
+`go install` names the built binary after the base name of the Go package path, but the command name isn't always the same as it.
+In that case, you can specify the built binary name by `files[].src`.
+
+e.g. `go install github.com/in-toto/in-toto-golang@v0.9.0` builds the binary `in-toto-golang`, but the command name is `in-toto`.
+
+```yaml
+packages:
+  - type: go_install
+    repo_owner: in-toto
+    repo_name: in-toto-golang
+    files:
+      - name: in-toto
+        src: in-toto-golang
+```


### PR DESCRIPTION
## What

Support `files[].src` in `go_install` packages.

## Why

`go install` names the built binary after the base name of the Go package path, which isn't always the command name. aqua assumed the built binary is named `files[0].name`, so packages whose command name differs from the base name of the package path are broken.

For example, `in-toto/in-toto-golang` in the standard registry:

```yaml
packages:
  - type: go_install
    repo_owner: in-toto
    repo_name: in-toto-golang
    files:
      - name: in-toto
```

`go install github.com/in-toto/in-toto-golang@v0.9.0` builds the binary `in-toto-golang`, but aqua looks for `in-toto` in GOBIN:

```console
$ aqua exec -- in-toto
ERR check file_src is correct exe_name=in-toto package_name=in-toto/in-toto-golang package_version=v0.9.0 exe_path=~/.local/share/aquaproj-aqua/pkgs/go_install/github.com/in-toto/in-toto-golang/v0.9.0/bin/in-toto error="check file_src is correct: exe_path isn't found: stat ...: no such file or directory"
ERR executable files aren't found
Files in the unarchived package:
in-toto-golang
```

Adding `src: in-toto-golang` to the registry doesn't help, because `files[].src` is silently ignored for `go_install` packages.

## Cause

In `(*Package).fileSrcWithoutWindowsExt`, `renderAsset` returns `path.Base(pkgInfo.GetFiles()[0].Name)` for `go_install` packages, and `resetByPkgType` clears `Format`, so `unarchive.IsUnarchived("", "in-toto")` is true and the function returns before it reads `file.Src`.

Deriving the binary name from the base name of the package path instead isn't an option either, since the path can have a major version suffix (e.g. `github.com/volatiletech/sqlboiler/v4` builds `sqlboiler`). So honoring `files[].src` is the way to express the built binary name.

## How

Return `files[].src` for `go_install` packages when it is set, before the unarchived shortcut. This is scoped to `go_install`, so packages of other types with `format: raw` keep the current behavior. When `src` is empty, the behavior is unchanged. On Windows, `.exe` is appended to `src` in the same way as it is to `name`.

## Test

Added test cases to `TestPackage_fileSrc` for `go_install` with and without `src`, including Windows.

Verified with a local build against the registry entry with `src: in-toto-golang` added:

```console
$ aqua which in-toto
~/.local/share/aquaproj-aqua/pkgs/go_install/github.com/in-toto/in-toto-golang/v0.9.0/bin/in-toto-golang

$ aqua exec -- in-toto
A framework to secure the integrity of software supply chains https://in-toto.io/

Usage:
  in-toto [command]
```

`cmdx t`, `cmdx v`, and `cmdx l` all pass.

## Note

The registry needs `src: in-toto-golang` added to `in-toto/in-toto-golang` after this is released. Adding it to the registry before the release is harmless (the package stays broken exactly as it is today), but it only takes effect with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016orMNitkRYi2yovLVgvazv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customizing the output binary filename for `go_install` packages.
  * Supports package paths whose default binary name differs from the desired command name.
  * Handles Windows `.exe` filenames correctly.

* **Documentation**
  * Added configuration guidance and an example for overriding `go_install` binary names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->