### PR TITLE
docs(deps): update aqua-installer examples to v4.0.5

### DIFF
--- a/website/docs/guides/build-container-image.md
+++ b/website/docs/guides/build-container-image.md
@@ -35,8 +35,8 @@ COPY aqua.yaml aqua-checksums.json /etc/aqua/
 ENV AQUA_GLOBAL_CONFIG=/etc/aqua/aqua.yaml
 RUN apt-get update && \
     apt-get install -y curl && \
-    curl -sSfL -O https://raw.githubusercontent.com/aquaproj/aqua-installer/v4.0.2/aqua-installer && \
-    echo "98b883756cdd0a6807a8c7623404bfc3bc169275ad9064dc23a6e24ad398f43d  aqua-installer" | sha256sum -c - && \
+    curl -sSfL -O https://raw.githubusercontent.com/aquaproj/aqua-installer/v4.0.5/aqua-installer && \
+    echo "451028d56959cc738564885b1dbebc2691ea038ffde04e2472e4d486a3591146  aqua-installer" | sha256sum -c - && \
     chmod +x aqua-installer && \
     ./aqua-installer -v v2.48.3 && \
     rm aqua-installer && \
@@ -62,8 +62,8 @@ COPY aqua.yaml aqua-checksums.json /etc/aqua/
 ENV AQUA_GLOBAL_CONFIG=/etc/aqua/aqua.yaml
 RUN apt-get update
 RUN apt-get install -y curl
-RUN curl -sSfL -O https://raw.githubusercontent.com/aquaproj/aqua-installer/v4.0.2/aqua-installer
-RUN echo "98b883756cdd0a6807a8c7623404bfc3bc169275ad9064dc23a6e24ad398f43d  aqua-installer" | sha256sum -c -
+RUN curl -sSfL -O https://raw.githubusercontent.com/aquaproj/aqua-installer/v4.0.5/aqua-installer
+RUN echo "451028d56959cc738564885b1dbebc2691ea038ffde04e2472e4d486a3591146  aqua-installer" | sha256sum -c -
 RUN chmod +x aqua-installer
 RUN ./aqua-installer -v v2.48.3
 RUN aqua i -a

--- a/website/docs/guides/wrap-aqua-with-task-runner.md
+++ b/website/docs/guides/wrap-aqua-with-task-runner.md
@@ -142,8 +142,8 @@ fi
 
 tempdir=$(mktemp -d)
 cd "$tempdir"
-curl -sSfL -O https://raw.githubusercontent.com/aquaproj/aqua-installer/v4.0.2/aqua-installer
-echo "98b883756cdd0a6807a8c7623404bfc3bc169275ad9064dc23a6e24ad398f43d  aqua-installer" | sha256sum -c -
+curl -sSfL -O https://raw.githubusercontent.com/aquaproj/aqua-installer/v4.0.5/aqua-installer
+echo "451028d56959cc738564885b1dbebc2691ea038ffde04e2472e4d486a3591146  aqua-installer" | sha256sum -c -
 chmod +x aqua-installer
 
 ./aqua-installer

--- a/website/docs/products/aqua-installer/index.md
+++ b/website/docs/products/aqua-installer/index.md
@@ -16,15 +16,15 @@ https://github.com/aquaproj/aqua-installer
 You can install aqua by the following one liner.
 
 ```bash
-curl -sSfL https://raw.githubusercontent.com/aquaproj/aqua-installer/v4.0.2/aqua-installer | bash
+curl -sSfL https://raw.githubusercontent.com/aquaproj/aqua-installer/v4.0.5/aqua-installer | bash
 ```
 
 But the one liner is a bit dangerous because aqua-installer may be tampered.
 We recommend verifying aqua-installer's checksum before running it.
 
 ```bash
-curl -sSfL -O https://raw.githubusercontent.com/aquaproj/aqua-installer/v4.0.2/aqua-installer
-echo "98b883756cdd0a6807a8c7623404bfc3bc169275ad9064dc23a6e24ad398f43d  aqua-installer" | sha256sum -c -
+curl -sSfL -O https://raw.githubusercontent.com/aquaproj/aqua-installer/v4.0.5/aqua-installer
+echo "451028d56959cc738564885b1dbebc2691ea038ffde04e2472e4d486a3591146  aqua-installer" | sha256sum -c -
 chmod +x aqua-installer
 ./aqua-installer
 ```
@@ -45,7 +45,7 @@ You can pass the following parameters.
 e.g.
 
 ```bash
-curl -sSfL https://raw.githubusercontent.com/aquaproj/aqua-installer/v4.0.2/aqua-installer | bash -s -- -v v2.43.1
+curl -sSfL https://raw.githubusercontent.com/aquaproj/aqua-installer/v4.0.5/aqua-installer | bash -s -- -v v2.43.1
 ```
 
 If the version isn't specified, the latest version would be installed.

