### PR TITLE
fix: suggest aqua init when configuration is missing

### DIFF
--- a/pkg/config-finder/config_finder.go
+++ b/pkg/config-finder/config_finder.go
@@ -9,7 +9,7 @@ import (
 	"github.com/suzuki-shunsuke/go-findconfig/findconfig"
 )
 
-var ErrConfigFileNotFound = errors.New("configuration file isn't found")
+var ErrConfigFileNotFound = errors.New("configuration file isn't found; run \"aqua init\" to create one")
 
 type ConfigFinder struct{}
 

--- a/pkg/config-finder/config_finder_test.go
+++ b/pkg/config-finder/config_finder_test.go
@@ -90,11 +90,13 @@ func Test_configFinderFind(t *testing.T) { //nolint:funlen
 		exp                   string
 		files                 map[string]string
 		isErr                 bool
+		errMsg                string
 	}{
 		{
-			name:  "not found",
-			wd:    "foo",
-			isErr: true,
+			name:   "not found",
+			wd:     "foo",
+			isErr:  true,
+			errMsg: "configuration file isn't found; run \"aqua init\" to create one",
 		},
 		{
 			name:              "configFilePath",
@@ -138,6 +140,9 @@ func Test_configFinderFind(t *testing.T) { //nolint:funlen
 			p, err := configFinder.Find(join(root, d.wd)[0], configFilePath, join(root, d.globalConfigFilePaths...)...)
 			if err != nil {
 				if d.isErr {
+					if err.Error() != d.errMsg {
+						t.Fatalf("wanted error message %q, got %q", d.errMsg, err)
+					}
 					return
 				}
 				t.Fatal(err)


### PR DESCRIPTION
## Summary

Commands that need an aqua configuration now explain how to create one when none is found. The error recommends running `aqua init`.

Closes #4814.

## Validation

- `cmdx l`
- `cmdx v`
- `cmdx t`
- Built `aqua` and confirmed its no-configuration CLI error in an empty temporary directory.

AI assistance was used for implementation and validation; the change was manually reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the missing configuration file error message by including guidance to run `aqua init` to create one.

- **Tests**
  - Added validation to ensure the expected error message is returned when the configuration file is not found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->