### PR TITLE
fix(docs): update copyright year at build time

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -4,6 +4,7 @@
 const {themes} = require('prism-react-renderer');
 const lightCodeTheme = themes.github;
 const darkCodeTheme = themes.dracula;
+const copyright = `Copyright © ${new Date().getFullYear()} Shunsuke Suzuki. Built with Docusaurus.`;
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -37,7 +38,7 @@ const config = {
           routeBasePath: '/blog',
           feedOptions: {
             type: 'all',
-            copyright: `Copyright © 2021 Shunsuke Suzuki. Built with Docusaurus.`,
+            copyright,
           },
         },
       }),
@@ -152,7 +153,7 @@ const config = {
             ],
           },
         ],
-        copyright: `Copyright © 2021 Shunsuke Suzuki. Built with Docusaurus.`,
+        copyright,
       },
       prism: {
         theme: lightCodeTheme,


### PR DESCRIPTION
The website footer still displays 2021. Compute the copyright year when Docusaurus loads its build configuration, and share the resulting string between the footer and blog feed. Future builds will use the current year automatically.

Closes #5217.

## Validation

- `npm run build` passed; generated home and installation pages contain the current year. Existing unrelated broken-anchor warnings remain.
- Evaluated the configuration with 2026 and 2027; both footer and feed settings follow the year.
- `golangci-lint run`, `go vet ./...`, `go test ./... -race -covermode=atomic`, and `git diff --check` passed.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: https://github.com/aquaproj/aqua/issues/5217
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

AI assistance was used for implementation and validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the website’s blog feed and footer copyright notices to display the current year automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->