--- a/website/docs/products/aqua-renovate-config.md
+++ b/website/docs/products/aqua-renovate-config.md
@@ -110,7 +110,7 @@ e.g.
 ```
 
 ```sh
-curl -sSfL https://raw.githubusercontent.com/aquaproj/aqua-installer/v4.0.2/aqua-installer | bash -s -- -v v2.28.0
+curl -sSfL https://raw.githubusercontent.com/aquaproj/aqua-installer/v4.0.5/aqua-installer | bash -s -- -v v2.28.0
 ```
 
 :warning: To update aqua, please don't add newlines.
@@ -118,13 +118,13 @@ curl -sSfL https://raw.githubusercontent.com/aquaproj/aqua-installer/v4.0.2/aqua
 :thumbsup:
 
 ```sh
-curl -sSfL https://raw.githubusercontent.com/aquaproj/aqua-installer/v4.0.2/aqua-installer | bash -s -- -v v2.28.0
+curl -sSfL https://raw.githubusercontent.com/aquaproj/aqua-installer/v4.0.5/aqua-installer | bash -s -- -v v2.28.0
 ```
 
 :thumbsdown:
 
 ```sh
-curl -sSfL https://raw.githubusercontent.com/aquaproj/aqua-installer/v4.0.2/aqua-installer |
+curl -sSfL https://raw.githubusercontent.com/aquaproj/aqua-installer/v4.0.5/aqua-installer |
   bash -s -- -v v2.28.0 # aqua isn't updated
 ```
 

--- a/website/docs/reference/security/cosign-slsa.md
+++ b/website/docs/reference/security/cosign-slsa.md
@@ -38,7 +38,7 @@ export PATH="${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua
 You can install aqua by the following one liner.
 
 ```sh
-curl -sSfL https://raw.githubusercontent.com/aquaproj/aqua-installer/v4.0.2/aqua-installer | bash
+curl -sSfL https://raw.githubusercontent.com/aquaproj/aqua-installer/v4.0.5/aqua-installer | bash
 ```
 
 But the one liner is a bit dangerous because aqua-installer may be tampered.
@@ -46,8 +46,8 @@ But the one liner is a bit dangerous because aqua-installer may be tampered.
 You can verify aqua-installer with checksum.
 
 ```sh
-curl -sSfL -O https://raw.githubusercontent.com/aquaproj/aqua-installer/v4.0.2/aqua-installer
-echo "98b883756cdd0a6807a8c7623404bfc3bc169275ad9064dc23a6e24ad398f43d  aqua-installer" | sha256sum -c -
+curl -sSfL -O https://raw.githubusercontent.com/aquaproj/aqua-installer/v4.0.5/aqua-installer
+echo "451028d56959cc738564885b1dbebc2691ea038ffde04e2472e4d486a3591146  aqua-installer" | sha256sum -c -
 chmod +x aqua-installer
 ```
 

--- a/website/docs/tutorial/index.md
+++ b/website/docs/tutorial/index.md
@@ -37,8 +37,8 @@ apt-get install -y curl vim
 mkdir ~/workspace
 cd ~/workspace
 export PATH="${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin:$PATH"
-curl -sSfL -O https://raw.githubusercontent.com/aquaproj/aqua-installer/v4.0.2/aqua-installer
-echo "98b883756cdd0a6807a8c7623404bfc3bc169275ad9064dc23a6e24ad398f43d  aqua-installer" | sha256sum -c -
+curl -sSfL -O https://raw.githubusercontent.com/aquaproj/aqua-installer/v4.0.5/aqua-installer
+echo "451028d56959cc738564885b1dbebc2691ea038ffde04e2472e4d486a3591146  aqua-installer" | sha256sum -c -
 
 chmod +x aqua-installer
 ./aqua-installer


### PR DESCRIPTION
Update the website's aqua-installer shell-script examples from v4.0.2 to [v4.0.5](https://github.com/aquaproj/aqua-installer/releases/tag/v4.0.5). Replace all 12 pinned download URLs and all six SHA-256 examples across six documentation pages.

The new SHA-256 is `451028d56959cc738564885b1dbebc2691ea038ffde04e2472e4d486a3591146`. It was computed from the v4.0.5 script and verified against the exact raw download URL used in the examples.

## Validation

- Confirmed the GitHub API and raw URL return identical script bytes, and every updated checksum matches those bytes.
- Confirmed no v4.0.2 installer URLs or old checksum remain in the website documentation.
- `npm run build` passed, with existing unrelated broken-anchor warnings.
- `git diff --check` passed.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [ ] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: N/A — routine version/checksum update in documentation.
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

AI assistance was used for editing and validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation guides, tutorials, container examples, and security verification instructions to use aqua-installer v4.0.5.
  - Updated SHA-256 checksum examples to match the new installer version.
  - Refreshed aqua-renovate-config examples to reference aqua-installer v4.0.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->