### PR TITLE
chore: fix Dockerfile build failure caused by a stale apt package index

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 # This Dockerfile is used by `cmdx docker`.
 FROM mirror.gcr.io/ubuntu:24.04@sha256:1e622c5f073b4f6bfad6632f2616c7f59ef256e96fe78bf6a595d1dc4376ac02 AS base
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update
-RUN apt-get install -y sudo vim ca-certificates
+RUN apt-get update && apt-get install -y sudo vim ca-certificates && rm -rf /var/lib/apt/lists/*
 RUN echo 'foo ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
 RUN useradd -u 900 -m -r foo
 USER foo
@@ -26,7 +25,7 @@ FROM alpine-base AS alpine-build
 COPY dist/aqua-docker /usr/local/bin/aqua
 
 FROM base AS prebuilt
-RUN sudo apt-get install -y curl
+RUN sudo apt-get update && sudo apt-get install -y curl && sudo rm -rf /var/lib/apt/lists/*
 RUN curl -sSfL -O https://raw.githubusercontent.com/aquaproj/aqua-installer/v4.0.4/aqua-installer
 RUN echo "acd21cbb06609dd9a701b0032ba4c21fa37b0e3b5cc4c9d721cc02f25ea33a28  aqua-installer" | sha256sum -c -
 RUN chmod +x aqua-installer


### PR DESCRIPTION
## Problem

`cmdx docker -t build` fails while building the `base` stage:

```
Err:1 http://ports.ubuntu.com/ubuntu-ports noble-updates/main arm64 libssl3t64 arm64 3.0.13-0ubuntu3.11
  404  Not Found [IP: 91.189.92.19 80]
...
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
The command '/bin/sh -c apt-get install -y sudo vim ca-certificates' returned a non-zero code: 100
```

`apt-get update` and `apt-get install` were separate `RUN` layers. Docker can reuse the cached `update` layer while re-running the install, so the build installs packages from a package index that may be months old. Ubuntu keeps only the current version of each package in the pool, so once `libssl3t64`, `vim`, `tzdata` and friends are superseded, every version recorded in the cached index returns 404 and the build breaks. Since the base image is pinned by digest, the cached layer is never invalidated on its own, and the failure is permanent until the cache is cleared by hand.

## Change

Merge the update and the install into a single `RUN` so the index is always fetched in the same layer that consumes it, and remove `/var/lib/apt/lists/*` afterwards to keep a stale index from being carried into later stages.

The `prebuilt` stage installs curl on top of `base`, which no longer carries the package lists, so it now runs its own `apt-get update` before installing and cleans up after itself.

## Testing

Both affected targets build successfully:

- `docker build --target build .`
- `docker build --target prebuilt .` (aqua v2.62.3 installed, SLSA verification passed)

The alpine stages are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved container image setup by cleaning package metadata after installations.
  * Updated build steps to ensure package indexes are refreshed before installing required tools.
  * Reduced leftover package cache data in generated images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->