### PR TITLE
fix: skip minisign verification if the host platform doesn't support minisign

### DIFF
--- a/pkg/installpackage/checksum.go
+++ b/pkg/installpackage/checksum.go
@@ -45,12 +45,13 @@ func (is *Installer) newChecksumVerifiers(pkg *config.Package, assetName string)
 			asset:     assetName,
 		},
 		&minisignVerifier{
-			pkg:       pkg,
-			minisign:  pkgInfo.Checksum.GetMinisign(),
-			installer: is.minisignInstaller,
-			verifier:  is.minisignVerifier,
-			runtime:   is.runtime,
-			asset:     assetName,
+			pkg:         pkg,
+			minisign:    pkgInfo.Checksum.GetMinisign(),
+			installer:   is.minisignInstaller,
+			verifier:    is.minisignVerifier,
+			runtime:     is.runtime,
+			realRuntime: is.realRuntime,
+			asset:       assetName,
 		},
 	}
 }

--- a/pkg/installpackage/download.go
+++ b/pkg/installpackage/download.go
@@ -118,12 +118,13 @@ func (is *Installer) download(ctx context.Context, logger *slog.Logger, param *D
 			asset:     param.Asset,
 		},
 		&minisignVerifier{
-			pkg:       ppkg,
-			installer: is.minisignInstaller,
-			verifier:  is.minisignVerifier,
-			runtime:   is.runtime,
-			asset:     param.Asset,
-			minisign:  pkgInfo.Minisign,
+			pkg:         ppkg,
+			installer:   is.minisignInstaller,
+			verifier:    is.minisignVerifier,
+			runtime:     is.runtime,
+			realRuntime: is.realRuntime,
+			asset:       param.Asset,
+			minisign:    pkgInfo.Minisign,
 		},
 	}
 

