### PR TITLE
docs: guide users through persistent PATH setup

### DIFF
--- a/website/docs/install.md
+++ b/website/docs/install.md
@@ -1,27 +1,57 @@
 ---
 sidebar_position: 150
+mdx:
+  format: mdx
 ---
+
+import TabItem from '@theme/TabItem';
+import InstallationSetup, {InstallationMethodTabs, InstallationShellTabs, InstallationTabLabel} from '@site/src/components/InstallationSetup';
 
 # Install
 
 aqua is a single binary written in Go.
 
-1. Install the binary `aqua` in `PATH`
-1. Set the environment variable `PATH`
-1. [(Optional) Shell completion](/docs/reference/config/shell-completion)
+For your local terminal, complete all three steps:
+
+1. **Install aqua** using one of the methods below.
+2. **Save the `PATH` setting** in your shell configuration: [Bash](?platform=linux#bash), [Zsh](?platform=macos#zsh), or [Windows](?platform=windows#powershell). Running `export` only in your terminal does not persist the setting.
+3. **Open a new terminal** and run `aqua -v` to check that aqua is still available.
+
+You can also enable [shell completion](/docs/reference/config/shell-completion) after setup.
 
 ## 1. Install the binary `aqua` in `PATH`
 
-- [Homebrew](#homebrew)
-- Windows
-  - [Winget](#winget)
-  - [Scoop](#scoop)
-- [aqua-installer (Shell Script)](/docs/products/aqua-installer#shell-script)
-- [aqua-installer (GitHub Actions)](/docs/products/aqua-installer#github-actions)
-- [CircleCI Orb](/docs/products/circleci-orb-aqua)
-- [go install](#go-install)
-- [Dev Container Feature](https://github.com/aquaproj/devcontainer-features/tree/main/src/aqua-installer)
-- [Download prebuilt binaries from GitHub Releases](#download-prebuilt-binaries-from-github-releases)
+Choose one installation method. For a local terminal, continue to step 2 to save your `PATH` setting.
+
+<InstallationMethodTabs>
+<TabItem value="script" label={<InstallationTabLabel title="Shell Script" detail="Linux / macOS / WSL" />}>
+
+For Linux, macOS, and WSL.
+
+### aqua-installer (Shell Script)
+
+Run the installer, then continue to step 2 below to save your `PATH` setting.
+
+```bash
+curl -sSfL -O https://raw.githubusercontent.com/aquaproj/aqua-installer/v4.0.2/aqua-installer
+echo "98b883756cdd0a6807a8c7623404bfc3bc169275ad9064dc23a6e24ad398f43d  aqua-installer" | sha256sum -c -
+chmod +x aqua-installer
+./aqua-installer
+```
+
+On macOS, use `shasum -a 256 -c -` instead of `sha256sum -c -`.
+See [aqua-installer](/docs/products/aqua-installer#shell-script) for installer options.
+
+:::tip Next: save your PATH setting
+Next, [save the `PATH` setting](#2-set-the-environment-variable-path) so your shell can find tools installed by aqua.
+You still need to complete step 2 to save this PATH setting for new terminal sessions.
+:::
+
+</TabItem>
+
+<TabItem value="homebrew" label={<InstallationTabLabel title="Homebrew" detail="macOS / Linux" />}>
+
+For macOS and Linux with Homebrew installed.
 
 ### Homebrew
 
@@ -39,6 +69,17 @@ Or
 brew install aquaproj/aqua/aqua
 ```
 
+:::tip Next: save your PATH setting
+Next, [save the `PATH` setting](#2-set-the-environment-variable-path) so your shell can find tools installed by aqua.
+You still need to complete step 2 to save this PATH setting for new terminal sessions.
+:::
+
+</TabItem>
+
+<TabItem value="winget" label={<InstallationTabLabel title="Winget" detail="Windows" />}>
+
+For Windows. Run the command in PowerShell or Command Prompt.
+
 ### Winget
 
 From [aqua v2.17.4](https://github.com/aquaproj/aqua/releases/tag/v2.17.4), you can install aqua by [Winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/).
@@ -52,6 +93,17 @@ Due to the mechanism of Winget, it takes a few days at most until we can install
 Everytime a new version is released, we need to send a pull request to [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) and wait until the pull request is merged.
 [The list of pull requests](https://github.com/microsoft/winget-pkgs/pulls?q=is%3Aopen+is%3Apr+author%3Asuzuki-shunsuke+aquaproj.aqua+in%3Atitle)
 :::
+
+:::tip Next: save your PATH setting
+Next, [save the `PATH` setting](#2-set-the-environment-variable-path) so your shell can find tools installed by aqua.
+You still need to complete step 2 to save this PATH setting for new terminal sessions.
+:::
+
+</TabItem>
+
+<TabItem value="scoop" label={<InstallationTabLabel title="Scoop" detail="Windows" />}>
+
+For Windows with Scoop installed.
 
 ### Scoop
 
@@ -71,17 +123,38 @@ scoop bucket add aquaproj https://github.com/aquaproj/scoop-bucket
 scoop install aqua
 ```
 
+:::tip Next: save your PATH setting
+Next, [save the `PATH` setting](#2-set-the-environment-variable-path) so your shell can find tools installed by aqua.
+You still need to complete step 2 to save this PATH setting for new terminal sessions.
+:::
+
+</TabItem>
+
+<TabItem value="go" label={<InstallationTabLabel title="Go" detail="Go toolchain" />}>
+
+Requires Go. Available on Linux, macOS, Windows, and WSL.
+
 ### go install
 
 ```sh
 go install github.com/aquaproj/aqua/v2/cmd/aqua@latest
 ```
 
+:::tip Next: save your PATH setting
+Next, [save the `PATH` setting](#2-set-the-environment-variable-path) so your shell can find tools installed by aqua.
+You still need to complete step 2 to save this PATH setting for new terminal sessions.
+:::
+
+</TabItem>
+
+<TabItem value="binary" label={<InstallationTabLabel title="Prebuilt binaries" detail="Manual download" />}>
+
 ### Download prebuilt binaries from GitHub Releases
 
 https://github.com/aquaproj/aqua/releases
 
-#### Verify downloaded binaries from GitHub Releases
+<details>
+<summary>Verify downloaded binaries from GitHub Releases</summary>
 
 You can verify downloaded binaries using some tools.
 
@@ -180,81 +253,232 @@ REPO                                 PREDICATE_TYPE                  WORKFLOW
 suzuki-shunsuke/go-release-workflow  https://slsa.dev/provenance/v1  .github/workflows/release.yaml@7f97a226912ee2978126019b1e95311d7d15c97a
 ```
 
+</details>
+
+:::tip Next: save your PATH setting
+Next, [save the `PATH` setting](#2-set-the-environment-variable-path) so your shell can find tools installed by aqua.
+You still need to complete step 2 to save this PATH setting for new terminal sessions.
+:::
+
+</TabItem>
+<TabItem value="github-actions" label={<InstallationTabLabel title="GitHub Actions" detail="CI workflows" />}>
+
+Add the following step to your workflow:
+
+```yaml
+- uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5
+  with:
+    aqua_version: v2.43.1
+```
+
+See [aqua-installer (GitHub Actions)](/docs/products/aqua-installer#github-actions) for configuration options.
+:::info PATH is configured automatically
+The action configures `PATH` for the workflow, so the local shell setup in steps 2 and 3 is not needed.
+:::
+
+</TabItem>
+<TabItem value="others" label={<InstallationTabLabel title="Others" detail="CI / containers" />}>
+
+Follow the setup instructions for your CI or development container:
+
+- [CircleCI Orb](/docs/products/circleci-orb-aqua)
+- [Dev Container Feature](https://github.com/aquaproj/devcontainer-features/tree/main/src/aqua-installer)
+
+:::info Follow the integration setup
+Use the linked instructions to configure your CI or development container. Steps 2 and 3 below are for local terminal installations.
+:::
+
+</TabItem>
+</InstallationMethodTabs>
+
 ## 2. Set the environment variable `PATH`
 
-:::info
-From aqua v2.8.0, `aqua root-dir` command is available.
+<InstallationSetup>
+
+<InstallationShellTabs>
+<TabItem value="linux" label={<InstallationTabLabel title="Bash" detail="Linux / WSL / Git Bash" />}>
+
+#### Bash
+
+##### Linux / WSL
+
+```bash
+cat >> ~/.bashrc <<'EOF'
+export PATH="${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin:$PATH"
+EOF
+
+source ~/.bashrc
+```
+
+Add the `export PATH=...` line shown above to `~/.bashrc` so aqua stays on PATH in new shells.
+The commands above append this line and reload the file; run them once.
+
+
+<details>
+<summary>Git Bash on Windows</summary>
+
+##### Git Bash (Windows)
+
+```bash
+cat >> ~/.bashrc <<'EOF'
+export PATH="${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-${LOCALAPPDATA:-$HOME/AppData/Local}}/aquaproj-aqua}/bin:$PATH"
+EOF
+
+source ~/.bashrc
+```
+
+This appends the Windows-specific PATH setting to `~/.bashrc` and loads it into the current shell.
+Git Bash uses the Windows install directory; WSL uses the Linux instructions above.
+Run this once, or just run `source ~/.bashrc` if you have already saved the line.
+
+The install directory is selected in this order: `AQUA_ROOT_DIR`, `XDG_DATA_HOME/aquaproj-aqua`, `LOCALAPPDATA/aquaproj-aqua`, then `$HOME/AppData/Local/aquaproj-aqua`.
+
+</details>
+
+Bash login shells read `~/.bash_profile`, `~/.bash_login`, or `~/.profile` instead of `~/.bashrc` (the first file that exists).
+If your terminal starts a login shell, ensure that file sources `~/.bashrc`, or add the `export` line to that file too.
+
+<details>
+<summary>PATH options and other version managers</summary>
+
+If you customize `AQUA_ROOT_DIR` or `XDG_DATA_HOME`, set it before the PATH line in your shell configuration.
+The quoted `EOF` keeps the variables unchanged until your shell reads the configuration.
+
+If aqua is already available in your shell, aqua v2.8.0 or later can also print its root directory:
 
 ```bash
 export PATH="$(aqua root-dir)/bin:$PATH"
 ```
-:::
 
-:::tip
-If you use aqua combined with other version manager such as asdf,
-please add `${AQUA_ROOT_DIR}/bin` to the environment variable `PATH` after other version manager.
-For detail, please see [here](/docs/reference/use-aqua-with-other-tools).
-:::
+Save this line in your shell configuration if you use it instead of the example above.
 
-### Linux, macOS
+If you use another version manager such as asdf, place aqua's PATH setting after that manager's setup.
+See [using aqua with other tools](/docs/reference/use-aqua-with-other-tools).
 
-```sh
+</details>
+
+</TabItem>
+<TabItem value="macos" label={<InstallationTabLabel title="Zsh" detail="macOS" />}>
+
+#### Zsh
+
+```zsh
+cat >> "${ZDOTDIR:-$HOME}/.zshrc" <<'EOF'
 export PATH="${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin:$PATH"
+EOF
+
+source "${ZDOTDIR:-$HOME}/.zshrc"
 ```
 
-### Windows
+Add the `export PATH=...` line shown above to `${ZDOTDIR:-$HOME}/.zshrc` so aqua stays on PATH in new shells.
+The commands above append this line and reload the file; run them once.
 
-About Windows, please see [here](/docs/reference/windows-support) too.
 
-- Git Bash (mingw)
-- PowerShell
-- Command Prompt
+<details>
+<summary>PATH options and other version managers</summary>
 
-#### Git Bash (mingw)
+If you customize `AQUA_ROOT_DIR` or `XDG_DATA_HOME`, set it before the PATH line in your shell configuration.
+The quoted `EOF` keeps the variables unchanged until your shell reads the configuration.
 
-```sh
-export PATH="${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-${LOCALAPPDATA:-$HOME/AppData/Local}}/aquaproj-aqua}/bin:$PATH"
+If aqua is already available in your shell, aqua v2.8.0 or later can also print its root directory:
+
+```bash
+export PATH="$(aqua root-dir)/bin:$PATH"
 ```
 
-The order of priority is as follows:
+Save this line in your shell configuration if you use it instead of the example above.
 
-1. `$AQUA_ROOT_DIR/bin`: If `$AQUA_ROOT_DIR` is set
-1. `$XDG_DATA_HOME/aquaproj-aqua/bin`: If `$XDG_DATA_HOME` is set
-1. `$LOCALAPPDATA/aquaproj-aqua/bin`: If `$LOCALAPPDATA` is set
-1. `$HOME/AppData/Local/aquaproj-aqua/bin`
+If you use another version manager such as asdf, place aqua's PATH setting after that manager's setup.
+See [using aqua with other tools](/docs/reference/use-aqua-with-other-tools).
+
+</details>
+
+</TabItem>
+<TabItem value="windows" label={<InstallationTabLabel title="PowerShell" detail="Windows" />}>
 
 #### PowerShell
 
-```sh
-Set-Item Env:Path "$Env:LOCALAPPDATA\aquaproj-aqua\bin;$Env:Path"
+```powershell
+if (!(Test-Path -Path $PROFILE)) {
+    New-Item -ItemType File -Path $PROFILE -Force
+}
+Add-Content -Path $PROFILE -Value 'Set-Item Env:Path "$Env:LOCALAPPDATA\aquaproj-aqua\bin;$Env:Path"'
+. $PROFILE
 ```
 
-If `LOCALAPPDATA` isn't set,
+PowerShell reads its profile when it starts. The commands above create that file if needed, append aqua's PATH setting, and load it into the current shell.
+`Add-Content` preserves the existing contents. Run this once; if the line is already saved, only run `. $PROFILE` to reload it.
+See [PowerShell profiles](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles) for details about the startup file.
 
-```sh
-Set-Item Env:Path "$Env:HOMEPATH\AppData\Local\aquaproj-aqua\bin;$Env:Path"
+<details>
+<summary>Custom install directory and PATH options</summary>
+
+If `LOCALAPPDATA` is not set, use this line in your profile instead:
+
+```powershell
+Set-Item Env:Path "$Env:USERPROFILE\AppData\Local\aquaproj-aqua\bin;$Env:Path"
 ```
 
-You can customize the path with the environment variable `AQUA_ROOT_DIR`.
+If you set `AQUA_ROOT_DIR`, use:
 
-```sh
-Set-Item Env:Path "$Env:AQUA_ROOT_DIR\bin;$ENV:Path"
+```powershell
+Set-Item Env:Path "$Env:AQUA_ROOT_DIR\bin;$Env:Path"
 ```
+
+Set any custom root directory before the PATH line in your profile.
+If you use another version manager, place aqua's PATH setting after that manager's setup.
+See [using aqua with other tools](/docs/reference/use-aqua-with-other-tools).
+
+</details>
+
+See [Windows support](/docs/reference/windows-support) for more details.
+
+</TabItem>
+<TabItem value="command-prompt" label={<InstallationTabLabel title="Command Prompt" detail="Windows" />}>
 
 #### Command Prompt
 
-```sh
-SET PATH=%LOCALAPPDATA%\aquaproj-aqua\bin;%PATH%
+1. Open **Edit environment variables for your account** from the Windows Start menu.
+2. Under **User variables**, select **Path**, choose **Edit**, and add `%LOCALAPPDATA%\aquaproj-aqua\bin` as a new entry.
+3. Save the change and open a new terminal.
+
+This saves aqua's bin directory in your user PATH so new Command Prompt sessions can find aqua and its tools.
+If you installed aqua under `AQUA_ROOT_DIR`, add that directory's `bin` folder instead.
+
+<details>
+<summary>Set PATH for the current session only</summary>
+
+```batch
+SET "PATH=%LOCALAPPDATA%\aquaproj-aqua\bin;%PATH%"
 ```
 
-If `LOCALAPPDATA` isn't set,
+If `LOCALAPPDATA` is not set:
 
-```sh
-SET PATH=%HOMEPATH%\AppData\Local\aquaproj-aqua\bin;%PATH%
+```batch
+SET "PATH=%USERPROFILE%\AppData\Local\aquaproj-aqua\bin;%PATH%"
 ```
 
-You can also customize the path with the environment variable `AQUA_ROOT_DIR`.
+If you set `AQUA_ROOT_DIR`:
+
+```batch
+SET "PATH=%AQUA_ROOT_DIR%\bin;%PATH%"
+```
+
+These commands only update the current session. Use the steps above to persist the setting.
+
+</details>
+
+</TabItem>
+</InstallationShellTabs>
+
+## 3. Check your setup
+
+Open a new terminal and confirm aqua is still available:
 
 ```sh
-SET PATH=%AQUA_ROOT_DIR%\bin;%PATH%
+aqua -v
 ```
+
+If the command is not found, check that you saved the `PATH` setting in the configuration file your shell reads.
+
+</InstallationSetup>

--- a/website/docs/install.md
+++ b/website/docs/install.md
@@ -5,7 +5,7 @@ mdx:
 ---
 
 import TabItem from '@theme/TabItem';
-import InstallationSetup, {InstallationMethodTabs, InstallationShellTabs, InstallationTabLabel} from '@site/src/components/InstallationSetup';
+import InstallationSetup, {InstallationMethodTabs, InstallationShellTabs, InstallationTabLabel, InstallationShellLink} from '@site/src/components/InstallationSetup';
 
 # Install
 
@@ -14,7 +14,7 @@ aqua is a single binary written in Go.
 For your local terminal, complete all three steps:
 
 1. **Install aqua** using one of the methods below.
-2. **Save the `PATH` setting** in your shell configuration: [Bash](?platform=linux#bash), [Zsh](?platform=macos#zsh), or [Windows](?platform=windows#powershell). Running `export` only in your terminal does not persist the setting.
+2. **Save the `PATH` setting** in your shell configuration: <InstallationShellLink platform="linux" hash="#bash">Bash</InstallationShellLink>, <InstallationShellLink platform="macos" hash="#zsh">Zsh</InstallationShellLink>, or <InstallationShellLink platform="windows" hash="#powershell">Windows</InstallationShellLink>. Running `export` only in your terminal does not persist the setting.
 3. **Open a new terminal** and run `aqua -v` to check that aqua is still available.
 
 You can also enable [shell completion](/docs/reference/config/shell-completion) after setup.
@@ -147,7 +147,7 @@ You still need to complete step 2 to save this PATH setting for new terminal ses
 
 </TabItem>
 
-<TabItem value="binary" label={<InstallationTabLabel title="Prebuilt binaries" detail="Manual download" />}>
+<TabItem value="binary" label={<InstallationTabLabel title="Prebuilt binaries" detail="GitHub Releases" />}>
 
 ### Download prebuilt binaries from GitHub Releases
 
@@ -277,15 +277,21 @@ The action configures `PATH` for the workflow, so the local shell setup in steps
 :::
 
 </TabItem>
-<TabItem value="others" label={<InstallationTabLabel title="Others" detail="CI / containers" />}>
+<TabItem value="circleci" label={<InstallationTabLabel title="CircleCI Orb" detail="CI workflows" />}>
 
-Follow the setup instructions for your CI or development container:
-
-- [CircleCI Orb](/docs/products/circleci-orb-aqua)
-- [Dev Container Feature](https://github.com/aquaproj/devcontainer-features/tree/main/src/aqua-installer)
+Follow the [CircleCI Orb setup instructions](/docs/products/circleci-orb-aqua).
 
 :::info Follow the integration setup
-Use the linked instructions to configure your CI or development container. Steps 2 and 3 below are for local terminal installations.
+Use the linked instructions to configure CircleCI. Steps 2 and 3 below are for local terminal installations.
+:::
+
+</TabItem>
+<TabItem value="devcontainer" label={<InstallationTabLabel title="Dev Container Feature" detail="Development containers" />}>
+
+Follow the [Dev Container Feature setup instructions](https://github.com/aquaproj/devcontainer-features/tree/main/src/aqua-installer).
+
+:::info Follow the integration setup
+Use the linked instructions to configure your development container. Steps 2 and 3 below are for local terminal installations.
 :::
 
 </TabItem>
@@ -471,7 +477,11 @@ These commands only update the current session. Use the steps above to persist t
 </TabItem>
 </InstallationShellTabs>
 
+</InstallationSetup>
+
 ## 3. Check your setup
+
+<InstallationSetup>
 
 Open a new terminal and confirm aqua is still available:
 

--- a/website/docs/products/aqua-installer/index.md
+++ b/website/docs/products/aqua-installer/index.md
@@ -13,6 +13,16 @@ https://github.com/aquaproj/aqua-installer
 
 ## Shell Script
 
+:::info Complete your local setup
+
+Installing aqua is the first step. To use it in future terminal sessions:
+
+1. Run the installer below.
+2. Save the `PATH` setting in your shell configuration using the [Bash](/docs/install?platform=linux#bash), [Zsh](/docs/install?platform=macos#zsh), or [Windows](/docs/install?platform=windows#powershell) instructions.
+3. Open a new terminal and run `aqua -v` to check that the setting persists.
+
+:::
+
 You can install aqua by the following one liner.
 
 ```bash
@@ -33,6 +43,9 @@ aqua-installer installs aqua to the following path.
 
 - linux, macOS: `${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin/aqua`
 - windows: `${AQUA_ROOT_DIR:-$HOME/AppData/Local/aquaproj-aqua}/bin/aqua`
+
+After installation, [configure `PATH`](/docs/install#2-set-the-environment-variable-path) and save the setting in your shell configuration so aqua remains available in new shells.
+The installation guide includes copy-paste commands for Bash and Zsh.
 
 :::caution
 From aqua-installer v2, aqua-installer doesn't support specifying the install path.

--- a/website/src/components/InstallationSetup.js
+++ b/website/src/components/InstallationSetup.js
@@ -4,8 +4,22 @@ import useIsBrowser from '@docusaurus/useIsBrowser';
 import Link from '@docusaurus/Link';
 import styles from './InstallationSetup.module.css';
 
-const suggestions = {homebrew: 'macos', winget: 'windows', scoop: 'windows'};
-const integrationMethods = ['github-actions', 'circleci', 'devcontainer'];
+const installationMethods = {
+  script: {platform: 'linux'},
+  homebrew: {platform: 'macos'},
+  winget: {platform: 'windows'},
+  scoop: {platform: 'windows'},
+  go: {platform: 'linux'},
+  binary: {platform: 'linux'},
+  'github-actions': {message: 'The GitHub Actions installer configures PATH for your workflow. No local shell setup or new-terminal check is needed.'},
+  circleci: {message: 'Follow the CircleCI Orb instructions in step 1. No local shell setup or new-terminal check is needed.'},
+  devcontainer: {message: 'Follow the Dev Container Feature instructions in step 1. No local shell setup or new-terminal check is needed.'},
+};
+
+function getInstallationMethod(search) {
+  const method = new URLSearchParams(search).get('method');
+  return Object.hasOwn(installationMethods, method) ? installationMethods[method] : installationMethods.script;
+}
 
 function useInstallationLocation() {
   const location = useLocation();
@@ -22,7 +36,7 @@ export function InstallationShellLink({platform, children, hash}) {
   const location = useInstallationLocation();
   const params = new URLSearchParams(location.search);
   params.set('platform', platform);
-  const targetHash = integrationMethods.includes(params.get('method')) ? '#2-set-the-environment-variable-path' : hash;
+  const targetHash = getInstallationMethod(location.search).message ? '#2-set-the-environment-variable-path' : hash;
   return <Link to={`${location.pathname}?${params}${targetHash}`}>{children}</Link>;
 }
 
@@ -36,6 +50,7 @@ function InstallationTabs({children, parameter, fallback, label}) {
   const selected = items.some(({props}) => props.value === requested) ? requested : fallback;
 
   function select(value) {
+    if (value === selected) return;
     const top = tabList.current.getBoundingClientRect().top;
     params.set(parameter, value);
     if (parameter === 'method') params.delete('platform');
@@ -78,6 +93,7 @@ export function InstallationMethodTabs({children}) {
   const location = useInstallationLocation();
   const history = useHistory();
   useEffect(() => {
+    let cancelDetailsScroll = () => {};
     // Hidden headings cannot be native scroll targets. Reveal their panel first,
     // including on a full page load when Docusaurus does not scroll again.
     function reveal(hash) {
@@ -93,6 +109,21 @@ export function InstallationMethodTabs({children}) {
         history.replace({...location, search: `?${params}`, hash});
         return;
       }
+      const details = target.closest('details[data-collapsed="true"]');
+      if (details) {
+        // Docusaurus tracks collapse state separately from the native open
+        // attribute. Use its toggle and wait until the content is expanded.
+        cancelDetailsScroll();
+        function onExpanded(event) {
+          if (event.propertyName !== 'height' || event.target.parentElement !== details) return;
+          cancelDetailsScroll();
+          reveal(hash);
+        }
+        details.addEventListener('transitionend', onExpanded);
+        cancelDetailsScroll = () => details.removeEventListener('transitionend', onExpanded);
+        details.querySelector('summary').click();
+        return;
+      }
       target.scrollIntoView();
     }
     const frame = requestAnimationFrame(() => reveal(location.hash));
@@ -105,25 +136,25 @@ export function InstallationMethodTabs({children}) {
       // Repeated clicks on an unchanged hash must reveal and scroll too.
       if (url.search === location.search && url.hash === location.hash) reveal(url.hash);
     }
-    document.addEventListener('click', onClick);
-    return () => { cancelAnimationFrame(frame); document.removeEventListener('click', onClick); };
+    // Details stops bubbling clicks, including clicks on heading permalinks.
+    document.addEventListener('click', onClick, true);
+    return () => {
+      cancelAnimationFrame(frame);
+      cancelDetailsScroll();
+      document.removeEventListener('click', onClick, true);
+    };
   }, [location.search, location.hash, location.pathname, history]);
   return <InstallationTabs parameter="method" fallback="script" label="Installation method">{children}</InstallationTabs>;
 }
 
 export default function InstallationSetup({children}) {
   const {search} = useInstallationLocation();
-  const method = new URLSearchParams(search).get('method');
-  const integrations = {
-    'github-actions': 'The GitHub Actions installer configures PATH for your workflow. No local shell setup or new-terminal check is needed.',
-    circleci: 'Follow the CircleCI Orb instructions in step 1. No local shell setup or new-terminal check is needed.',
-    devcontainer: 'Follow the Dev Container Feature instructions in step 1. No local shell setup or new-terminal check is needed.',
-  };
-  return integrations[method] ? <p>{integrations[method]}</p> : children;
+  const {message} = getInstallationMethod(search);
+  return message ? <p>{message}</p> : children;
 }
 
 export function InstallationShellTabs({children}) {
   const {search} = useInstallationLocation();
-  const method = new URLSearchParams(search).get('method');
-  return <InstallationTabs parameter="platform" fallback={suggestions[method] || 'linux'} label="Shell">{children}</InstallationTabs>;
+  const {platform} = getInstallationMethod(search);
+  return <InstallationTabs parameter="platform" fallback={platform || 'linux'} label="Shell">{children}</InstallationTabs>;
 }

--- a/website/src/components/InstallationSetup.js
+++ b/website/src/components/InstallationSetup.js
@@ -1,0 +1,74 @@
+import React, {useState} from 'react';
+import {useLocation} from '@docusaurus/router';
+import Tabs from '@theme/Tabs';
+import styles from './InstallationSetup.module.css';
+
+export function InstallationTabLabel({title, detail}) {
+  return (
+    <span className={styles.label}>
+      {title}
+      <span className={styles.detail}>{detail}</span>
+    </span>
+  );
+}
+
+export function InstallationMethodTabs({children}) {
+  return (
+    <Tabs className={styles.tabs} queryString="method" defaultValue="script">
+      {children}
+    </Tabs>
+  );
+}
+
+function useInstallationMethod() {
+  const {search} = useLocation();
+  const params = new URLSearchParams(search);
+  return {
+    method: params.get('method') || 'script',
+    platform: params.get('platform'),
+  };
+}
+
+export default function InstallationSetup({children}) {
+  const {method} = useInstallationMethod();
+
+  if (method === 'github-actions') {
+    return <p>The GitHub Actions installer configures PATH for your workflow. No shell configuration or new-terminal check is needed.</p>;
+  }
+
+  if (method === 'others') {
+    return <p>Follow the CircleCI Orb or Dev Container Feature setup instructions linked in step 1. The local terminal instructions do not apply to those environments.</p>;
+  }
+
+  return children;
+}
+
+export function InstallationShellTabs({children}) {
+  const {method, platform} = useInstallationMethod();
+  const [selection, setSelection] = useState({method, urlPlatform: platform, platform});
+  if (selection.method !== method || selection.urlPlatform !== platform) {
+    // A new method resets the suggestion unless the link also selects a platform.
+    setSelection({
+      method,
+      urlPlatform: platform,
+      platform: selection.urlPlatform !== platform ? platform : null,
+    });
+  }
+  const suggestedPlatforms = {
+    script: 'linux',
+    homebrew: 'macos',
+    winget: 'windows',
+    scoop: 'windows',
+    go: 'linux',
+    binary: 'linux',
+  };
+  const defaultValue = ['linux', 'macos', 'windows', 'command-prompt'].includes(selection.platform)
+    ? selection.platform
+    : suggestedPlatforms[method] || suggestedPlatforms.script;
+
+  return (
+    <Tabs className={styles.tabs} key={`${method}:${platform}`} defaultValue={defaultValue}>
+      {children}
+    </Tabs>
+  );
+}

--- a/website/src/components/InstallationSetup.js
+++ b/website/src/components/InstallationSetup.js
@@ -1,74 +1,129 @@
-import React, {useState} from 'react';
-import {useLocation} from '@docusaurus/router';
-import Tabs from '@theme/Tabs';
+import React, {Children, useEffect, useRef} from 'react';
+import {useHistory, useLocation} from '@docusaurus/router';
+import useIsBrowser from '@docusaurus/useIsBrowser';
+import Link from '@docusaurus/Link';
 import styles from './InstallationSetup.module.css';
 
+const suggestions = {homebrew: 'macos', winget: 'windows', scoop: 'windows'};
+const integrationMethods = ['github-actions', 'circleci', 'devcontainer'];
+
+function useInstallationLocation() {
+  const location = useLocation();
+  const isBrowser = useIsBrowser();
+  // The server and the first client render must use the same defaults.
+  return {...location, search: isBrowser ? location.search : '', hash: isBrowser ? location.hash : ''};
+}
+
 export function InstallationTabLabel({title, detail}) {
-  return (
-    <span className={styles.label}>
-      {title}
-      <span className={styles.detail}>{detail}</span>
-    </span>
-  );
+  return <span className={styles.label}>{title}<span className={styles.detail}>{detail}</span></span>;
+}
+
+export function InstallationShellLink({platform, children, hash}) {
+  const location = useInstallationLocation();
+  const params = new URLSearchParams(location.search);
+  params.set('platform', platform);
+  const targetHash = integrationMethods.includes(params.get('method')) ? '#2-set-the-environment-variable-path' : hash;
+  return <Link to={`${location.pathname}?${params}${targetHash}`}>{children}</Link>;
+}
+
+function InstallationTabs({children, parameter, fallback, label}) {
+  const location = useInstallationLocation();
+  const history = useHistory();
+  const tabList = useRef(null);
+  const items = Children.toArray(children);
+  const params = new URLSearchParams(location.search);
+  const requested = params.get(parameter);
+  const selected = items.some(({props}) => props.value === requested) ? requested : fallback;
+
+  function select(value) {
+    const top = tabList.current.getBoundingClientRect().top;
+    params.set(parameter, value);
+    if (parameter === 'method') params.delete('platform');
+    history.push({...location, search: `?${params}`, hash: ''});
+    // Clearing an old anchor must not send the reader back to the page top.
+    requestAnimationFrame(() => {
+      if (tabList.current) window.scrollBy(0, tabList.current.getBoundingClientRect().top - top);
+    });
+  }
+
+  function onKeyDown(event, index) {
+    const offsets = {ArrowRight: 1, ArrowLeft: -1, Home: -index, End: items.length - 1 - index};
+    if (!(event.key in offsets)) return;
+    event.preventDefault();
+    const next = (index + offsets[event.key] + items.length) % items.length;
+    event.currentTarget.parentElement.children[next].focus();
+    select(items[next].props.value);
+  }
+
+  return <div className="tabs-container">
+    <div ref={tabList} className={`tabs ${styles.tabs}`} role="tablist" aria-label={label}>
+      {items.map(({props}, index) => <button
+        type="button" role="tab" key={props.value}
+        id={`${parameter}-tab-${props.value}`} aria-controls={`${parameter}-panel-${props.value}`}
+        aria-selected={selected === props.value} tabIndex={selected === props.value ? 0 : -1}
+        className="tabs__item" onClick={() => select(props.value)} onKeyDown={(event) => onKeyDown(event, index)}>
+        {props.label}
+      </button>)}
+    </div>
+    {items.map(({props}) => <div key={props.value} role="tabpanel"
+      id={`${parameter}-panel-${props.value}`} aria-labelledby={`${parameter}-tab-${props.value}`}
+      data-installation-parameter={parameter} data-installation-value={props.value}
+      hidden={selected !== props.value} className="margin-top--md">
+      {props.children}
+    </div>)}
+  </div>;
 }
 
 export function InstallationMethodTabs({children}) {
-  return (
-    <Tabs className={styles.tabs} queryString="method" defaultValue="script">
-      {children}
-    </Tabs>
-  );
-}
-
-function useInstallationMethod() {
-  const {search} = useLocation();
-  const params = new URLSearchParams(search);
-  return {
-    method: params.get('method') || 'script',
-    platform: params.get('platform'),
-  };
+  const location = useInstallationLocation();
+  const history = useHistory();
+  useEffect(() => {
+    // Hidden headings cannot be native scroll targets. Reveal their panel first,
+    // including on a full page load when Docusaurus does not scroll again.
+    function reveal(hash) {
+      let id;
+      try { id = decodeURIComponent(hash.slice(1)); } catch { return; }
+      const target = document.getElementById(id);
+      if (!target) return;
+      const panel = target.closest('[data-installation-parameter]');
+      const params = new URLSearchParams(location.search);
+      if (panel && params.get(panel.dataset.installationParameter) !== panel.dataset.installationValue) {
+        params.set(panel.dataset.installationParameter, panel.dataset.installationValue);
+        if (panel.dataset.installationParameter === 'method') params.delete('platform');
+        history.replace({...location, search: `?${params}`, hash});
+        return;
+      }
+      target.scrollIntoView();
+    }
+    const frame = requestAnimationFrame(() => reveal(location.hash));
+    function onClick(event) {
+      if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+      const anchor = event.target.closest('a[href]');
+      if (!anchor) return;
+      const url = new URL(anchor.href);
+      if (url.origin !== window.location.origin || url.pathname !== location.pathname || !url.hash) return;
+      // Repeated clicks on an unchanged hash must reveal and scroll too.
+      if (url.search === location.search && url.hash === location.hash) reveal(url.hash);
+    }
+    document.addEventListener('click', onClick);
+    return () => { cancelAnimationFrame(frame); document.removeEventListener('click', onClick); };
+  }, [location.search, location.hash, location.pathname, history]);
+  return <InstallationTabs parameter="method" fallback="script" label="Installation method">{children}</InstallationTabs>;
 }
 
 export default function InstallationSetup({children}) {
-  const {method} = useInstallationMethod();
-
-  if (method === 'github-actions') {
-    return <p>The GitHub Actions installer configures PATH for your workflow. No shell configuration or new-terminal check is needed.</p>;
-  }
-
-  if (method === 'others') {
-    return <p>Follow the CircleCI Orb or Dev Container Feature setup instructions linked in step 1. The local terminal instructions do not apply to those environments.</p>;
-  }
-
-  return children;
+  const {search} = useInstallationLocation();
+  const method = new URLSearchParams(search).get('method');
+  const integrations = {
+    'github-actions': 'The GitHub Actions installer configures PATH for your workflow. No local shell setup or new-terminal check is needed.',
+    circleci: 'Follow the CircleCI Orb instructions in step 1. No local shell setup or new-terminal check is needed.',
+    devcontainer: 'Follow the Dev Container Feature instructions in step 1. No local shell setup or new-terminal check is needed.',
+  };
+  return integrations[method] ? <p>{integrations[method]}</p> : children;
 }
 
 export function InstallationShellTabs({children}) {
-  const {method, platform} = useInstallationMethod();
-  const [selection, setSelection] = useState({method, urlPlatform: platform, platform});
-  if (selection.method !== method || selection.urlPlatform !== platform) {
-    // A new method resets the suggestion unless the link also selects a platform.
-    setSelection({
-      method,
-      urlPlatform: platform,
-      platform: selection.urlPlatform !== platform ? platform : null,
-    });
-  }
-  const suggestedPlatforms = {
-    script: 'linux',
-    homebrew: 'macos',
-    winget: 'windows',
-    scoop: 'windows',
-    go: 'linux',
-    binary: 'linux',
-  };
-  const defaultValue = ['linux', 'macos', 'windows', 'command-prompt'].includes(selection.platform)
-    ? selection.platform
-    : suggestedPlatforms[method] || suggestedPlatforms.script;
-
-  return (
-    <Tabs className={styles.tabs} key={`${method}:${platform}`} defaultValue={defaultValue}>
-      {children}
-    </Tabs>
-  );
+  const {search} = useInstallationLocation();
+  const method = new URLSearchParams(search).get('method');
+  return <InstallationTabs parameter="platform" fallback={suggestions[method] || 'linux'} label="Shell">{children}</InstallationTabs>;
 }

--- a/website/src/components/InstallationSetup.module.css
+++ b/website/src/components/InstallationSetup.module.css
@@ -12,6 +12,9 @@
   border: 1px solid var(--ifm-color-emphasis-300);
   border-radius: var(--ifm-global-radius);
   text-align: left;
+  background: transparent;
+  color: inherit;
+  font: inherit;
 }
 
 .tabs > [aria-selected='true'] {

--- a/website/src/components/InstallationSetup.module.css
+++ b/website/src/components/InstallationSetup.module.css
@@ -1,0 +1,41 @@
+.tabs {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.5rem;
+  overflow: visible;
+}
+
+.tabs > [role='tab'] {
+  display: block;
+  min-width: 0;
+  padding: 0.75rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-global-radius);
+  text-align: left;
+}
+
+.tabs > [aria-selected='true'] {
+  border-color: var(--ifm-color-primary);
+  background: var(--ifm-color-emphasis-100);
+}
+
+.label {
+  display: block;
+  font-size: 0.875rem;
+  line-height: 1.4;
+}
+
+.detail {
+  display: block;
+  margin-top: 0.25rem;
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.75rem;
+  font-weight: 400;
+  line-height: 1.4;
+}
+
+@media (max-width: 1200px) {
+  .tabs {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}


### PR DESCRIPTION
Users can finish installing aqua without realizing that PATH must be saved for future terminal sessions. This reorganizes the installation guide into method selection, persistent shell setup, and verification in a new terminal.

- Add responsive installation-method tabs with platform subtitles and a PATH reminder in every local method.
- Suggest the relevant shell tab and provide persistent Bash, Zsh, PowerShell, and Command Prompt instructions; keep Git Bash under Bash and advanced details collapsed.
- Provide separate GitHub Actions, CircleCI Orb, and Dev Container Feature tabs, and link aqua-installer documentation to the setup steps.
- Keep tab selection synchronized with the URL after hydration, reveal hidden panels for anchor navigation, and preserve installation methods in the shell links.

Closes #5205.

## Initial layout preview

<img width="600" alt="output" src="https://github.com/user-attachments/assets/0156b41c-b150-4db0-a9fb-6fbc818995d9" />



## Validation

- Website production build passed; it reports existing broken-anchor warnings on four unrelated documentation pages.
- Production Chrome checks passed with no console errors: direct query-string loads, PowerShell/Zsh anchors, hidden-panel TOC links, CI shell links, reloads, Back/Forward (including removal of query parameters), keyboard navigation, and tab scroll preservation. Checked desktop and 412px layouts with no horizontal page overflow.
- Additional production regressions passed: Git Bash heading links expand their collapsed content and scroll after the animation (including reduced motion); clicking an active tab preserves the selected shell, URL and history; invalid method values including `__proto__`, `constructor` and `toString` fall back to Shell Script without React errors.
- Checked generated tab panels and callouts, plus Bash/Zsh snippets in temporary configuration files. Git Bash command syntax was checked with Bash; Windows-specific commands were not executed on Windows.
- `cmdx l`, `cmdx v`, and `cmdx t` passed.
- `git diff --check` passed.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: https://github.com/aquaproj/aqua/issues/5205
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

The design and wording were developed through hands-on review; AI assistance was used for implementation and validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Restructured installation instructions into guided tabs for installation methods and shell-specific PATH setup.
  - Added expanded instructions for Bash, Zsh, PowerShell, and Command Prompt.
  - Added a “Check your setup” step and made binary verification details collapsible.
  - Added dedicated guidance for GitHub Releases, CircleCI Orb, and Dev Container Feature.
  - Updated the aqua installer page with PATH configuration and setup verification guidance.

- **New Features**
  - Added responsive, URL-linked navigation for installation methods and platform setup.
  - Added contextual tips and suggested platform selections to simplify installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
