### PR TITLE
fix: ignore incomplete release assets in aqua gr

### DIFF
--- a/pkg/controller/generate-registry/const.go
+++ b/pkg/controller/generate-registry/const.go
@@ -9,4 +9,8 @@ const (
 	flagSignature          = "--signature"
 	urlOIDCIssuer          = "https://token.actions.githubusercontent.com"
 	fileCosignPub          = "cosign.pub"
+
+	// assetStateUploaded is the state of a GitHub Release asset whose upload has completed.
+	// Assets in any other state (e.g. "starter") are invisible in the release page and aren't downloadable.
+	assetStateUploaded = "uploaded"
 )

--- a/pkg/controller/generate-registry/generate.go
+++ b/pkg/controller/generate-registry/generate.go
@@ -273,7 +273,7 @@ func (c *Controller) listReleaseAssets(ctx context.Context, logger *slog.Logger,
 			// GitHub keeps assets whose upload didn't complete with the state "starter".
 			// They are hidden from the release page and can't be downloaded,
 			// so they must not be used to generate a package configuration.
-			if state := a.GetState(); state != assetStateUploaded {
+			if a.GetState() != assetStateUploaded {
 				continue
 			}
 			arr = append(arr, a)

--- a/pkg/controller/generate-registry/generate.go
+++ b/pkg/controller/generate-registry/generate.go
@@ -269,7 +269,15 @@ func (c *Controller) listReleaseAssets(ctx context.Context, logger *slog.Logger,
 			)
 			return arr
 		}
-		arr = append(arr, assets...)
+		for _, a := range assets {
+			// GitHub keeps assets whose upload didn't complete with the state "starter".
+			// They are hidden from the release page and can't be downloaded,
+			// so they must not be used to generate a package configuration.
+			if state := a.GetState(); state != assetStateUploaded {
+				continue
+			}
+			arr = append(arr, a)
+		}
 		if len(assets) < opts.PerPage {
 			return arr
 		}

--- a/pkg/controller/generate-registry/generate_internal_test.go
+++ b/pkg/controller/generate-registry/generate_internal_test.go
@@ -92,16 +92,25 @@ func TestController_getPackageInfo(t *testing.T) { //nolint:funlen
 			},
 			assets: []*github.ReleaseAsset{
 				{
-					Name: new("gh_2.13.0_linux_amd64.tar.gz"),
+					Name:  new("gh_2.13.0_linux_amd64.tar.gz"),
+					State: new(assetStateUploaded),
 				},
 				{
-					Name: new("gh_2.13.0_linux_arm64.tar.gz"),
+					Name:  new("gh_2.13.0_linux_arm64.tar.gz"),
+					State: new(assetStateUploaded),
 				},
 				{
-					Name: new("gh_2.13.0_macOS_amd64.tar.gz"),
+					Name:  new("gh_2.13.0_macOS_amd64.tar.gz"),
+					State: new(assetStateUploaded),
 				},
 				{
-					Name: new("gh_2.13.0_windows_amd64.zip"),
+					Name:  new("gh_2.13.0_windows_amd64.zip"),
+					State: new(assetStateUploaded),
+				},
+				{
+					// An incomplete upload. It must be ignored.
+					Name:  new("gh_2.13.0_windows_arm64.zip"),
+					State: new("starter"),
 				},
 			},
 		},


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [ ] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue:
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

## What

`aqua gr` ignores GitHub Release assets whose `state` isn't `uploaded`.

## Why

GitHub keeps an asset whose upload was interrupted with the state `starter`.
Such an asset is hidden from the release page and can't be downloaded, but the
REST API still returns it from `GET /repos/{owner}/{repo}/releases/{id}/assets`.
`listReleaseAssets` didn't look at `state`, so `aqua gr` generated a package
configuration referring to an asset that doesn't exist.

A real example is `keilerkonzept/terraform-module-versions`. Its releases 3.0.29
and 3.1.14 have exactly one asset each, and both are in the `starter` state:

```console
$ gh api repos/keilerkonzept/terraform-module-versions/releases/tags/3.0.29 --jq '.assets|length'
0

$ gh api repos/keilerkonzept/terraform-module-versions/releases/52798480/assets --jq '.[] | "\(.state)\t\(.name)"'
starter	terraform-module-versions_3.0.29_osx_x86_64.tar.gz
```

Note that the `assets` field embedded in the release object is empty while the
assets API returns the asset. `aqua gr` uses the latter, so it generated

```yaml
      - version_constraint: Version in ["3.0.29", "3.1.14"]
        asset: terraform-module-versions_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
        format: tar.gz
        rosetta2: true
        replacements:
          amd64: x86_64
          darwin: osx
        supported_envs:
          - darwin
```

and `aqua i` failed:

```
ERR install the package package_name=keilerkonzept/terraform-module-versions package_version=3.0.29 error="the asset isn't found: terraform-module-versions_3.0.29_osx_x86_64.tar.gz"
```

The correct configuration is `no_asset: true`.

## How

`listReleaseAssets` skips any asset whose `state` isn't `uploaded`.

## Verification

`aqua gr` now generates `no_asset: true` for 3.1.14 (3.0.29 is out of `--limit 25`):

```console
$ go run ./cmd/aqua gr --limit 25 keilerkonzept/terraform-module-versions
packages:
  - type: github_release
    repo_owner: keilerkonzept
    repo_name: terraform-module-versions
    ...
    version_overrides:
      - version_constraint: Version in ["3.1.14", "v3.2.1"]
        no_asset: true
      - version_constraint: semver("<= 3.2.1")
        asset: terraform-module-versions_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
        ...
```

`TestController_getPackageInfo` gained an asset in the `starter` state, and it
fails without this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented incomplete release assets from appearing in generated package configurations.
  - Ensured only fully uploaded assets are included and available for download.
- **Tests**
  - Added coverage confirming incomplete starter assets are ignored during package generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->