### PR TITLE
chore: ignore macOS .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ node_modules
 third_party_licenses
 
 .claude/settings.local.json
+
+**/.DS_Store


### PR DESCRIPTION
Add `**/.DS_Store` to the root `.gitignore` so macOS Finder metadata is ignored throughout the repository.

Validation: `git check-ignore -v` confirms that root and nested `.DS_Store` paths are ignored; `git diff --check` passes.

## Check List

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [ ] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: N/A — minor repository housekeeping.
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

AI assistance was used to apply and validate this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project ignore rules to exclude macOS system files and an additional local file pattern from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->