--- a/pkg/installpackage/verify_minisign.go
+++ b/pkg/installpackage/verify_minisign.go
@@ -17,8 +17,11 @@ type minisignVerifier struct {
 	installer *DedicatedInstaller
 	verifier  MinisignVerifier
 	runtime   *runtime.Runtime
-	asset     string
-	minisign  *registry.Minisign
+	// realRuntime is the host platform. It can be different from runtime,
+	// which AQUA_GOOS and AQUA_GOARCH can change.
+	realRuntime *runtime.Runtime
+	asset       string
+	minisign    *registry.Minisign
 }
 
 func (s *minisignVerifier) Enabled(logger *slog.Logger) (bool, error) {
@@ -26,11 +29,15 @@ func (s *minisignVerifier) Enabled(logger *slog.Logger) (bool, error) {
 		return false, nil
 	}
 
+	// minisign is executed on the host, so its support must be checked with the
+	// host platform, not the target platform.
+	rt := s.realRuntime
 	mPkg := minisign.Package()
-	if f, err := mPkg.PackageInfo.CheckSupported(s.runtime, s.runtime.Env()); err != nil {
+	if f, err := mPkg.PackageInfo.CheckSupported(rt, rt.Env()); err != nil {
 		return false, fmt.Errorf("check if minisign supports this environment: %w", err)
 	} else if !f {
-		logger.Warn("minisign doesn't support this environment")
+		logger.Warn("minisign doesn't support this environment, so the package isn't verified with minisign",
+			"minisign_env", rt.Env())
 		return false, nil
 	}
 	return true, nil

--- a/pkg/installpackage/verify_minisign_internal_test.go
+++ b/pkg/installpackage/verify_minisign_internal_test.go
@@ -1,0 +1,64 @@
+package installpackage
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/aquaproj/aqua/v2/pkg/config/registry"
+	"github.com/aquaproj/aqua/v2/pkg/runtime"
+)
+
+func TestMinisignVerifier_Enabled(t *testing.T) {
+	t.Parallel()
+	data := []struct {
+		name string
+		// rt is the target platform, which AQUA_GOOS and AQUA_GOARCH can change.
+		rt *runtime.Runtime
+		// realRT is the host platform, where minisign is executed.
+		realRT   *runtime.Runtime
+		minisign *registry.Minisign
+		exp      bool
+	}{
+		{
+			name:     "disabled",
+			rt:       &runtime.Runtime{GOOS: "linux", GOARCH: "amd64"},
+			realRT:   &runtime.Runtime{GOOS: "linux", GOARCH: "amd64"},
+			minisign: nil,
+			exp:      false,
+		},
+		{
+			name:     "supported",
+			rt:       &runtime.Runtime{GOOS: "linux", GOARCH: "amd64"},
+			realRT:   &runtime.Runtime{GOOS: "linux", GOARCH: "amd64"},
+			minisign: &registry.Minisign{},
+			exp:      true,
+		},
+		{
+			// minisign provides no linux/arm64 asset, so the verification must be
+			// skipped even if the target platform is linux/amd64.
+			name:     "the host platform isn't supported",
+			rt:       &runtime.Runtime{GOOS: "linux", GOARCH: "amd64"},
+			realRT:   &runtime.Runtime{GOOS: "linux", GOARCH: "arm64"},
+			minisign: &registry.Minisign{},
+			exp:      false,
+		},
+	}
+	logger := slog.New(slog.DiscardHandler)
+	for _, d := range data {
+		t.Run(d.name, func(t *testing.T) {
+			t.Parallel()
+			v := &minisignVerifier{
+				runtime:     d.rt,
+				realRuntime: d.realRT,
+				minisign:    d.minisign,
+			}
+			enabled, err := v.Enabled(logger)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if enabled != d.exp {
+				t.Fatalf("got %v, wanted %v", enabled, d.exp)
+			}
+		})
+	}
+}

--- a/pkg/minisign/exec.go
+++ b/pkg/minisign/exec.go
@@ -67,11 +67,16 @@ func wait(ctx context.Context, logger *slog.Logger, retryCount int) error {
 	return nil
 }
 
-var errVerify = errors.New("verify with minisign")
+var (
+	errVerify = errors.New("verify with minisign")
+	// errUnsupportedEnv is returned when NewExecutor returned a nil executor
+	// because minisign doesn't support the host platform.
+	errUnsupportedEnv = errors.New("minisign doesn't support this environment, so aqua can't verify the package with minisign")
+)
 
 func (e *ExecutorImpl) Verify(ctx context.Context, logger *slog.Logger, param *ParamVerify, signature string) error {
 	if e == nil {
-		return errors.New("executor is nil")
+		return errUnsupportedEnv
 	}
 	// minisign -Vm myfile.txt -P <pub key>
 	args := []string{
@@ -102,7 +107,7 @@ func (e *ExecutorImpl) Verify(ctx context.Context, logger *slog.Logger, param *P
 
 func (e *ExecutorImpl) exec(ctx context.Context, args []string) error {
 	if e == nil {
-		return errors.New("executor is nil")
+		return errUnsupportedEnv
 	}
 	if e.executor == nil {
 		return errors.New("e.executor is nil")


### PR DESCRIPTION
## Problem

Installing a package that is verified with minisign fails on a host where minisign isn't available, even though aqua is supposed to skip the verification in that case:

```
ERR install the package program=aqua version=2.62.3 env=linux/amd64 package_name=minio/mc package_version=RELEASE.2023-03-23T20-03-04Z registry=standard error="verify the asset: verify a package with minisign: executor is nil"
```

aqua's embedded minisign package (`pkg/minisign/package.go`) declares `supported_envs: [darwin/arm64, windows, linux/amd64]`, matching aqua-registry, because jedisct1/minisign publishes no linux/arm64 asset.

The support check was done against two different platforms:

- `minisignVerifier.Enabled` checked `s.runtime`, the target platform, which `AQUA_GOOS` and `AQUA_GOARCH` can change.
- `minisign.NewExecutor` checks the host platform (`runtime.NewR`) and returns a nil executor when minisign isn't supported there.

So on a linux/arm64 host with `AQUA_GOARCH=amd64` (for example a linux/arm64 container installing linux/amd64 packages), `Enabled` returned true, the verification wasn't skipped, and the nil executor surfaced as the opaque error `executor is nil`.

## Changes

- `minisignVerifier` gets a `realRuntime` field and `Enabled` checks the host platform with it, so minisign verification is skipped with a warning when the host can't run minisign. `runtime` is still used to render the target platform's signature asset. Both construction sites (package download and checksum file verification) pass `is.realRuntime`, which is already the host runtime used by the dedicated minisign installer.
- The warning now includes the host platform: `minisign doesn't support this environment, so the package isn't verified with minisign minisign_env=linux/arm64`.
- `errors.New("executor is nil")` in `pkg/minisign/exec.go` is replaced with a sentinel error explaining the cause, so a remaining wiring mistake doesn't look like an internal error.
- Adds a regression test for `minisignVerifier.Enabled` covering the target linux/amd64 + host linux/arm64 case.

## Behavior after the fix

On a linux/arm64 host, minisign verification is skipped with a warning instead of failing the installation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Minisign verification now correctly checks compatibility with the host environment rather than the installation target.
  - Verification is skipped when minisign is unavailable for the host platform, preventing unsupported execution attempts.
  - Warnings now provide clearer host environment details when verification cannot be enabled.
  - Unsupported minisign environments now return a specific error instead of a generic executor error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->